### PR TITLE
[issue:34] Fix zlib compress Decompress logic

### DIFF
--- a/pkg/compression/zlib.go
+++ b/pkg/compression/zlib.go
@@ -37,12 +37,11 @@ func (zlibProvider) CanCompress() bool {
 func (zlibProvider) Compress(data []byte) []byte {
 	var b bytes.Buffer
 	w := zlib.NewWriter(&b)
-	_, err := w.Write(data)
-	if err != nil {
+
+	if _, err := w.Write(data); err != nil {
 		return nil
 	}
-	err = w.Close()
-	if err != nil {
+	if err := w.Close(); err != nil {
 		return nil
 	}
 
@@ -50,23 +49,17 @@ func (zlibProvider) Compress(data []byte) []byte {
 }
 
 func (zlibProvider) Decompress(compressedData []byte, originalSize int) ([]byte, error) {
-	r, err := zlib.NewReader(bytes.NewBuffer(compressedData))
+	r, err := zlib.NewReader(bytes.NewReader(compressedData))
 	if err != nil {
 		return nil, err
 	}
 
 	uncompressed := make([]byte, originalSize)
-	for {
-		_, err = r.Read(uncompressed)
-		if err == io.EOF {
-			break
-		}
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
+	if _, err = io.ReadFull(r, uncompressed); err != nil {
+		return nil, err
 	}
-	err = r.Close()
-	if err != nil {
+
+	if err = r.Close(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/compression/zlib.go
+++ b/pkg/compression/zlib.go
@@ -20,6 +20,7 @@ package compression
 import (
 	"bytes"
 	"compress/zlib"
+	"io"
 )
 
 type zlibProvider struct{}
@@ -55,9 +56,14 @@ func (zlibProvider) Decompress(compressedData []byte, originalSize int) ([]byte,
 	}
 
 	uncompressed := make([]byte, originalSize)
-	_, err = r.Read(uncompressed)
-	if err != nil {
-		return nil, err
+	for {
+		_, err = r.Read(uncompressed)
+		if err == io.EOF {
+			break
+		}
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
 	}
 	err = r.Close()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #34 

### Motivation

In `reader.Read()`, only a portion of the data will be read at a time. Here we should read all the data until it encounters `io.EOF` and then returns.

This problem has not been reproduced in the previous Test case, because we ignored the processing of error, so whether it succeeds or not, he returns correctly.