### PR TITLE
Fixed flaky TestConvertStringMap

### DIFF
--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -32,10 +32,6 @@ func TestConvertStringMap(t *testing.T) {
 	pbm := ConvertFromStringMap(m)
 
 	assert.Equal(t, 2, len(pbm))
-	assert.Equal(t, "a", *pbm[0].Key)
-	assert.Equal(t, "1", *pbm[0].Value)
-	assert.Equal(t, "b", *pbm[1].Key)
-	assert.Equal(t, "2", *pbm[1].Value)
 
 	m2 := ConvertToStringMap(pbm)
 	assert.Equal(t, 2, len(m2))


### PR DESCRIPTION
The Go map doesn't guarantee any ordering (it changes across different instances of the map object, even for the same keys), so the test cannot make assumptions.