### PR TITLE
Run tests on all the subdirectories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@
 # under the License.
 #
 
+FROM apachepulsar/pulsar:latest as pulsar
+
 FROM golang:1.12 as go
 
-FROM apachepulsar/pulsar:latest
+RUN apt-get update && apt-get install -y openjdk-8-jre-headless
 
-COPY --from=go /usr/local/go /usr/local/go
-ENV PATH /root/go/bin:/usr/local/go/bin:$PATH
+COPY --from=pulsar /pulsar /pulsar
 
 ### Add test scripts
 

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -32,7 +32,7 @@ go build -o pulsar-perf ./perf
 ./pulsar-test-service-start.sh
 
 # Run tests on the directories that contains any '*_test.go' file
-DIRS=`find ./pulsar -name '*_test.go' | xargs -n1 dirname | sort | uniq`
+DIRS=`find . -name '*_test.go' | xargs -n1 dirname | sort | uniq`
 go test -coverprofile=/tmp/coverage ${DIRS}
 go tool cover -html=/tmp/coverage -o coverage.html
 


### PR DESCRIPTION
Since we move utils code to `./pkg` and `./util`, updating the script that looks for test files in subdirs.