### PR TITLE
[ISSUE #152][consumer] add consumer timeout

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -135,6 +135,10 @@ type Consumer interface {
 	// This calls blocks until a message is available.
 	Receive(context.Context) (Message, error)
 
+	// Receive a single message.
+	// This calls blocks until a message is available or timeout.
+	ReceiveBlock(context.Context, time.Duration) (Message, error)
+
 	// Chan returns a channel to consume messages from
 	Chan() <-chan ConsumerMessage
 

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -240,6 +240,12 @@ func (c *consumer) Receive(ctx context.Context) (message Message, err error) {
 	}
 }
 
+func (c *consumer) ReceiveBlock(ctx context.Context, timeout time.Duration) (message Message, err error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return c.Receive(ctx)
+}
+
 // Messages
 func (c *consumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	pkgerrors "github.com/pkg/errors"
 
@@ -99,6 +100,12 @@ func (c *multiTopicConsumer) Receive(ctx context.Context) (message Message, err 
 			return nil, ctx.Err()
 		}
 	}
+}
+
+func (c *multiTopicConsumer) ReceiveBlock(ctx context.Context, timeout time.Duration) (message Message, err error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return c.Receive(ctx)
 }
 
 // Messages

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -146,6 +146,12 @@ func (c *regexConsumer) Receive(ctx context.Context) (message Message, err error
 	}
 }
 
+func (c *regexConsumer) ReceiveBlock(ctx context.Context, timeout time.Duration) (message Message, err error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return c.Receive(ctx)
+}
+
 // Chan
 func (c *regexConsumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh


### PR DESCRIPTION
### Motivation
- *support receiveMessage with timeout*

### Modifications
- *add `ReceiveBlock(context.Context, time.Duration) (Message, error)` for consumer interface* 
- *impl ReceiveBlock for consumer、regexConsumer、multiTopicConsumer*

