### PR TITLE
Move util files to internal so they are not exported.

### DIFF
--- a/pulsar/impl_partition_producer.go
+++ b/pulsar/impl_partition_producer.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/apache/pulsar-client-go/pkg/pb"
 	"github.com/apache/pulsar-client-go/pulsar/internal"
-	"github.com/apache/pulsar-client-go/util"
 )
 
 type producerState int
@@ -58,8 +57,8 @@ type partitionProducer struct {
 	// Channel where app is posting messages to be published
 	eventsChan chan interface{}
 
-	publishSemaphore util.Semaphore
-	pendingQueue     util.BlockingQueue
+	publishSemaphore internal.Semaphore
+	pendingQueue     internal.BlockingQueue
 	lastSequenceID   int64
 
 	partitionIdx int
@@ -92,8 +91,8 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 		producerID:       client.rpcClient.NewProducerID(),
 		eventsChan:       make(chan interface{}, 1),
 		batchFlushTicker: time.NewTicker(batchingMaxPublishDelay),
-		publishSemaphore: make(util.Semaphore, maxPendingMessages),
-		pendingQueue:     util.NewBlockingQueue(maxPendingMessages),
+		publishSemaphore: make(internal.Semaphore, maxPendingMessages),
+		pendingQueue:     internal.NewBlockingQueue(maxPendingMessages),
 		lastSequenceID:   -1,
 		partitionIdx:     partitionIdx,
 	}

--- a/pulsar/internal/blocking_queue.go
+++ b/pulsar/internal/blocking_queue.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package util
+package internal
 
 import (
 	"sync"

--- a/pulsar/internal/blocking_queue_test.go
+++ b/pulsar/internal/blocking_queue_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package util
+package internal
 
 import (
 	"fmt"

--- a/pulsar/internal/semaphore.go
+++ b/pulsar/internal/semaphore.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package util
+package internal
 
 // Semaphore is a channel of bool, used to receive a bool type semaphore.
 type Semaphore chan bool

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -20,12 +20,12 @@ package pulsar
 import (
 	"context"
 	"fmt"
+	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/apache/pulsar-client-go/util"
 	"github.com/stretchr/testify/assert"
 
 	log "github.com/sirupsen/logrus"
@@ -124,7 +124,7 @@ func TestProducerAsyncSend(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(10)
-	errors := util.NewBlockingQueue(10)
+	errors := internal.NewBlockingQueue(10)
 
 	for i := 0; i < 10; i++ {
 		producer.SendAsync(context.Background(), &ProducerMessage{
@@ -306,7 +306,7 @@ func TestFlushInProducer(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(5)
-	errors := util.NewBlockingQueue(10)
+	errors := internal.NewBlockingQueue(10)
 	for i := 0; i < numOfMessages/2; i++ {
 		messageContent := prefix + fmt.Sprintf("%d", i)
 		producer.SendAsync(ctx, &ProducerMessage{
@@ -404,7 +404,7 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 	prefix := "msg-batch-async-"
 	wg := sync.WaitGroup{}
 	wg.Add(5)
-	errors := util.NewBlockingQueue(5)
+	errors := internal.NewBlockingQueue(5)
 	for i := 0; i < numOfMessages/2; i++ {
 		messageContent := prefix + fmt.Sprintf("%d", i)
 		producer.SendAsync(ctx, &ProducerMessage{


### PR DESCRIPTION
### Motivation

Move blocking queue and semaphore to the internal package so they are not exported with the client. These are only for internal purposes.
