### PR TITLE
[Issue #112] Fix installation of go module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 *.out
 
 perf/perf
+
+
+# dummy executable in root dir
+pulsar-client-go

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/apache/pulsar-client-go
+module github.com/BoseCorp/pulsar-client-go
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/BoseCorp/pulsar-client-go
+module github.com/apache/pulsar-client-go
 
 go 1.12
 

--- a/no_code.go
+++ b/no_code.go
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// There is only one purpose for this file: to allow the go module
+// to be installed.  At the moment, without no_code.go there is only
+// one source file in the root directory of the module and it's a
+// *_test.go file... this keeps the module from being installed via
+// go get.
+
+
+
+package main
+
+func main() {
+}


### PR DESCRIPTION
### Motivation

Fix the installation of the client's go module: github.com/apache/pulsar-client-go
With this change, no one can install the client using the standard `go get` tool chain

https://github.com/apache/pulsar-client-go/issues/112

### Modifications

Added a no_code.go source file to the root directory.  This is required the module currently won't install because the only source in the root directory is licence_test.go (which walks the source tree looking for license txt in each file).

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API:  no
  - The schema: no 
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

No need for documentation besides the comments in the no_code.go source file.  If the project changes how licensing is checked, then this change can be reverted.

