### PR TITLE
[Issue #140] Consumer should not block on received if closed.

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -48,8 +48,9 @@ type consumer struct {
 	// channel used to deliver message to clients
 	messageCh chan ConsumerMessage
 
-	closeCh chan struct{}
-	errorCh chan error
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	errorCh   chan error
 
 	log *log.Entry
 }
@@ -116,6 +117,7 @@ func internalTopicSubscribe(client *client, options ConsumerOptions, topic strin
 	consumer := &consumer{
 		options:   options,
 		messageCh: messageCh,
+		closeCh:   make(chan struct{}),
 		errorCh:   make(chan error),
 		log:       log.WithField("topic", topic),
 	}
@@ -226,6 +228,8 @@ func (c *consumer) Unsubscribe() error {
 func (c *consumer) Receive(ctx context.Context) (message Message, err error) {
 	for {
 		select {
+		case <-c.closeCh:
+			return nil, ErrConsumerClosed
 		case cm, ok := <-c.messageCh:
 			if !ok {
 				return nil, ErrConsumerClosed
@@ -298,15 +302,18 @@ func (c *consumer) NackID(msgID MessageID) {
 }
 
 func (c *consumer) Close() {
-	var wg sync.WaitGroup
-	for i := range c.consumers {
-		wg.Add(1)
-		go func(pc *partitionConsumer) {
-			defer wg.Done()
-			pc.Close()
-		}(c.consumers[i])
-	}
-	wg.Wait()
+	c.closeOnce.Do(func() {
+		var wg sync.WaitGroup
+		for i := range c.consumers {
+			wg.Add(1)
+			go func(pc *partitionConsumer) {
+				defer wg.Done()
+				pc.Close()
+			}(c.consumers[i])
+		}
+		wg.Wait()
+		close(c.closeCh)
+	})
 }
 
 var r = &random{


### PR DESCRIPTION
If the consumer has been closed a call to receive should not block and return an error.