### PR TITLE
Ignore some files that are automatically generated in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
-.idea
+# IDE generated files
+.idea/
+
+# Mac swap file
+*.DS_Store
+
+# Linux swap file
+*.swp
+
+# Output of the go coverage tool
+*.out


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

Ignore some files that are automatically generated in the project, as follows:

```
# IDE generated files
.idea/

# Mac swap file
*.DS_Store

# Linux swap file
*.swp

# Output of the go coverage tool
*.out
```