### PR TITLE
Fix runtime error: integer divide by zero

### DIFF
--- a/pulsar/internal/default_router.go
+++ b/pulsar/internal/default_router.go
@@ -63,7 +63,10 @@ func NewDefaultRouter(clock Clock, hashFunc func(string) uint32, maxBatchingDela
 		// of batching of the messages.
 		//
 		//currentMs / maxBatchingDelayMs + startPtnIdx
-		n := uint32(state.clock()/uint64(maxBatchingDelay.Nanoseconds())) + state.shiftIdx
-		return int(n % numPartitions)
+		if maxBatchingDelay.Nanoseconds() != 0 {
+			n := uint32(state.clock()/uint64(maxBatchingDelay.Nanoseconds())) + state.shiftIdx
+			return int(n % numPartitions)
+		}
+		return 0
 	}
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

Fix runtime error: integer divide by zero

The `maxBatchingDelay.Nanoseconds()`  may be zero, so we need check zero.