### PR TITLE
Fix seg fault when producer with same name is created.

### DIFF
--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -93,8 +93,9 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 		if ok {
 			if pe.err != nil {
 				err = pe.err
+			} else {
+				p.producers[pe.partition] = pe.prod
 			}
-			p.producers[pe.partition] = pe.prod
 		}
 	}
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -107,7 +107,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 		return nil, err
 	}
 
-	p.log = p.log.WithField("name", *p.producerName)
+	p.log = p.log.WithField("name", p.producerName)
 	p.log.Info("Created producer")
 	p.state = producerReady
 

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -495,3 +495,31 @@ func TestNonPersistentTopic(t *testing.T) {
 	assert.Nil(t, err)
 	defer consumer.Close()
 }
+
+func TestProducerDuplicateNameOnSameTopic(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	topicName := newTopicName()
+	producerName := "my-producer"
+
+	p1, err := client.CreateProducer(ProducerOptions{
+		Topic: topicName,
+		Name:  producerName,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p1.Close()
+
+	_, err = client.CreateProducer(ProducerOptions{
+		Topic: topicName,
+		Name:  producerName,
+	})
+	assert.NotNil(t, err, "expected error when creating producer with same name")
+}


### PR DESCRIPTION
### Motivation

This fixes a seg fault when a producer with the same name is created for a topic. 

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd755d6]

goroutine 48 [running]:
github.com/apache/pulsar-client-go/pulsar.(*partitionProducer).Close(0x0)

        github.com/apache/pulsar-client-go/pulsar/impl_partition_producer.go:443 +0x26

github.com/apache/pulsar-client-go/pulsar.newProducer(0xc0000c68c0, 0xc000342780, 0x58, 0x58, 0xc000596360)

        github.com/apache/pulsar-client-go/pulsar/impl_producer.go:103 +0x31c

github.com/apache/pulsar-client-go/pulsar.(*client).CreateProducer(0xc0000c68c0, 0xc0000344c0, 0x13, 0x1030d22, 0xd, 0x0, 0x0, 0x0, 0x0, 0x0, ...)

        github.com/apache/pulsar-client-go/pulsar/client_impl.go:94 +0x7a
```
