### PR TITLE
Add reconnect timeout after unload topic

### DIFF
--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -176,6 +176,8 @@ func (p *partitionProducer) ConnectionClosed() {
 func (p *partitionProducer) reconnectToBroker() {
 	p.log.Info("Reconnecting to broker")
 	backoff := internal.Backoff{}
+	// Delay one secnd to reconnect
+	time.Sleep(1 * time.Second)
 	for {
 		if p.state != producerReady {
 			// Producer is already closing

--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -176,7 +176,7 @@ func (p *partitionProducer) ConnectionClosed() {
 func (p *partitionProducer) reconnectToBroker() {
 	p.log.Info("Reconnecting to broker")
 	backoff := internal.Backoff{}
-	// Delay one secnd to reconnect
+	// Delay one second to reconnect
 	time.Sleep(1 * time.Second)
 	for {
 		if p.state != producerReady {


### PR DESCRIPTION

Currently, for a producer that is sending data, if the topic is unload, the following exception will be thrown, resulting in reconnection failure
```
ERRO[0094] Error: ServiceNotReady, Error Message: Topic is temporarily unavailable  local_addr="127.0.0.1:55800" remote_addr="pulsar://localhost:6650"
```

Reproduce:
```
1. pulsar-perf produce -s 10 test-topic
2. ./bin/pulsar-admin topics unload test-topic
```