### PR TITLE
Remove maligned check from linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,4 +25,3 @@ linters:
     - varcheck
     - lll
     - prealloc
-    - maligned


### PR DESCRIPTION
We should error on the side of readability in
code base so we don't need the maligned lint flag.

