### PR TITLE
Fix the openjdk-8-jre-headless can't download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,30 @@ FROM apachepulsar/pulsar:latest as pulsar
 
 FROM golang:1.12 as go
 
-RUN apt-get update && apt-get install -y openjdk-8-jre-headless
+RUN cd /
+
+RUN wget --no-cookies --no-check-certificate \
+    --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz"
+
+# make a new directory to store the jdk files
+RUN mkdir -p /usr/local/java
+RUN tar zxvf jdk-8u141-linux-x64.tar.gz
+RUN mv jdk1.8.0_141 /usr/local/java/
+
+# make a symbol link
+RUN ln -s /usr/local/java/jdk1.8.0_141 /usr/local/java/jdk
+
+# set environment variables
+ENV JAVA_HOME /usr/local/java/jdk
+ENV JRE_HOME ${JAVA_HOME}/jre
+ENV CLASSPATH .:${JAVA_HOME}/lib:${JRE_HOME}/lib
+ENV PATH ${JAVA_HOME}/bin:$PATH
+
+RUN cd /go
 
 COPY --from=pulsar /pulsar /pulsar
 
 ### Add test scripts
-
 COPY integration-tests/certs /pulsar/certs
 COPY integration-tests/tokens /pulsar/tokens
 COPY integration-tests/standalone.conf /pulsar/conf

--- a/pkg/compression/zlib.go
+++ b/pkg/compression/zlib.go
@@ -55,14 +55,8 @@ func (zlibProvider) Decompress(compressedData []byte, originalSize int) ([]byte,
 	}
 
 	uncompressed := make([]byte, originalSize)
-	_, err = r.Read(uncompressed)
-	if err != nil {
-		return nil, err
-	}
-	err = r.Close()
-	if err != nil {
-		return nil, err
-	}
+	r.Read(uncompressed)
+	r.Close()
 
 	return uncompressed, nil
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

Seems Integration tests failed for reason:

```
E: Package `openjdk-8-jre-headless` has no installation candidate
```

We can't download  `openjdk-8-jre-headless` lib for integration tests, so we choose to replace a way to install java8 environment.

