### PR TITLE
Exit goroutine when signal is caught.

### DIFF
--- a/perf/pulsar-perf-go.go
+++ b/perf/pulsar-perf-go.go
@@ -90,12 +90,8 @@ func stopCh() <-chan struct{} {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt)
 	go func() {
-		for {
-			select {
-			case <-signalCh:
-				close(stop)
-			}
-		}
+		<-signalCh
+		close(stop)
 	}()
 	return stop
 }
@@ -122,8 +118,8 @@ func serveProfiling(addr string, stop <-chan struct{}) error {
 	}()
 
 	fmt.Printf("Starting pprof server at: %s\n", addr)
-	fmt.Printf("  use `go tool pprof http://%s/debug/pprof/prof` to get pprof file(cpu info)\n", addr)
-	fmt.Printf("  use `go tool pprof http://%s/debug/pprof/heap` to get inuse_space file\n", addr)
+	fmt.Printf("  use go tool pprof http://%s/debug/pprof/prof to get pprof file(cpu info)\n", addr)
+	fmt.Printf("  use go tool pprof http://%s/debug/pprof/heap to get inuse_space file\n", addr)
 	fmt.Println()
 
 	return s.ListenAndServe()


### PR DESCRIPTION
This change ensures that the go routine listening for the interrupt exists properly. It work before because we exited the program whenever we received a signal from this channel. This change just ensures proper clean up so we don't ever leak a go routine.