### PR TITLE
Remove error return on Close() methods

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -108,5 +108,5 @@ type Client interface {
 	TopicPartitions(topic string) ([]string, error)
 
 	// Close the Client and free associated resources
-	Close() error
+	Close()
 }

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -165,5 +165,5 @@ type Consumer interface {
 	NackID(MessageID)
 
 	// Close the consumer and stop the broker to push more messages
-	Close() error
+	Close()
 }

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -163,7 +163,7 @@ func topicSubscribe(client *client, options ConsumerOptions, topic string,
 		// cleanup all the partitions that succeeded in creating the consumer
 		for _, c := range consumer.consumers {
 			if c != nil {
-				_ = c.Close()
+				c.Close()
 			}
 		}
 		return nil, err
@@ -253,7 +253,7 @@ func (c *consumer) NackID(msgID MessageID) {
 	c.consumers[partition].NackID(mid)
 }
 
-func (c *consumer) Close() error {
+func (c *consumer) Close() {
 	var wg sync.WaitGroup
 	for i := range c.consumers {
 		wg.Add(1)
@@ -263,8 +263,6 @@ func (c *consumer) Close() error {
 		}(c.consumers[i])
 	}
 	wg.Wait()
-
-	return nil
 }
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -28,8 +28,8 @@ import (
 func TestSingleMessageIDNoAckTracker(t *testing.T) {
 	eventsCh := make(chan interface{}, 1)
 	pc := partitionConsumer{
-		queueCh:          make(chan []*message, 1),
-		eventsCh:         eventsCh,
+		queueCh:  make(chan []*message, 1),
+		eventsCh: eventsCh,
 	}
 
 	headersAndPayload := internal.NewBufferWrapper(rawCompatSingleMessage)
@@ -46,8 +46,8 @@ func TestSingleMessageIDNoAckTracker(t *testing.T) {
 	// ack the message id
 	pc.AckID(messages[0].msgID.(*messageID))
 
-	select{
-	case <- eventsCh:
+	select {
+	case <-eventsCh:
 	default:
 		t.Error("Expected an ack request to be triggered!")
 	}
@@ -56,8 +56,8 @@ func TestSingleMessageIDNoAckTracker(t *testing.T) {
 func TestBatchMessageIDNoAckTracker(t *testing.T) {
 	eventsCh := make(chan interface{}, 1)
 	pc := partitionConsumer{
-		queueCh:          make(chan []*message, 1),
-		eventsCh:         eventsCh,
+		queueCh:  make(chan []*message, 1),
+		eventsCh: eventsCh,
 	}
 
 	headersAndPayload := internal.NewBufferWrapper(rawBatchMessage1)
@@ -74,8 +74,8 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 	// ack the message id
 	pc.AckID(messages[0].msgID.(*messageID))
 
-	select{
-	case <- eventsCh:
+	select {
+	case <-eventsCh:
 	default:
 		t.Error("Expected an ack request to be triggered!")
 	}
@@ -84,8 +84,8 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 func TestBatchMessageIDWithAckTracker(t *testing.T) {
 	eventsCh := make(chan interface{}, 1)
 	pc := partitionConsumer{
-		queueCh:          make(chan []*message, 1),
-		eventsCh:         eventsCh,
+		queueCh:  make(chan []*message, 1),
+		eventsCh: eventsCh,
 	}
 
 	headersAndPayload := internal.NewBufferWrapper(rawBatchMessage10)
@@ -104,8 +104,8 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 		pc.AckID(messages[i].msgID.(*messageID))
 	}
 
-	select{
-	case <- eventsCh:
+	select {
+	case <-eventsCh:
 		t.Error("The message id should not be acked!")
 	default:
 	}
@@ -113,8 +113,8 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 	// ack last message
 	pc.AckID(messages[9].msgID.(*messageID))
 
-	select{
-	case <- eventsCh:
+	select {
+	case <-eventsCh:
 	default:
 		t.Error("Expected an ack request to be triggered!")
 	}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -593,8 +593,7 @@ func TestConsumerAck(t *testing.T) {
 		}
 	}
 
-	err = consumer.Close()
-	assert.Nil(t, err)
+	consumer.Close()
 
 	// Subscribe again
 	consumer, err = client.Subscribe(ConsumerOptions{

--- a/pulsar/impl_client.go
+++ b/pulsar/impl_client.go
@@ -143,12 +143,8 @@ func (client *client) TopicPartitions(topic string) ([]string, error) {
 	return []string{topicName.Name}, nil
 }
 
-func (client *client) Close() error {
+func (client *client) Close() {
 	for handler := range client.handlers {
-		if err := handler.Close(); err != nil {
-			return err
-		}
+		handler.Close()
 	}
-
-	return nil
 }

--- a/pulsar/impl_client_test.go
+++ b/pulsar/impl_client_test.go
@@ -47,8 +47,7 @@ func TestTLSConnectionCAError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTLSInsecureConnection(t *testing.T) {
@@ -65,8 +64,7 @@ func TestTLSInsecureConnection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTLSConnection(t *testing.T) {
@@ -83,8 +81,7 @@ func TestTLSConnection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTLSConnectionHostNameVerification(t *testing.T) {
@@ -102,8 +99,7 @@ func TestTLSConnectionHostNameVerification(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTLSConnectionHostNameVerificationError(t *testing.T) {
@@ -121,8 +117,7 @@ func TestTLSConnectionHostNameVerificationError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTLSAuthError(t *testing.T) {
@@ -139,8 +134,7 @@ func TestTLSAuthError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTLSAuth(t *testing.T) {
@@ -158,8 +152,7 @@ func TestTLSAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTokenAuth(t *testing.T) {
@@ -179,8 +172,7 @@ func TestTokenAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTokenAuthFromFile(t *testing.T) {
@@ -197,8 +189,7 @@ func TestTokenAuthFromFile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 
-	err = client.Close()
-	assert.NoError(t, err)
+	client.Close()
 }
 
 func TestTopicPartitions(t *testing.T) {

--- a/pulsar/impl_producer.go
+++ b/pulsar/impl_producer.go
@@ -19,8 +19,6 @@ package pulsar
 
 import (
 	"context"
-	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 )
@@ -102,7 +100,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 		// Since there were some failures, cleanup all the partitions that succeeded in creating the producers
 		for _, producer := range p.producers {
 			if producer != nil {
-				_ = producer.Close()
+				producer.Close()
 			}
 		}
 		return nil, err
@@ -154,13 +152,8 @@ func (p *producer) Flush() error {
 	return nil
 }
 
-func (p *producer) Close() error {
-	var errs error
+func (p *producer) Close() {
 	for _, pp := range p.producers {
-		if err := pp.Close(); err != nil {
-			errs = errors.Wrap(err, fmt.Sprintf("unable to close producer %s", p.Name()))
-		}
-
+		pp.Close()
 	}
-	return errs
 }

--- a/pulsar/internal/closable.go
+++ b/pulsar/internal/closable.go
@@ -18,5 +18,5 @@
 package internal
 
 type Closable interface {
-	Close() error
+	Close()
 }

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -162,5 +162,5 @@ type Producer interface {
 	// Close the producer and releases resources allocated
 	// No more writes will be accepted from this producer. Waits until all pending write request are persisted. In case
 	// of errors, pending writes will not be retried.
-	Close() error
+	Close()
 }

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -85,6 +85,7 @@ func TestSimpleProducer(t *testing.T) {
 		URL: serviceURL,
 	})
 	assert.NoError(t, err)
+	defer client.Close()
 
 	producer, err := client.CreateProducer(ProducerOptions{
 		Topic: newTopicName(),
@@ -92,6 +93,7 @@ func TestSimpleProducer(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
+	defer producer.Close()
 
 	for i := 0; i < 10; i++ {
 		err = producer.Send(context.Background(), &ProducerMessage{
@@ -100,12 +102,6 @@ func TestSimpleProducer(t *testing.T) {
 
 		assert.NoError(t, err)
 	}
-
-	err = producer.Close()
-	assert.NoError(t, err)
-
-	err = client.Close()
-	assert.NoError(t, err)
 }
 
 func TestProducerAsyncSend(t *testing.T) {
@@ -113,6 +109,7 @@ func TestProducerAsyncSend(t *testing.T) {
 		URL: serviceURL,
 	})
 	assert.NoError(t, err)
+	defer client.Close()
 
 	producer, err := client.CreateProducer(ProducerOptions{
 		Topic:                   newTopicName(),
@@ -121,6 +118,7 @@ func TestProducerAsyncSend(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
+	defer producer.Close()
 
 	wg := sync.WaitGroup{}
 	wg.Add(10)
@@ -148,12 +146,6 @@ func TestProducerAsyncSend(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, 0, errors.Size())
-
-	err = producer.Close()
-	assert.NoError(t, err)
-
-	err = client.Close()
-	assert.NoError(t, err)
 }
 
 func TestProducerCompression(t *testing.T) {
@@ -176,6 +168,7 @@ func TestProducerCompression(t *testing.T) {
 				URL: serviceURL,
 			})
 			assert.NoError(t, err)
+			defer client.Close()
 
 			producer, err := client.CreateProducer(ProducerOptions{
 				Topic:           newTopicName(),
@@ -184,6 +177,7 @@ func TestProducerCompression(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotNil(t, producer)
+			defer producer.Close()
 
 			for i := 0; i < 10; i++ {
 				err = producer.Send(context.Background(), &ProducerMessage{
@@ -192,12 +186,6 @@ func TestProducerCompression(t *testing.T) {
 
 				assert.NoError(t, err)
 			}
-
-			err = producer.Close()
-			assert.NoError(t, err)
-
-			err = client.Close()
-			assert.NoError(t, err)
 		})
 	}
 }
@@ -207,6 +195,7 @@ func TestProducerLastSequenceID(t *testing.T) {
 		URL: serviceURL,
 	})
 	assert.NoError(t, err)
+	defer client.Close()
 
 	producer, err := client.CreateProducer(ProducerOptions{
 		Topic: newTopicName(),
@@ -214,6 +203,7 @@ func TestProducerLastSequenceID(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
+	defer producer.Close()
 
 	assert.Equal(t, int64(-1), producer.LastSequenceID())
 
@@ -225,12 +215,6 @@ func TestProducerLastSequenceID(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int64(i), producer.LastSequenceID())
 	}
-
-	err = producer.Close()
-	assert.NoError(t, err)
-
-	err = client.Close()
-	assert.NoError(t, err)
 }
 
 func TestEventTime(t *testing.T) {

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -79,5 +79,5 @@ type Reader interface {
 	HasNext() (bool, error)
 
 	// Close the reader and stop the broker to push more messages
-	Close() error
+	Close()
 }


### PR DESCRIPTION
### Motivation

Fixes #17. As per discussion, simplify the API by allowing `defer client.Close()` methods. Internally, we need to make sure we release all the resources even when we have failures.