### PR TITLE
[Issue #123] Ensure message is sent if no room in current batch.

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -787,7 +787,8 @@ func TestConsumerMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	subs := stats["subscriptions"].(map[string]interface{})
-	meta := subs["my-sub"].(map[string]interface{})["consumers"].([]interface{})[0].(map[string]interface{})["metadata"].(map[string]interface{})
+	cons := subs["my-sub"].(map[string]interface{})["consumers"].([]interface{})[0].(map[string]interface{})
+	meta := cons["metadata"].(map[string]interface{})
 	assert.Equal(t, len(props), len(meta))
 	for k, v := range props {
 		mv := meta[k].(string)

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -29,9 +29,9 @@ import (
 const testNackDelay = 300 * time.Millisecond
 
 type nackMockedConsumer struct {
-	ch chan messageID
+	ch     chan messageID
 	closed bool
-	lock sync.Mutex
+	lock   sync.Mutex
 	msgIds []messageID
 }
 
@@ -42,7 +42,7 @@ func newNackMockedConsumer() *nackMockedConsumer {
 	go func() {
 		// since the client ticks at an interval of delay / 3
 		// wait another interval to ensure we get all messages
-		time.Sleep(testNackDelay + 101 * time.Millisecond)
+		time.Sleep(testNackDelay + 101*time.Millisecond)
 		t.lock.Lock()
 		defer t.lock.Unlock()
 		t.closed = true
@@ -69,7 +69,7 @@ func sortMessageIds(msgIds []messageID) []messageID {
 	return msgIds
 }
 
-func (nmc *nackMockedConsumer) Wait() <- chan messageID {
+func (nmc *nackMockedConsumer) Wait() <-chan messageID {
 	return nmc.ch
 }
 

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -613,7 +613,8 @@ func TestBatchMessageFlushing(t *testing.T) {
 			if published == 2 {
 				keepGoing = false
 			}
-		case <-time.After(defaultBatchingMaxPublishDelay * 3):
+		case <-time.After(defaultBatchingMaxPublishDelay * 10):
+			fmt.Println("TestBatchMessageFlushing timeout waiting to publish messages")
 			keepGoing = false
 		}
 	}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -558,3 +558,65 @@ func TestProducerMetadata(t *testing.T) {
 		assert.Equal(t, v, mv)
 	}
 }
+
+// test for issues #76 and #114
+func TestBatchMessageFlushing(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	topic := newTopicName()
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: topic,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer producer.Close()
+
+	maxBytes := internal.MaxBatchSize
+	genbytes := func(n int) []byte {
+		c := []byte("a")[0]
+		bytes := make([]byte, n)
+		for i := 0; i < n; i++ {
+			bytes[i] = c
+		}
+		return bytes
+	}
+
+	msgs := [][]byte{
+		genbytes(maxBytes - 10),
+		genbytes(11),
+	}
+
+	ch := make(chan struct{}, 2)
+	ctx := context.Background()
+	for _, msg := range msgs {
+		msg := &ProducerMessage{
+			Payload: msg,
+		}
+		producer.SendAsync(ctx, msg, func(id MessageID, producerMessage *ProducerMessage, err error) {
+			ch <- struct{}{}
+		})
+	}
+
+	published := 0
+	keepGoing := true
+	for keepGoing {
+		select {
+		case <-ch:
+			published++
+			if published == 2 {
+				keepGoing = false
+			}
+		case <-time.After(defaultBatchingMaxPublishDelay * 2):
+			keepGoing = false
+		}
+	}
+
+	assert.Equal(t, 2, published, "expected to publish two messages")
+}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -559,7 +559,7 @@ func TestProducerMetadata(t *testing.T) {
 	}
 }
 
-// test for issues #76 and #114
+// test for issues #76, #114 and #123
 func TestBatchMessageFlushing(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -613,7 +613,7 @@ func TestBatchMessageFlushing(t *testing.T) {
 			if published == 2 {
 				keepGoing = false
 			}
-		case <-time.After(defaultBatchingMaxPublishDelay * 2):
+		case <-time.After(defaultBatchingMaxPublishDelay * 3):
 			keepGoing = false
 		}
 	}


### PR DESCRIPTION
Fixes #123
Fixes #76 
Fixes #114 

If the current message being published does not fit in the current batch that message is never sent. This patch will add the message to the batch after flushing the current batch.
