### PR TITLE
[issue:40]Fix producer send protocol error

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -67,7 +67,7 @@ func TestProducerConsumer(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		if err := producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
-			Key: "pulsar",
+			Key:     "pulsar",
 			Properties: map[string]string{
 				"key-1": "pulsar-1",
 			},

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -50,7 +50,7 @@ func TestProducerConsumer(t *testing.T) {
 	consumer, err := client.Subscribe(ConsumerOptions{
 		Topic:            topic,
 		SubscriptionName: "my-sub",
-		Type:             Shared,
+		Type:             Exclusive,
 	})
 	assert.Nil(t, err)
 	defer consumer.Close()
@@ -67,6 +67,10 @@ func TestProducerConsumer(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		if err := producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+			Key: "pulsar",
+			Properties: map[string]string{
+				"key-1": "pulsar-1",
+			},
 		}); err != nil {
 			log.Fatal(err)
 		}
@@ -80,7 +84,12 @@ func TestProducerConsumer(t *testing.T) {
 		}
 
 		expectMsg := fmt.Sprintf("hello-%d", i)
+		expectProperties := map[string]string{
+			"key-1": "pulsar-1",
+		}
 		assert.Equal(t, []byte(expectMsg), msg.Payload())
+		assert.Equal(t, "pulsar", msg.Key())
+		assert.Equal(t, expectProperties, msg.Properties())
 
 		// ack message
 		if err := consumer.Ack(msg); err != nil {
@@ -213,7 +222,7 @@ func makeHTTPCall(t *testing.T, method string, urls string, body string) {
 	defer res.Body.Close()
 }
 
-func TestConsumerShared(t *testing.T) {
+func TestConsumerKeyShared(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,
 	})

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -18,20 +18,20 @@
 package internal
 
 import (
-    `bytes`
-    `encoding/binary`
-    `fmt`
-    "github.com/golang/protobuf/proto"
-    `io`
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"io"
 
-    "github.com/apache/pulsar-client-go/pkg/pb"
-    log "github.com/sirupsen/logrus"
+	"github.com/apache/pulsar-client-go/pkg/pb"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
 	// MaxFrameSize limit the maximum size that pulsar allows for messages to be sent.
-	MaxFrameSize = 5 * 1024 * 1024
-	magicCrc32c uint16 = 0x0e01
+	MaxFrameSize        = 5 * 1024 * 1024
+	magicCrc32c  uint16 = 0x0e01
 )
 
 func baseCommand(cmdType pb.BaseCommand_Type, msg proto.Message) *pb.BaseCommand {
@@ -151,7 +151,7 @@ func ParseMessage(headersAndPayload []byte) (msgMeta *pb.MessageMetadata, payloa
 	// guard against allocating large buffer
 	if metadataSize > MaxFrameSize {
 		return nil, nil, fmt.Errorf("frame metadata size (%d) "+
-				"cannot b greater than max frame size (%d)", metadataSize, MaxFrameSize)
+			"cannot b greater than max frame size (%d)", metadataSize, MaxFrameSize)
 	}
 
 	// Read protobuf encoded metadata
@@ -164,30 +164,30 @@ func ParseMessage(headersAndPayload []byte) (msgMeta *pb.MessageMetadata, payloa
 		return nil, nil, err
 	}
 
-    // Anything left in the frame is considered
-    // the payload and can be any sequence of bytes.
-    payloads := make([]byte, lr.N)
-    if _, err = io.ReadFull(lr, payloads); err != nil {
-        return nil, nil, err
-    }
+	// Anything left in the frame is considered
+	// the payload and can be any sequence of bytes.
+	payloads := make([]byte, lr.N)
+	if _, err = io.ReadFull(lr, payloads); err != nil {
+		return nil, nil, err
+	}
 
-    numMsg := msgMeta.GetNumMessagesInBatch()
+	numMsg := msgMeta.GetNumMessagesInBatch()
 
-    singleMessages, err := decodeBatchPayload(payloads, numMsg)
-    if err != nil {
-        return nil, nil, err
-    }
+	singleMessages, err := decodeBatchPayload(payloads, numMsg)
+	if err != nil {
+		return nil, nil, err
+	}
 
-    for _, singleMsg := range singleMessages {
-        payload = singleMsg.SinglePayload
-        msgMeta.PartitionKey = singleMsg.SingleMeta.PartitionKey
-        msgMeta.Properties = singleMsg.SingleMeta.Properties
-        msgMeta.EventTime = singleMsg.SingleMeta.EventTime
-    }
+	for _, singleMsg := range singleMessages {
+		payload = singleMsg.SinglePayload
+		msgMeta.PartitionKey = singleMsg.SingleMeta.PartitionKey
+		msgMeta.Properties = singleMsg.SingleMeta.Properties
+		msgMeta.EventTime = singleMsg.SingleMeta.EventTime
+	}
 
 	if computed := chksum.compute(); !bytes.Equal(computed, expectedChksum) {
 		return nil, nil, fmt.Errorf("checksum mismatch: computed (0x%X) does "+
-				"not match given checksum (0x%X)", computed, expectedChksum)
+			"not match given checksum (0x%X)", computed, expectedChksum)
 	}
 
 	return msgMeta, payload, nil

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -275,7 +275,7 @@ func decodeBatchPayload(bp []byte, batchNum int32) ([]*singleMessage, error) {
 			return nil, err
 		}
 		d := &singleMessage{}
-		//d.SingleMetaSize = singleMetaSize
+		d.SingleMetaSize = singleMetaSize
 		d.SingleMeta = singleMeta
 		d.SinglePayload = singlePayload
 		list = append(list, d)

--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -39,8 +39,9 @@ func TestConvertStringMap(t *testing.T) {
 }
 
 func TestDecodeBatchPayload(t *testing.T) {
-	payload := []byte{0, 0, 0, 2, 24, 12, 104, 101, 108, 108, 111, 45, 112, 117, 108, 115, 97, 114} // hello-pulsar
-	list, err := decodeBatchPayload(payload, 1)
+	// singleMsg = singleMetaSize(4  bytes) + singleMeta(var length) + payload
+	singleMsg := []byte{0, 0, 0, 2, 24, 12, 104, 101, 108, 108, 111, 45, 112, 117, 108, 115, 97, 114}
+	list, err := decodeBatchPayload(singleMsg, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -37,3 +37,19 @@ func TestConvertStringMap(t *testing.T) {
 	assert.Equal(t, "1", m2["a"])
 	assert.Equal(t, "2", m2["b"])
 }
+
+func TestDecodeBatchPayload(t *testing.T) {
+	payload := []byte{0, 0, 0, 2, 24, 12, 104, 101, 108, 108, 111, 45, 112, 117, 108, 115, 97, 114} // hello-pulsar
+	list, err := decodeBatchPayload(payload, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if get, want := len(list), 1; get != want {
+		t.Errorf("want %v, but get %v", get, want)
+	}
+
+	m := list[0]
+	if get, want := string(m.SinglePayload), "hello-pulsar"; get != want {
+		t.Errorf("want %v, but get %v", get, want)
+	}
+}


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

Fixes #40 #39 #33 

### Motivation

"Payload" command frame format (It has the same 3 fields as a "simple" command, plus the following):

|"Simple" fields var length|magicNumber (0x0e01) 2 bytes|checksum (CRC32-C) 4 bytes| metadataSize (uint32) 4 bytes| metadata (protobuf encoded) var length| payload (bytes) totalSize - (SUM others)|
|----|----|----|----|----|----|
||OPTIONAL If present, indicates following 4 bytes are checksum|OPTIONAL Checksum of the following bytes| size of the metadata| |Any sequence of bytes, possibly compressed and or encrypted (see metadata)|

When using batch messages, the payload will be containing a list of entries, each of them with its individual metadata, defined by the `SingleMessageMetadata` object.

```
singleMetaSize(4  bytes) + singleMeta(var length) + payload
```

Go client producer send code as follows：

```
producer.Send(ctx, &pulsar.ProducerMessage{
            Payload: []byte(fmt.Sprintf("hello-%d", i)),
            Key:     "pulsar",
            Properties: map[string]string{
                "key":"apache",
            },
```

output byte slice as follows:

```
0a 0d 0a 03
     6b 65 79 message properties key: key（3 bytes）
12 06
    61 70 61 63 68 65 properties value: apache（6 bytes）
12 06
    70 75 6c 73 61 72 message key: pulsar（6 bytes）
18 07
    68 65 6c 6c 6f 2d 39 message payload: hello-%d（7 bytes）
```

We can see that in the output byte slice, we did not find the singleMetaSize(4 bytes) field in `SingleMessageMetadata`.


