### PR TITLE
[Issue:49]Fix test killed with quit: ran too long

### DIFF
--- a/run-ci.sh
+++ b/run-ci.sh
@@ -33,7 +33,7 @@ go build -o pulsar-perf ./perf
 
 # Run tests on the directories that contains any '*_test.go' file
 DIRS=`find . -name '*_test.go' | xargs -n1 dirname | sort | uniq`
-go test -coverprofile=/tmp/coverage ${DIRS}
+go test -coverprofile=/tmp/coverage -timeout=1h ${DIRS}
 go tool cover -html=/tmp/coverage -o coverage.html
 
 ./pulsar-test-service-stop.sh


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

Fixes #49

### Motivation

By default, timeout exit after 10 minutes

```
go test --help

-timeout d
        If a test binary runs longer than duration d, panic.
        If d is 0, the timeout is disabled.
        The default is 10 minutes (10m).
```