### PR TITLE
Removed SendTimeout from producer options

### DIFF
--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -86,7 +86,6 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 		Topic:                   produceArgs.Topic,
 		MaxPendingMessages:      produceArgs.ProducerQueueSize,
 		BatchingMaxPublishDelay: time.Millisecond * time.Duration(produceArgs.BatchingTimeMillis),
-		SendTimeout:             0,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -63,12 +63,6 @@ type ProducerOptions struct {
 	// This properties will be visible in the topic stats
 	Properties map[string]string
 
-	// SendTimeout set the send timeout (default: 30 seconds)
-	// If a message is not acknowledged by the server before the sendTimeout expires, an error will be reported.
-	// Setting the timeout to -1, will set the timeout to infinity, which can be useful when using Pulsar's message
-	// duplication feature.
-	SendTimeout time.Duration
-
 	// MaxPendingMessages set the max size of the queue holding the messages pending to receive an acknowledgment from the broker.
 	MaxPendingMessages int
 


### PR DESCRIPTION
### Motivation

`SendTimeout` is not currently being used, rather we are relying on the `ctx` object to timeout the send requests