### PR TITLE
Handle RPC errors in reconnections

### DIFF
--- a/pulsar/impl_partition_consumer.go
+++ b/pulsar/impl_partition_consumer.go
@@ -693,24 +693,22 @@ func (pc *partitionConsumer) ConnectionClosed() {
 }
 
 func (pc *partitionConsumer) reconnectToBroker() {
-	pc.log.Info("Reconnecting to broker")
-	backoff := new(internal.Backoff)
+	backoff := internal.Backoff{}
 	for {
 		if pc.state != consumerReady {
 			// Consumer is already closing
 			return
 		}
 
+		d := backoff.Next()
+		pc.log.Info("Reconnecting to broker in ", d)
+		time.Sleep(d)
+
 		err := pc.grabCnx()
 		if err == nil {
 			// Successfully reconnected
-			pc.log.Info("Successfully reconnected")
+			pc.log.Info("Reconnected consumer to broker")
 			return
 		}
-
-		d := backoff.Next()
-		pc.log.Info("Retrying reconnection after ", d)
-
-		time.Sleep(d)
 	}
 }

--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -174,7 +174,6 @@ func (p *partitionProducer) ConnectionClosed() {
 }
 
 func (p *partitionProducer) reconnectToBroker() {
-	p.log.Info("Reconnecting to broker")
 	backoff := internal.Backoff{}
 	for {
 		if p.state != producerReady {
@@ -182,16 +181,16 @@ func (p *partitionProducer) reconnectToBroker() {
 			return
 		}
 
+		d := backoff.Next()
+		p.log.Info("Reconnecting to broker in ", d)
+		time.Sleep(d)
+
 		err := p.grabCnx()
 		if err == nil {
 			// Successfully reconnected
+			p.log.Info("Reconnected producer to broker")
 			return
 		}
-
-		d := backoff.Next()
-		p.log.Info("Retrying reconnection after ", d)
-
-		time.Sleep(d)
 	}
 }
 

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -84,14 +84,17 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 		Cnx: cnx,
 	}
 
+	var rpcErr error = nil
+
 	// TODO: Handle errors with disconnections
-	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand) {
+	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {
 		rpcResult.Response = response
+		rpcErr = err
 		wg.Done()
 	})
 
 	wg.Wait()
-	return rpcResult, nil
+	return rpcResult, rpcErr
 }
 
 func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
@@ -103,13 +106,15 @@ func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.Ba
 		Cnx: cnx,
 	}
 
-	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand) {
+	var rpcErr error = nil
+	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {
 		rpcResult.Response = response
+		rpcErr = err
 		wg.Done()
 	})
 
 	wg.Wait()
-	return rpcResult, nil
+	return rpcResult, rpcErr
 }
 
 func (c *rpcClient) RequestOnCnxNoWait(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
@@ -118,7 +123,7 @@ func (c *rpcClient) RequestOnCnxNoWait(cnx Connection, requestID uint64, cmdType
 		Cnx: cnx,
 	}
 
-	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand) {
+	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {
 		rpcResult.Response = response
 	})
 


### PR DESCRIPTION
### Motivation

We're not currently handling the `ServerError` responses in the `RpcClient`. That leaves the caller hanging when any request fails on broker side.
