### PR TITLE
[Issue #153] Fix handler memory leak

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -41,6 +41,7 @@ type acker interface {
 }
 
 type consumer struct {
+	client    *client
 	options   ConsumerOptions
 	consumers []*partitionConsumer
 
@@ -114,6 +115,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 func internalTopicSubscribe(client *client, options ConsumerOptions, topic string,
 	messageCh chan ConsumerMessage) (*consumer, error) {
 	consumer := &consumer{
+		client:    client,
 		options:   options,
 		messageCh: messageCh,
 		closeCh:   make(chan struct{}),
@@ -317,6 +319,7 @@ func (c *consumer) Close() {
 		wg.Wait()
 		close(c.closeCh)
 	})
+	c.client.handlers.Del(c)
 }
 
 var r = &random{

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -318,8 +318,8 @@ func (c *consumer) Close() {
 		}
 		wg.Wait()
 		close(c.closeCh)
+		c.client.handlers.Del(c)
 	})
-	c.client.handlers.Del(c)
 }
 
 var r = &random{

--- a/pulsar/internal/client_handlers.go
+++ b/pulsar/internal/client_handlers.go
@@ -40,9 +40,7 @@ func (h *ClientHandlers) Add(c Closable) {
 func (h *ClientHandlers) Del(c Closable) {
 	h.l.Lock()
 	defer h.l.Unlock()
-	if _, has := h.handlers[c]; has {
-		delete(h.handlers, c)
-	}
+	delete(h.handlers, c)
 }
 
 func (h *ClientHandlers) Val(c Closable) bool {

--- a/pulsar/internal/client_handlers.go
+++ b/pulsar/internal/client_handlers.go
@@ -36,6 +36,15 @@ func (h *ClientHandlers) Add(c Closable) {
 	defer h.l.Unlock()
 	h.handlers[c] = true
 }
+
+func (h *ClientHandlers) Del(c Closable) {
+	h.l.Lock()
+	defer h.l.Unlock()
+	if _, has := h.handlers[c]; has {
+		delete(h.handlers, c)
+	}
+}
+
 func (h *ClientHandlers) Val(c Closable) bool {
 	h.l.RLock()
 	defer h.l.RUnlock()

--- a/pulsar/internal/client_handlers.go
+++ b/pulsar/internal/client_handlers.go
@@ -51,9 +51,13 @@ func (h *ClientHandlers) Val(c Closable) bool {
 
 func (h *ClientHandlers) Close() {
 	h.l.Lock()
-	defer h.l.Unlock()
-
+	handlers := make([]Closable, 0, len(h.handlers))
 	for handler := range h.handlers {
+		handlers = append(handlers, handler)
+	}
+	h.l.Unlock()
+
+	for _, handler := range handlers {
 		handler.Close()
 	}
 }

--- a/pulsar/internal/client_handlers_test.go
+++ b/pulsar/internal/client_handlers_test.go
@@ -28,7 +28,7 @@ func TestClientHandlers(t *testing.T) {
 	assert.NotNil(t, h.l)
 	assert.Equal(t, h.handlers, map[Closable]bool{})
 
-	closable := &testClosable{h: &h, closed:false}
+	closable := &testClosable{h: &h, closed: false}
 	h.Add(closable)
 	assert.True(t, h.Val(closable))
 
@@ -42,10 +42,10 @@ func TestClientHandlers_Del(t *testing.T) {
 	assert.NotNil(t, h.l)
 	assert.Equal(t, h.handlers, map[Closable]bool{})
 
-	closable1 := &testClosable{h: &h, closed:false}
+	closable1 := &testClosable{h: &h, closed: false}
 	h.Add(closable1)
 
-	closable2 := &testClosable{h: &h, closed:false}
+	closable2 := &testClosable{h: &h, closed: false}
 	h.Add(closable2)
 
 	assert.Len(t, h.handlers, 2)
@@ -66,7 +66,7 @@ func TestClientHandlers_Del(t *testing.T) {
 }
 
 type testClosable struct {
-	h *ClientHandlers
+	h      *ClientHandlers
 	closed bool
 }
 

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -24,7 +24,7 @@ import (
 )
 
 type producer struct {
-	client *client
+	client        *client
 	topic         string
 	producers     []Producer
 	messageRouter func(*ProducerMessage, TopicMetadata) int
@@ -47,7 +47,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 	}
 
 	p := &producer{
-		topic: options.Topic,
+		topic:  options.Topic,
 		client: client,
 	}
 

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -24,6 +24,7 @@ import (
 )
 
 type producer struct {
+	client *client
 	topic         string
 	producers     []Producer
 	messageRouter func(*ProducerMessage, TopicMetadata) int
@@ -47,6 +48,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 
 	p := &producer{
 		topic: options.Topic,
+		client: client,
 	}
 
 	if options.MessageRouter == nil {
@@ -160,4 +162,5 @@ func (p *producer) Close() {
 	for _, pp := range p.producers {
 		pp.Close()
 	}
+	p.client.handlers.Del(p)
 }


### PR DESCRIPTION
Fixes: #153 

Makes producer & consumer removed from client handler when producer / consumer closed.