### PR TITLE
enable to specify the sequenceID

### DIFF
--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -246,7 +246,12 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		smm.Properties = internal.ConvertFromStringMap(msg.Properties)
 	}
 
-	sequenceID := internal.GetAndAdd(p.sequenceIDGenerator, 1)
+	var sequenceID uint64
+	if msg.SequenceID != nil {
+		sequenceID = uint64(*msg.SequenceID)
+	} else {
+		sequenceID = internal.GetAndAdd(p.sequenceIDGenerator, 1)
+	}
 
 	if sendAsBatch {
 		ok := p.batchBuilder.Add(smm, sequenceID, msg.Payload, request, msg.ReplicationClusters)


### PR DESCRIPTION
Fixes #59 

## Motivation

When I specify the SequenceID : `producer.SendAsync(cox, &pulsar.ProducerMessage{Payload: msg,SequenceID:&id},)`, it doesn't work.