### PR TITLE
Added negative acks tracker and integration

### DIFF
--- a/examples/consumer-listener/consumer-listener.go
+++ b/examples/consumer-listener/consumer-listener.go
@@ -57,8 +57,6 @@ func main() {
 		fmt.Printf("Received message  msgId: %v -- content: '%s'\n",
 			msg.ID(), string(msg.Payload()))
 
-		if err := consumer.Ack(msg); err != nil {
-			log.Fatal(err)
-		}
+		consumer.Ack(msg)
 	}
 }

--- a/examples/consumer/consumer.go
+++ b/examples/consumer/consumer.go
@@ -52,9 +52,7 @@ func main() {
 		fmt.Printf("Received message msgId: %#v -- content: '%s'\n",
 			msg.ID(), string(msg.Payload()))
 
-		if err := consumer.Ack(msg); err != nil {
-			log.Fatal(err)
-		}
+		consumer.Ack(msg)
 	}
 
 	if err := consumer.Unsubscribe(); err != nil {

--- a/perf/perf-consumer.go
+++ b/perf/perf-consumer.go
@@ -101,9 +101,7 @@ func consume(consumeArgs *ConsumeArgs, stop <-chan struct{}) {
 			}
 			msgReceived++
 			bytesReceived += int64(len(cm.Message.Payload()))
-			if err := consumer.Ack(cm.Message); err != nil {
-				return
-			}
+			consumer.Ack(cm.Message)
 		case <-tick.C:
 			currentMsgReceived := atomic.SwapInt64(&msgReceived, 0)
 			currentBytesReceived := atomic.SwapInt64(&bytesReceived, 0)

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"time"
 )
 
 // Pair of a Consumer and Message
@@ -106,6 +107,10 @@ type ConsumerOptions struct {
 	// ReceiverQueueSize(int) if the total exceeds this value (default: 50000).
 	MaxTotalReceiverQueueSizeAcrossPartitions int
 
+	// The delay after which to redeliver the messages that failed to be
+	// processed. Default is 1min. (See `Consumer.Nack()`)
+	NackRedeliveryDelay *time.Duration
+
 	// Set the consumer name.
 	Name string
 
@@ -136,10 +141,28 @@ type Consumer interface {
 	Chan() <-chan ConsumerMessage
 
 	// Ack the consumption of a single message
-	Ack(Message) error
+	Ack(Message)
 
 	// AckID the consumption of a single message, identified by its MessageID
-	AckID(MessageID) error
+	AckID(MessageID)
+
+	// Acknowledge the failure to process a single message.
+	//
+	// When a message is "negatively acked" it will be marked for redelivery after
+	// some fixed delay. The delay is configurable when constructing the consumer
+	// with ConsumerOptions.NAckRedeliveryDelay .
+	//
+	// This call is not blocking.
+	Nack(Message)
+
+	// Acknowledge the failure to process a single message.
+	//
+	// When a message is "negatively acked" it will be marked for redelivery after
+	// some fixed delay. The delay is configurable when constructing the consumer
+	// with ConsumerOptions.NackRedeliveryDelay .
+	//
+	// This call is not blocking.
+	NackID(MessageID)
 
 	// Close the consumer and stop the broker to push more messages
 	Close() error

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -214,7 +214,7 @@ func (c *consumer) Ack(msg Message) {
 }
 
 // Ack the consumption of a single message, identified by its MessageID
-func (c *consumer) AckID(msgID MessageID)  {
+func (c *consumer) AckID(msgID MessageID) {
 	mid, ok := msgID.(*messageID)
 	if !ok {
 		c.log.Warnf("invalid message id type")

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -218,6 +218,7 @@ func (c *consumer) AckID(msgID MessageID)  {
 	mid, ok := msgID.(*messageID)
 	if !ok {
 		c.log.Warnf("invalid message id type")
+		return
 	}
 
 	partition := mid.partitionIdx
@@ -225,6 +226,7 @@ func (c *consumer) AckID(msgID MessageID)  {
 	if partition < 0 || partition >= len(c.consumers) {
 		c.log.Warnf("invalid partition index %d expected a partition between [0-%d]",
 			partition, len(c.consumers))
+		return
 	}
 	c.consumers[partition].AckID(mid)
 }
@@ -237,6 +239,7 @@ func (c *consumer) NackID(msgID MessageID) {
 	mid, ok := msgID.(*messageID)
 	if !ok {
 		c.log.Warnf("invalid message id type")
+		return
 	}
 
 	partition := mid.partitionIdx
@@ -244,6 +247,7 @@ func (c *consumer) NackID(msgID MessageID) {
 	if partition < 0 || partition >= len(c.consumers) {
 		c.log.Warnf("invalid partition index %d expected a partition between [0-%d]",
 			partition, len(c.consumers))
+		return
 	}
 
 	c.consumers[partition].NackID(mid)

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -149,7 +149,7 @@ func (pc *partitionConsumer) internalUnsubscribe(unsub *unsubscribeRequest) {
 
 func (pc *partitionConsumer) AckID(msgID *messageID) {
 	req := &ackRequest{
-		msgID:  msgID,
+		msgID: msgID,
 	}
 	pc.eventsCh <- req
 }
@@ -201,7 +201,7 @@ func (pc *partitionConsumer) internalAck(req *ackRequest) {
 	messageIDs := make([]*pb.MessageIdData, 1)
 	messageIDs[0] = &pb.MessageIdData{
 		LedgerId: proto.Uint64(uint64(msgId.ledgerID)),
-		EntryId: proto.Uint64(uint64(msgId.entryID)),
+		EntryId:  proto.Uint64(uint64(msgId.entryID)),
 	}
 	requestID := internal.RequestIDNoResponse
 	cmdAck := &pb.CommandAck{
@@ -386,7 +386,7 @@ func (pc *partitionConsumer) dispatcher() {
 }
 
 type ackRequest struct {
-	msgID  *messageID
+	msgID *messageID
 }
 
 type unsubscribeRequest struct {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -90,9 +90,7 @@ func TestProducerConsumer(t *testing.T) {
 		assert.Equal(t, expectProperties, msg.Properties())
 
 		// ack message
-		if err := consumer.Ack(msg); err != nil {
-			log.Fatal(err)
-		}
+		consumer.Ack(msg)
 	}
 }
 
@@ -163,8 +161,7 @@ func TestBatchMessageReceive(t *testing.T) {
 	for i := 0; i < numOfMessages; i++ {
 		msg, err := consumer.Receive(ctx)
 		assert.Nil(t, err)
-		err = consumer.Ack(msg)
-		assert.Nil(t, err)
+		consumer.Ack(msg)
 		count++
 	}
 
@@ -301,17 +298,13 @@ func TestConsumerKeyShared(t *testing.T) {
 				break
 			}
 			receivedConsumer1++
-			if err := consumer1.Ack(cm.Message); err != nil {
-				log.Fatal(err)
-			}
+			consumer1.Ack(cm.Message)
 		case cm, ok := <-consumer2.Chan():
 			if !ok {
 				break
 			}
 			receivedConsumer2++
-			if err := consumer2.Ack(cm.Message); err != nil {
-				log.Fatal(err)
-			}
+			consumer2.Ack(cm.Message)
 		}
 	}
 
@@ -372,9 +365,7 @@ func TestPartitionTopicsConsumerPubSub(t *testing.T) {
 		fmt.Printf("Received message msgId: %#v -- content: '%s'\n",
 			msg.ID(), string(msg.Payload()))
 
-		if err := consumer.Ack(msg); err != nil {
-			assert.Nil(t, err)
-		}
+		consumer.Ack(msg)
 	}
 
 	assert.Equal(t, len(msgs), 10)
@@ -465,9 +456,7 @@ func TestConsumerShared(t *testing.T) {
 			payload := string(cm.Message.Payload())
 			messages[payload] = struct{}{}
 			fmt.Printf("consumer1 msg id is: %v, value is: %s\n", cm.Message.ID(), payload)
-			if err := consumer1.Ack(cm.Message); err != nil {
-				log.Fatal(err)
-			}
+			consumer1.Ack(cm.Message)
 		case cm, ok := <-consumer2.Chan():
 			if !ok {
 				break
@@ -476,9 +465,7 @@ func TestConsumerShared(t *testing.T) {
 			payload := string(cm.Message.Payload())
 			messages[payload] = struct{}{}
 			fmt.Printf("consumer2 msg id is: %v, value is: %s\n", cm.Message.ID(), payload)
-			if err := consumer2.Ack(cm.Message); err != nil {
-				log.Fatal(err)
-			}
+			consumer2.Ack(cm.Message)
 		}
 	}
 

--- a/pulsar/impl_producer.go
+++ b/pulsar/impl_producer.go
@@ -146,9 +146,9 @@ func (p *producer) LastSequenceID() int64 {
 
 func (p *producer) Flush() error {
 	for _, pp := range p.producers {
-		 if err :=  pp.Flush(); err != nil {
-		 	return err
-		 }
+		if err := pp.Flush(); err != nil {
+			return err
+		}
 
 	}
 	return nil

--- a/pulsar/negative_acks_tracker.go
+++ b/pulsar/negative_acks_tracker.go
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	log "github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
+
+type redeliveryConsumer interface {
+	Redeliver(msgIds []messageID)
+}
+
+type negativeAcksTracker struct {
+	sync.Mutex
+
+	doneCh       chan interface{}
+	negativeAcks map[messageID]time.Time
+	rc           redeliveryConsumer
+	tick         *time.Ticker
+	delay        time.Duration
+}
+
+func newNegativeAcksTracker(rc redeliveryConsumer, delay time.Duration) *negativeAcksTracker {
+	t := &negativeAcksTracker{
+		doneCh:       make(chan interface{}),
+		negativeAcks: make(map[messageID]time.Time),
+		rc:           rc,
+		tick:         time.NewTicker(delay / 3),
+		delay:        delay,
+	}
+
+	go t.track()
+	return t
+}
+
+func (t *negativeAcksTracker) Add(msgID *messageID) {
+	// Always clear up the batch index since we want to track the nack
+	// for the entire batch
+	batchMsgId := messageID{
+		ledgerID: msgID.ledgerID,
+		entryID:  msgID.entryID,
+		batchIdx: 0,
+	}
+
+	t.Lock()
+	defer t.Unlock()
+
+	_, present := t.negativeAcks[batchMsgId]
+	if present {
+		// The batch is already being tracked
+		return
+	} else {
+		targetTime := time.Now().Add(t.delay)
+		t.negativeAcks[batchMsgId] = targetTime
+	}
+}
+
+func (t *negativeAcksTracker) track() {
+	for {
+		select {
+		case <-t.doneCh:
+			log.Debug("Closing nack tracker")
+			return
+
+		case <-t.tick.C:
+			{
+				t.Lock()
+
+				now := time.Now()
+				msgIds := make([]messageID, 0)
+				for msgID, targetTime := range t.negativeAcks {
+					log.Debugf("MsgId: %v -- targetTime: %v -- now: %v", msgID, targetTime, now)
+					if targetTime.Before(now) {
+						log.Debugf("Adding MsgId: %v", msgID)
+						msgIds = append(msgIds, msgID)
+						delete(t.negativeAcks, msgID)
+					}
+				}
+
+				t.Unlock()
+
+				if len(msgIds) > 0 {
+					t.rc.Redeliver(msgIds)
+				}
+			}
+
+		}
+	}
+}
+
+func (t *negativeAcksTracker) Close() {
+	t.doneCh <- nil
+}

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -27,7 +27,7 @@ import (
 
 type nackMockedConsumer struct {
 	sync.Mutex
-	cond *sync.Cond
+	cond   *sync.Cond
 	msgIds []messageID
 }
 
@@ -44,7 +44,7 @@ func (nmc *nackMockedConsumer) Redeliver(msgIds []messageID) {
 	nmc.Unlock()
 }
 
-func (nmc *nackMockedConsumer) Wait() []messageID{
+func (nmc *nackMockedConsumer) Wait() []messageID {
 	nmc.Lock()
 	defer nmc.Unlock()
 	nmc.cond.Wait()
@@ -55,18 +55,18 @@ func (nmc *nackMockedConsumer) Wait() []messageID{
 func TestNacksTracker(t *testing.T) {
 	nmc := &nackMockedConsumer{}
 	nmc.cond = sync.NewCond(nmc)
-	nacks := newNegativeAcksTracker(nmc, 1 * time.Second)
+	nacks := newNegativeAcksTracker(nmc, 1*time.Second)
 
 	nacks.Add(&messageID{
-		ledgerID:     1,
-		entryID:      1,
-		batchIdx:     1,
+		ledgerID: 1,
+		entryID:  1,
+		batchIdx: 1,
 	})
 
 	nacks.Add(&messageID{
-		ledgerID:     2,
-		entryID:      2,
-		batchIdx:     1,
+		ledgerID: 2,
+		entryID:  2,
+		batchIdx: 1,
 	})
 
 	msgIds := nmc.Wait()
@@ -83,30 +83,30 @@ func TestNacksTracker(t *testing.T) {
 func TestNacksWithBatchesTracker(t *testing.T) {
 	nmc := &nackMockedConsumer{}
 	nmc.cond = sync.NewCond(nmc)
-	nacks := newNegativeAcksTracker(nmc, 1 * time.Second)
+	nacks := newNegativeAcksTracker(nmc, 1*time.Second)
 
 	nacks.Add(&messageID{
-		ledgerID:     1,
-		entryID:      1,
-		batchIdx:     1,
+		ledgerID: 1,
+		entryID:  1,
+		batchIdx: 1,
 	})
 
 	nacks.Add(&messageID{
-		ledgerID:     1,
-		entryID:      1,
-		batchIdx:     2,
+		ledgerID: 1,
+		entryID:  1,
+		batchIdx: 2,
 	})
 
 	nacks.Add(&messageID{
-		ledgerID:     1,
-		entryID:      1,
-		batchIdx:     3,
+		ledgerID: 1,
+		entryID:  1,
+		batchIdx: 3,
 	})
 
 	nacks.Add(&messageID{
-		ledgerID:     2,
-		entryID:      2,
-		batchIdx:     1,
+		ledgerID: 2,
+		entryID:  2,
+		batchIdx: 1,
 	})
 
 	msgIds := nmc.Wait()

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+type nackMockedConsumer struct {
+	sync.Mutex
+
+	msgIds []messageID
+}
+
+func (nmc *nackMockedConsumer) Redeliver(msgIds []messageID) {
+	nmc.Lock()
+	if nmc.msgIds == nil {
+		nmc.msgIds = msgIds
+		sort.Slice(msgIds, func(i, j int) bool {
+			return msgIds[i].ledgerID < msgIds[j].entryID
+		})
+	}
+	nmc.Unlock()
+}
+
+func TestNacksTracker(t *testing.T) {
+	nmc := &nackMockedConsumer{}
+	nacks := newNegativeAcksTracker(nmc, 1 * time.Second)
+
+	nacks.Add(&messageID{
+		ledgerID:     1,
+		entryID:      1,
+		batchIdx:     1,
+	})
+
+	nacks.Add(&messageID{
+		ledgerID:     2,
+		entryID:      2,
+		batchIdx:     1,
+	})
+
+	time.Sleep(2 * time.Second)
+
+	assert.Equal(t, 2, len(nmc.msgIds))
+	assert.Equal(t, int64(1), nmc.msgIds[0].ledgerID)
+	assert.Equal(t, int64(1), nmc.msgIds[0].entryID)
+	assert.Equal(t, int64(2), nmc.msgIds[1].ledgerID)
+	assert.Equal(t, int64(2), nmc.msgIds[1].entryID)
+
+	nacks.Close()
+}
+
+func TestNacksWithBatchesTracker(t *testing.T) {
+	nmc := &nackMockedConsumer{}
+	nacks := newNegativeAcksTracker(nmc, 1 * time.Second)
+
+	nacks.Add(&messageID{
+		ledgerID:     1,
+		entryID:      1,
+		batchIdx:     1,
+	})
+
+	nacks.Add(&messageID{
+		ledgerID:     1,
+		entryID:      1,
+		batchIdx:     2,
+	})
+
+	nacks.Add(&messageID{
+		ledgerID:     1,
+		entryID:      1,
+		batchIdx:     3,
+	})
+
+	nacks.Add(&messageID{
+		ledgerID:     2,
+		entryID:      2,
+		batchIdx:     1,
+	})
+
+	time.Sleep(2 * time.Second)
+
+	assert.Equal(t, 2, len(nmc.msgIds))
+	assert.Equal(t, int64(1), nmc.msgIds[0].ledgerID)
+	assert.Equal(t, int64(1), nmc.msgIds[0].entryID)
+	assert.Equal(t, int64(2), nmc.msgIds[1].ledgerID)
+	assert.Equal(t, int64(2), nmc.msgIds[1].entryID)
+
+	nacks.Close()
+
+	time.Sleep(1 * time.Second)
+}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -434,8 +434,7 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 		fmt.Printf("Received message msgId: %#v -- content: '%s'\n",
 			msg.ID(), string(msg.Payload()))
 		assert.Nil(t, err)
-		err = consumer.Ack(msg)
-		assert.Nil(t, err)
+		consumer.Ack(msg)
 		msgCount++
 	}
 	assert.Equal(t, msgCount, numOfMessages/2)


### PR DESCRIPTION
### Motivation

Added negative acks tracker and integration in the consumer. 

Fixed the API to not return errors for Ack and Nack since these operations will never fail given that we don't wait for confirmation.

cc/ @cckellogg 