### PR TITLE
Removed unused config options

### DIFF
--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -87,7 +87,6 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 		MaxPendingMessages:      produceArgs.ProducerQueueSize,
 		BatchingMaxPublishDelay: time.Millisecond * time.Duration(produceArgs.BatchingTimeMillis),
 		SendTimeout:             0,
-		BlockIfQueueFull:        true,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -49,12 +49,6 @@ func NewAuthenticationTLS(certificatePath string, privateKeyPath string) Authent
 	return auth.NewAuthenticationTLS(certificatePath, privateKeyPath)
 }
 
-// Create new Athenz Authentication provider with configuration in JSON form
-func NewAuthenticationAthenz(authParams string) Authentication {
-	// TODO: return newAuthenticationAthenz(authParams)
-	return nil
-}
-
 // Builder interface that is used to construct a Pulsar Client instance.
 type ClientOptions struct {
 	// Configure the service URL for the Pulsar service.

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -105,11 +105,6 @@ type ConsumerOptions struct {
 	// Set to -1 to disable prefetching in consumer
 	ReceiverQueueSize int
 
-	// Set the max total receiver queue size across partitions.
-	// This setting will be used to reduce the receiver queue size for individual partitions
-	// ReceiverQueueSize(int) if the total exceeds this value (default: 50000).
-	MaxTotalReceiverQueueSizeAcrossPartitions int
-
 	// The delay after which to redeliver the messages that failed to be
 	// processed. Default is 1min. (See `Consumer.Nack()`)
 	NackRedeliveryDelay time.Duration

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -136,7 +136,6 @@ func TestBatchMessageReceive(t *testing.T) {
 		Topic:               topicName,
 		BatchingMaxMessages: uint(batchSize),
 		DisableBatching:     false,
-		BlockIfQueueFull:    true,
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, topicName, producer.Topic())

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -74,16 +74,6 @@ type ProducerOptions struct {
 	// unless `BlockIfQueueFull` is set to true. Use BlockIfQueueFull(boolean) to change the blocking behavior.
 	MaxPendingMessages int
 
-	// MaxPendingMessagesAcrossPartitions set the number of max pending messages across all the partitions
-	// This setting will be used to lower the max pending messages for each partition
-	// `MaxPendingMessages(int)`, if the total exceeds the configured value.
-	MaxPendingMessagesAcrossPartitions int
-
-	// BlockIfQueueFull set whether the `Producer.Send()` and `Producer.sendAsync()` operations should block when the outgoing
-	// message queue is full. Default is `false`. If set to `false`, send operations will immediately fail with
-	// `ProducerQueueIsFullError` when there is no space left in pending queue.
-	BlockIfQueueFull bool
-
 	// HashingScheme change the `HashingScheme` used to chose the partition on where to publish a particular message.
 	// Standard hashing functions available are:
 	//

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -70,8 +70,6 @@ type ProducerOptions struct {
 	SendTimeout time.Duration
 
 	// MaxPendingMessages set the max size of the queue holding the messages pending to receive an acknowledgment from the broker.
-	// When the queue is full, by default, all calls to Producer.send() and Producer.sendAsync() will fail
-	// unless `BlockIfQueueFull` is set to true. Use BlockIfQueueFull(boolean) to change the blocking behavior.
 	MaxPendingMessages int
 
 	// HashingScheme change the `HashingScheme` used to chose the partition on where to publish a particular message.

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -269,7 +269,6 @@ func TestFlushInProducer(t *testing.T) {
 		DisableBatching:         false,
 		BatchingMaxMessages:     uint(numOfMessages),
 		BatchingMaxPublishDelay: time.Second * 10,
-		BlockIfQueueFull:        true,
 		Properties: map[string]string{
 			"producer-name": "test-producer-name",
 			"producer-id":   "test-producer-id",
@@ -380,7 +379,6 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 		DisableBatching:         false,
 		BatchingMaxMessages:     uint(numOfMessages / numberOfPartitions),
 		BatchingMaxPublishDelay: time.Second * 10,
-		BlockIfQueueFull:        true,
 	})
 	defer producer.Close()
 


### PR DESCRIPTION
### Motivation

There are some config options that are currently ignored in the Go client and make more sense in C++ client lib. Removing them for now, until it's clear that we need them.