### PR TITLE
[Issue:45] Fix the logic of message router

### DIFF
--- a/pulsar/impl_producer.go
+++ b/pulsar/impl_producer.go
@@ -57,6 +57,8 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 		p.messageRouter = func(message *ProducerMessage, metadata TopicMetadata) int {
 			return internalRouter(message.Key, metadata.NumPartitions())
 		}
+	} else {
+		p.messageRouter = options.MessageRouter
 	}
 
 	partitions, err := client.TopicPartitions(options.Topic)

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -107,7 +107,7 @@ type ProducerOptions struct {
 	// MessageRouter set a custom message routing policy by passing an implementation of MessageRouter
 	// The router is a function that given a particular message and the topic metadata, returns the
 	// partition index where the message should be routed to
-	MessageRouter func(Message, TopicMetadata) int
+	MessageRouter func(*ProducerMessage, TopicMetadata) int
 
 	// DisableBatching control whether automatic batching of messages is enabled for the producer. By default batching
 	// is enabled.

--- a/pulsar/test_helper.go
+++ b/pulsar/test_helper.go
@@ -18,7 +18,11 @@
 package pulsar
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
 	"time"
 )
 
@@ -38,4 +42,23 @@ func newTopicName() string {
 
 func newAuthTopicName() string {
 	return fmt.Sprintf("private/auth/my-topic-%v", time.Now().Nanosecond())
+}
+
+func httpPut(url string, body interface{}) {
+	client := http.Client{}
+
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(data))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	req.Header = map[string][]string{
+		"Content-Type": {"application/json"},
+	}
+
+	_, err = client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #45 

### Motivation

In the original code logic, if the user customized the `MessageRouter` policy, the `messageRouter` of producer is not initialized. The pull request will fix it.
