### PR TITLE
[Producer] Set error only if not nil

### DIFF
--- a/pulsar/impl_producer.go
+++ b/pulsar/impl_producer.go
@@ -91,7 +91,9 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 	for i := 0; i < numPartitions; i++ {
 		pe, ok := <-c
 		if ok {
-			err = pe.err
+			if pe.err != nil {
+				err = pe.err
+			}
 			p.producers[pe.partition] = pe.prod
 		}
 	}


### PR DESCRIPTION
### Motivation
Fix error set bug in impl_producer.go

### Modifications

```go
if pe.err != nil {
	err = pe.err
}
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
