### PR TITLE
[Issue 118][client_impl.go] fix race condition when accessing client.handlers

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -93,7 +93,7 @@ func newClient(options ClientOptions) (Client, error) {
 func (c *client) CreateProducer(options ProducerOptions) (Producer, error) {
 	producer, err := newProducer(c, &options)
 	if err == nil {
-		c.handlers.Set(producer, true)
+		c.handlers.Add(producer)
 	}
 	return producer, err
 }
@@ -103,7 +103,7 @@ func (c *client) Subscribe(options ConsumerOptions) (Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.handlers.Set(consumer, true)
+	c.handlers.Add(consumer)
 	return consumer, nil
 }
 

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -39,7 +39,7 @@ type client struct {
 	lookupService internal.LookupService
 	auth          auth.Provider
 
-	handlers            map[internal.Closable]bool
+	handlers            internal.ClientHandlers
 	producerIDGenerator uint64
 	consumerIDGenerator uint64
 }
@@ -86,14 +86,14 @@ func newClient(options ClientOptions) (Client, error) {
 	}
 	c.rpcClient = internal.NewRPCClient(url, c.cnxPool)
 	c.lookupService = internal.NewLookupService(c.rpcClient, url)
-	c.handlers = make(map[internal.Closable]bool)
+	c.handlers = internal.NewClientHandlers()
 	return c, nil
 }
 
 func (c *client) CreateProducer(options ProducerOptions) (Producer, error) {
 	producer, err := newProducer(c, &options)
 	if err == nil {
-		c.handlers[producer] = true
+		c.handlers.Set(producer, true)
 	}
 	return producer, err
 }
@@ -103,7 +103,7 @@ func (c *client) Subscribe(options ConsumerOptions) (Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.handlers[consumer] = true
+	c.handlers.Set(consumer, true)
 	return consumer, nil
 }
 
@@ -145,9 +145,7 @@ func (c *client) TopicPartitions(topic string) ([]string, error) {
 }
 
 func (c *client) Close() {
-	for handler := range c.handlers {
-		handler.Close()
-	}
+	c.handlers.Close()
 }
 
 func (c *client) namespaceTopics(namespace string) ([]string, error) {

--- a/pulsar/internal/client_handlers.go
+++ b/pulsar/internal/client_handlers.go
@@ -31,10 +31,10 @@ func NewClientHandlers() ClientHandlers {
 		l:        &sync.RWMutex{},
 	}
 }
-func (h *ClientHandlers) Set(c Closable, b bool) {
+func (h *ClientHandlers) Add(c Closable) {
 	h.l.Lock()
 	defer h.l.Unlock()
-	h.handlers[c] = b
+	h.handlers[c] = true
 }
 func (h *ClientHandlers) Val(c Closable) bool {
 	h.l.RLock()

--- a/pulsar/internal/client_handlers.go
+++ b/pulsar/internal/client_handlers.go
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import "sync"
+
+// ClientHandlerMap is a simple concurrent-safe map for the client type
+type ClientHandlers struct {
+	handlers map[Closable]bool
+	l        *sync.RWMutex
+}
+
+func NewClientHandlers() ClientHandlers {
+	return ClientHandlers{
+		handlers: map[Closable]bool{},
+		l:        &sync.RWMutex{},
+	}
+}
+func (h *ClientHandlers) Set(c Closable, b bool) {
+	h.l.Lock()
+	defer h.l.Unlock()
+	h.handlers[c] = b
+}
+func (h *ClientHandlers) Val(c Closable) bool {
+	h.l.RLock()
+	defer h.l.RUnlock()
+	return h.handlers[c]
+}
+
+func (h *ClientHandlers) Close() {
+	h.l.Lock()
+	defer h.l.Unlock()
+
+	for handler := range h.handlers {
+		handler.Close()
+	}
+}

--- a/pulsar/internal/client_handlers_test.go
+++ b/pulsar/internal/client_handlers_test.go
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientHandlers(t *testing.T) {
+	h := NewClientHandlers()
+	assert.NotNil(t, h.l)
+	assert.Equal(t, h.handlers, map[Closable]bool{})
+
+	closable := &testClosable{false}
+	h.Set(closable, true)
+	assert.True(t, h.Val(closable))
+
+	h.Close()
+	t.Log("closable is: ", closable.closed)
+	assert.True(t, closable.closed)
+}
+
+type testClosable struct {
+	closed bool
+}
+
+func (t *testClosable) Close() {
+	t.closed = true
+}

--- a/pulsar/internal/client_handlers_test.go
+++ b/pulsar/internal/client_handlers_test.go
@@ -29,7 +29,7 @@ func TestClientHandlers(t *testing.T) {
 	assert.Equal(t, h.handlers, map[Closable]bool{})
 
 	closable := &testClosable{false}
-	h.Set(closable, true)
+	h.Add(closable)
 	assert.True(t, h.Val(closable))
 
 	h.Close()

--- a/pulsar/internal/client_handlers_test.go
+++ b/pulsar/internal/client_handlers_test.go
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package internal
 
 import (


### PR DESCRIPTION
### Motivation

fix race condition caused by writing to map in multiple goroutines

### Modifications

Created new internal type: ClientHandlers which encapsulates a sync.Mutex to make read/writes to clients.handlers concurrent safe.

### Verifying this change

This change added tests and can be verified as follows:  just run: `go test -timeout 30s github.com/apache/pulsar-client-go/pulsar/internal -run "^(TestClientHandlers)$"`

### Documentation

  - Does this pull request introduce a new feature? no
  