### PR TITLE
[ISSUE #72] Fix data race conditions.

### DIFF
--- a/license_test.go
+++ b/license_test.go
@@ -65,7 +65,7 @@ var otherCheck = regexp.MustCompile(`#
 `)
 
 var skip = map[string]bool{
-	"pkg/pb/PulsarApi.pb.go":true,
+	"pkg/pb/PulsarApi.pb.go": true,
 }
 
 func TestLicense(t *testing.T) {

--- a/pulsar/impl_consumer.go
+++ b/pulsar/impl_consumer.go
@@ -102,7 +102,6 @@ func singleTopicSubscribe(client *client, options *ConsumerOptions, topic string
 		// newPartitionConsumer can modify the shared options struct causing a race condition
 		cons, err := newPartitionConsumer(client, partitionTopic, options, partitionIdx, numPartitions, c.queue)
 		go func(partitionIdx int, partitionTopic string) {
-			//cons, err := newPartitionConsumer(client, partitionTopic, options, partitionIdx, numPartitions, c.queue)
 			ch <- ConsumerError{
 				err:       err,
 				partition: partitionIdx,

--- a/pulsar/impl_consumer.go
+++ b/pulsar/impl_consumer.go
@@ -98,10 +98,13 @@ func singleTopicSubscribe(client *client, options *ConsumerOptions, topic string
 	ch := make(chan ConsumerError, numPartitions)
 
 	for partitionIdx, partitionTopic := range partitions {
+		// this needs to be created outside in the same go routine since
+		// newPartitionConsumer can modify the shared options struct causing a race condition
+		cons, err := newPartitionConsumer(client, partitionTopic, options, partitionIdx, numPartitions, c.queue)
 		go func(partitionIdx int, partitionTopic string) {
-			cons, e := newPartitionConsumer(client, partitionTopic, options, partitionIdx, numPartitions, c.queue)
+			//cons, err := newPartitionConsumer(client, partitionTopic, options, partitionIdx, numPartitions, c.queue)
 			ch <- ConsumerError{
-				err:       e,
+				err:       err,
 				partition: partitionIdx,
 				cons:      cons,
 			}
@@ -141,8 +144,8 @@ func (c *consumer) Subscription() string {
 
 func (c *consumer) Unsubscribe() error {
 	var errMsg string
-	for _, c := range c.consumers {
-		if err := c.Unsubscribe(); err != nil {
+	for _, consumer := range c.consumers {
+		if err := consumer.Unsubscribe(); err != nil {
 			errMsg += fmt.Sprintf("topic %s, subscription %s: %s", c.Topic(), c.Subscription(), err)
 		}
 	}

--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/apache/pulsar-client-go/pkg/pb"
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/apache/pulsar-client-go/util"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type producerState int
@@ -272,6 +272,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 }
 
 type pendingItem struct {
+	sync.Mutex
 	batchData    []byte
 	sequenceID   uint64
 	sendRequests []interface{}
@@ -300,13 +301,19 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		return
 	}
 
-	pi.sendRequests = append(pi.sendRequests, &sendRequest{
+	sendReq := &sendRequest{
 		msg: nil,
 		callback: func(id MessageID, message *ProducerMessage, e error) {
 			fr.err = e
 			fr.waitGroup.Done()
 		},
-	})
+	}
+
+	// lock the pending request while adding requests
+	// since the ReceivedSendReceipt func iterates over this list
+	pi.Lock()
+	pi.sendRequests = append(pi.sendRequests, sendReq)
+	pi.Unlock()
 }
 
 func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) error {
@@ -370,6 +377,10 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 
 	// The ack was indeed for the expected item in the queue, we can remove it and trigger the callback
 	p.pendingQueue.Poll()
+
+	// lock the pending item while sending the requests
+	pi.Lock()
+	defer pi.Unlock()
 	for idx, i := range pi.sendRequests {
 		sr := i.(*sendRequest)
 		if sr.msg != nil {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -155,7 +155,7 @@ func newConnection(logicalAddr *url.URL, physicalAddr *url.URL, tlsOptions *TLSO
 		auth:                 auth,
 
 		incomingRequestsCh: make(chan *request),
-		writeRequestsCh:    make(chan []byte, 100),
+		writeRequestsCh:    make(chan []byte),
 		listeners:          make(map[uint64]ConnectionListener),
 		consumerHandlers:   make(map[uint64]ConsumerHandler),
 	}

--- a/pulsar/unacked_msg_tracker_test.go
+++ b/pulsar/unacked_msg_tracker_test.go
@@ -20,9 +20,10 @@ package pulsar
 import (
 	"testing"
 
-	"github.com/apache/pulsar-client-go/pkg/pb"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/pulsar-client-go/pkg/pb"
 )
 
 func TestUnackedMessageTracker(t *testing.T) {


### PR DESCRIPTION
Fixes #72

This patch adds locking to fix all the data race warnings when discovered when running.
`go test ./... -race`
