### PR TITLE
Fixed locking between connection_reader and connection

### DIFF
--- a/pulsar/impl_partition_consumer.go
+++ b/pulsar/impl_partition_consumer.go
@@ -600,11 +600,9 @@ func (pc *partitionConsumer) internalFlow(permits uint32) error {
 	return nil
 }
 
-func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, headersAndPayload []byte) error {
+func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, headersAndPayload internal.Buffer) error {
 	pbMsgID := response.GetMessageId()
-
-	reader := internal.NewMessageReader(headersAndPayload)
-
+	reader := internal.NewMessageReader(headersAndPayload.ReadableSlice())
 	msgMeta, err := reader.ReadMessageMetadata()
 	if err != nil {
 		// TODO send discardCorruptedMessage

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -55,7 +55,7 @@ func (r *connectionReader) readFromConnection() {
 	}
 }
 
-func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndPayload []byte, err error) {
+func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndPayload Buffer, err error) {
 	// First, we need to read the frame size
 	if r.buffer.ReadableBytes() < 4 {
 		if r.buffer.ReadableBytes() == 0 {
@@ -92,8 +92,8 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 	// Also read the eventual payload
 	headersAndPayloadSize := frameSize - (cmdSize + 4)
 	if cmdSize+4 < frameSize {
-		headersAndPayload = make([]byte, headersAndPayloadSize)
-		copy(headersAndPayload, r.buffer.Read(headersAndPayloadSize))
+		headersAndPayload = NewBuffer(int(headersAndPayloadSize))
+		headersAndPayload.Write(r.buffer.Read(headersAndPayloadSize))
 	}
 	return cmd, headersAndPayload, nil
 }


### PR DESCRIPTION
### Motivation

Fixed locking around the `mapMutex` in consumer. The current behavior is mixing read-write and read-only locks even when modifying the map. 

The `pendingReqs` was really meant to be accessed by a single go-routine. Changed the logic to pass the received commands on a channel, to be processed in the connection's own go-routine.

cc/ @cckellogg 