### PR TITLE
Make nack tracker tests more robust.

### DIFF
--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -40,7 +40,7 @@ func newNackMockedConsumer() *nackMockedConsumer {
 		ch: make(chan messageID, 10),
 	}
 	go func() {
-		// since the client ticks at at interval of delay / 3
+		// since the client ticks at an interval of delay / 3
 		// wait another interval to ensure we get all messages
 		time.Sleep(testNackDelay + 101 * time.Millisecond)
 		t.lock.Lock()


### PR DESCRIPTION
Make the nack tracker test for robust. I've seen them occasionally fail.

https://builds.apache.org/job/pulsar_precommit_client_go/195/console