### PR TITLE
Switch to OpenJDK for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,26 +21,7 @@ FROM apachepulsar/pulsar:latest as pulsar
 
 FROM golang:1.12 as go
 
-RUN cd /
-
-RUN wget --no-cookies --no-check-certificate \
-    --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u141-b15/336fa29ff2bb4ef291e347e091f7f4a7/jdk-8u141-linux-x64.tar.gz"
-
-# make a new directory to store the jdk files
-RUN mkdir -p /usr/local/java
-RUN tar zxvf jdk-8u141-linux-x64.tar.gz
-RUN mv jdk1.8.0_141 /usr/local/java/
-
-# make a symbol link
-RUN ln -s /usr/local/java/jdk1.8.0_141 /usr/local/java/jdk
-
-# set environment variables
-ENV JAVA_HOME /usr/local/java/jdk
-ENV JRE_HOME ${JAVA_HOME}/jre
-ENV CLASSPATH .:${JAVA_HOME}/lib:${JRE_HOME}/lib
-ENV PATH ${JAVA_HOME}/bin:$PATH
-
-RUN cd /go
+RUN apt-get update && apt-get install -y openjdk-11-jre-headless
 
 COPY --from=pulsar /pulsar /pulsar
 


### PR DESCRIPTION
### Motivation

We shouldn't be using Oracle JDK and especially automatically accepting the condition when building the image.

If Java 8 is not available on the go-1.12 image, we can switch to the default java 11 package.