### PR TITLE
Fix interface conversion panic

### DIFF
--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -293,6 +293,9 @@ func (p *partitionProducer) internalFlushCurrentBatch() {
 func (p *partitionProducer) internalFlush(fr *flushRequest) {
 	p.internalFlushCurrentBatch()
 
+	if util.IsNil(p.pendingQueue.PeekLast()) {
+		return
+	}
 	pi := p.pendingQueue.PeekLast().(*pendingItem)
 	pi.sendRequests = append(pi.sendRequests, &sendRequest{
 		msg: nil,


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <ranxiaolong716@gmail.com>

### Motivation

Fix as follows:

```
panic: interface conversion: interface {} is nil, not *pulsar.pendingItem
```