### PR TITLE
Fixed RpcClient.RequestOnCnxNoWait() to not require a request id

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -174,8 +174,7 @@ func (pc *partitionConsumer) internalRedeliver(req *redeliveryRequest) {
 		}
 	}
 
-	requestID := internal.RequestIDNoResponse
-	pc.client.rpcClient.RequestOnCnxNoWait(pc.conn, requestID,
+	pc.client.rpcClient.RequestOnCnxNoWait(pc.conn,
 		pb.BaseCommand_REDELIVER_UNACKNOWLEDGED_MESSAGES, &pb.CommandRedeliverUnacknowledgedMessages{
 			ConsumerId: proto.Uint64(pc.consumerID),
 			MessageIds: msgIdDataList,
@@ -203,14 +202,14 @@ func (pc *partitionConsumer) internalAck(req *ackRequest) {
 		LedgerId: proto.Uint64(uint64(msgId.ledgerID)),
 		EntryId:  proto.Uint64(uint64(msgId.entryID)),
 	}
-	requestID := internal.RequestIDNoResponse
+
 	cmdAck := &pb.CommandAck{
 		ConsumerId: proto.Uint64(pc.consumerID),
 		MessageId:  messageIDs,
 		AckType:    pb.CommandAck_Individual.Enum(),
 	}
 
-	pc.client.rpcClient.RequestOnCnxNoWait(pc.conn, requestID, pb.BaseCommand_ACK, cmdAck)
+	pc.client.rpcClient.RequestOnCnxNoWait(pc.conn, pb.BaseCommand_ACK, cmdAck)
 }
 
 func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, headersAndPayload internal.Buffer) error {
@@ -281,15 +280,11 @@ func (pc *partitionConsumer) internalFlow(permits uint32) error {
 		return fmt.Errorf("invalid number of permits requested: %d", permits)
 	}
 
-	requestID := internal.RequestIDNoResponse
 	cmdFlow := &pb.CommandFlow{
 		ConsumerId:     proto.Uint64(pc.consumerID),
 		MessagePermits: proto.Uint32(permits),
 	}
-	_, err := pc.client.rpcClient.RequestOnCnxNoWait(pc.conn, requestID, pb.BaseCommand_FLOW, cmdFlow)
-	if err != nil {
-		return err
-	}
+	pc.client.rpcClient.RequestOnCnxNoWait(pc.conn, pb.BaseCommand_FLOW, cmdFlow)
 
 	return nil
 }

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -68,7 +68,6 @@ type MessageReader struct {
 	batched bool
 }
 
-
 // ReadChecksum
 func (r *MessageReader) readChecksum() (uint32, error) {
 	if r.buffer.ReadableBytes() < 6 {
@@ -82,7 +81,6 @@ func (r *MessageReader) readChecksum() (uint32, error) {
 	checksum := r.buffer.ReadUint32()
 	return checksum, nil
 }
-
 
 func (r *MessageReader) ReadMessageMetadata() (*pb.MessageMetadata, error) {
 	// Wire format
@@ -144,7 +142,6 @@ func (r *MessageReader) readSingleMessage() (*pb.SingleMessageMetadata, []byte, 
 
 	return &meta, r.buffer.Read(uint32(meta.GetPayloadSize())), nil
 }
-
 
 func baseCommand(cmdType pb.BaseCommand_Type, msg proto.Message) *pb.BaseCommand {
 	cmd := &pb.BaseCommand{
@@ -245,7 +242,6 @@ func serializeBatch(wb Buffer, cmdSend *pb.BaseCommand, msgMetadata *pb.MessageM
 	// set computed checksum
 	wb.PutUint32(checksum, checksumIdx)
 }
-
 
 // ConvertFromStringMap convert a string map to a KeyValue []byte
 func ConvertFromStringMap(m map[string]string) []*pb.KeyValue {

--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -38,7 +38,6 @@ func TestConvertStringMap(t *testing.T) {
 	assert.Equal(t, "2", m2["b"])
 }
 
-
 func TestReadMessageMetadata(t *testing.T) {
 	// read old style message (not batched)
 	reader := NewMessageReaderFromArray(rawCompatSingleMessage)
@@ -71,7 +70,6 @@ func TestReadMessageMetadata(t *testing.T) {
 	assert.Equal(t, 10, int(meta.GetNumMessagesInBatch()))
 }
 
-
 func TestReadMessageOldFormat(t *testing.T) {
 	reader := NewMessageReaderFromArray(rawCompatSingleMessage)
 	_, err := reader.ReadMessageMetadata()
@@ -87,10 +85,9 @@ func TestReadMessageOldFormat(t *testing.T) {
 	assert.Equal(t, true, ssm == nil)
 	assert.Equal(t, "hello", string(payload))
 
-	_ , _, err = reader.ReadMessage()
+	_, _, err = reader.ReadMessage()
 	assert.Equal(t, ErrEOM, err)
 }
-
 
 func TestReadMessagesBatchSize1(t *testing.T) {
 	reader := NewMessageReaderFromArray(rawBatchMessage1)
@@ -109,10 +106,9 @@ func TestReadMessagesBatchSize1(t *testing.T) {
 		assert.Equal(t, "hello", string(payload))
 	}
 
-	_ , _, err = reader.ReadMessage()
+	_, _, err = reader.ReadMessage()
 	assert.Equal(t, ErrEOM, err)
 }
-
 
 func TestReadMessagesBatchSize10(t *testing.T) {
 	reader := NewMessageReaderFromArray(rawBatchMessage10)
@@ -131,10 +127,9 @@ func TestReadMessagesBatchSize10(t *testing.T) {
 		assert.Equal(t, "hello", string(payload))
 	}
 
-	_ , _, err = reader.ReadMessage()
+	_, _, err = reader.ReadMessage()
 	assert.Equal(t, ErrEOM, err)
 }
-
 
 // Raw single message in old format
 // metadata properties:<key:"a" value:"1" > properties:<key:"b" value:"2" >

--- a/pulsar/internal/lookup_service_test.go
+++ b/pulsar/internal/lookup_service_test.go
@@ -95,10 +95,8 @@ func (c *mockedRPCClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType
 	return nil, nil
 }
 
-func (c *mockedRPCClient) RequestOnCnxNoWait(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
-	message proto.Message) (*RPCResult, error) {
+func (c *mockedRPCClient) RequestOnCnxNoWait(cnx Connection, cmdType pb.BaseCommand_Type, message proto.Message) {
 	assert.Fail(c.t, "Shouldn't be called")
-	return nil, nil
 }
 
 func responseType(r pb.CommandLookupTopicResponse_LookupType) *pb.CommandLookupTopicResponse_LookupType {

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -31,9 +31,6 @@ type RPCResult struct {
 	Cnx      Connection
 }
 
-// RequestID for a request when there is no expected response
-const RequestIDNoResponse = uint64(0)
-
 type RPCClient interface {
 	// Create a new unique request id
 	NewRequestID() uint64
@@ -48,7 +45,7 @@ type RPCClient interface {
 	Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
 		cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
 
-	RequestOnCnxNoWait(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
+	RequestOnCnxNoWait(cnx Connection, cmdType pb.BaseCommand_Type, message proto.Message)
 
 	RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
 }
@@ -120,17 +117,8 @@ func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.Ba
 	return rpcResult, rpcErr
 }
 
-func (c *rpcClient) RequestOnCnxNoWait(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
-	message proto.Message) (*RPCResult, error) {
-	rpcResult := &RPCResult{
-		Cnx: cnx,
-	}
-
-	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {
-		rpcResult.Response = response
-	})
-
-	return rpcResult, nil
+func (c *rpcClient) RequestOnCnxNoWait(cnx Connection, cmdType pb.BaseCommand_Type, message proto.Message) {
+	cnx.SendRequestNoWait(baseCommand(cmdType, message))
 }
 
 func (c *rpcClient) NewRequestID() uint64 {


### PR DESCRIPTION
### Motivation

Simplified the rpc client handling of request that don't need to track the response.