### PR TITLE
Add metadata to produce and subscribe commands.

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -140,6 +140,7 @@ func internalTopicSubscribe(client *client, options ConsumerOptions, topic strin
 	}
 
 	receiverQueueSize := options.ReceiverQueueSize
+	metadata := options.Properties
 	var wg sync.WaitGroup
 	ch := make(chan ConsumerError, numPartitions)
 	wg.Add(numPartitions)
@@ -162,6 +163,7 @@ func internalTopicSubscribe(client *client, options ConsumerOptions, topic strin
 				partitionIdx:        idx,
 				receiverQueueSize:   receiverQueueSize,
 				nackRedeliveryDelay: nackRedeliveryDelay,
+				metadata:            metadata,
 			}
 			cons, err := newPartitionConsumer(consumer, client, opts, messageCh)
 			ch <- ConsumerError{

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -58,6 +58,7 @@ type partitionConsumerOpts struct {
 	partitionIdx        int
 	receiverQueueSize   int
 	nackRedeliveryDelay time.Duration
+	metadata            map[string]string
 }
 
 type partitionConsumer struct {
@@ -523,6 +524,9 @@ func (pc *partitionConsumer) grabConn() error {
 		ConsumerName:    proto.String(pc.name),
 		InitialPosition: initialPosition.Enum(),
 		Schema:          nil,
+	}
+	if len(pc.options.metadata) > 0 {
+		cmdSubscribe.Metadata = toKeyValues(pc.options.metadata)
 	}
 
 	res, err := pc.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, requestID,

--- a/pulsar/helper.go
+++ b/pulsar/helper.go
@@ -22,6 +22,8 @@ import (
 
 	pkgerrors "github.com/pkg/errors"
 
+	"github.com/golang/protobuf/proto"
+
 	"github.com/apache/pulsar-client-go/pkg/pb"
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 )
@@ -60,4 +62,17 @@ func validateTopicNames(topics ...string) error {
 	}
 
 	return errs
+}
+
+func toKeyValues(metadata map[string]string) []*pb.KeyValue {
+	kvs := make([]*pb.KeyValue, 0, len(metadata))
+	for k, v := range metadata {
+		kv := &pb.KeyValue{
+			Key:   proto.String(k),
+			Value: proto.String(v),
+		}
+		kvs = append(kvs, kv)
+	}
+
+	return kvs
 }

--- a/pulsar/helper_test.go
+++ b/pulsar/helper_test.go
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToKeyValues(t *testing.T) {
+	meta := map[string]string{
+		"key1": "value1",
+	}
+
+	kvs := toKeyValues(meta)
+	assert.Equal(t, 1, len(kvs))
+	assert.Equal(t, "key1", *kvs[0].Key)
+	assert.Equal(t, "value1", *kvs[0].Value)
+
+	meta = map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	kvs = toKeyValues(meta)
+	assert.Equal(t, 2, len(kvs))
+	for _, kv := range kvs {
+		v := meta[*kv.Key]
+		assert.Equal(t, v, *kv.Value)
+	}
+}


### PR DESCRIPTION
### Motivation

Add the metadata to the produce and subscribe commands (the other clients support this) so the properties from the configs will show up in the topic stats response from the brokers.
