### PR TITLE
Fixed the connection pool logic

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -530,7 +530,7 @@ func (pc *partitionConsumer) grabConn() error {
 	}
 
 	res, err := pc.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, requestID,
-		pb.BaseCommand_SUBSCRIBE, cmdSubscribe, lr.ConnectingThroughProxy)
+		pb.BaseCommand_SUBSCRIBE, cmdSubscribe)
 
 	if err != nil {
 		pc.log.WithError(err).Error("Failed to create consumer")

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -119,9 +119,9 @@ type connection struct {
 	state             connectionState
 	connectionTimeout time.Duration
 
-	logicalAddr            *url.URL
-	physicalAddr           *url.URL
-	cnx                    net.Conn
+	logicalAddr  *url.URL
+	physicalAddr *url.URL
+	cnx          net.Conn
 
 	writeBufferLock sync.Mutex
 	writeBuffer     Buffer
@@ -154,18 +154,18 @@ type connection struct {
 func newConnection(logicalAddr *url.URL, physicalAddr *url.URL, tlsOptions *TLSOptions,
 	connectionTimeout time.Duration, auth auth.Provider) *connection {
 	cnx := &connection{
-		state:                  connectionInit,
-		connectionTimeout:      connectionTimeout,
-		logicalAddr:            logicalAddr,
-		physicalAddr:           physicalAddr,
-		writeBuffer:            NewBuffer(4096),
-		log:                    log.WithField("remote_addr", physicalAddr),
-		pendingReqs:            make(map[uint64]*request),
-		lastDataReceivedTime:   time.Now(),
-		pingTicker:             time.NewTicker(keepAliveInterval),
-		pingCheckTicker:        time.NewTicker(keepAliveInterval),
-		tlsOptions:             tlsOptions,
-		auth:                   auth,
+		state:                connectionInit,
+		connectionTimeout:    connectionTimeout,
+		logicalAddr:          logicalAddr,
+		physicalAddr:         physicalAddr,
+		writeBuffer:          NewBuffer(4096),
+		log:                  log.WithField("remote_addr", physicalAddr),
+		pendingReqs:          make(map[uint64]*request),
+		lastDataReceivedTime: time.Now(),
+		pingTicker:           time.NewTicker(keepAliveInterval),
+		pingCheckTicker:      time.NewTicker(keepAliveInterval),
+		tlsOptions:           tlsOptions,
+		auth:                 auth,
 
 		closeCh:            make(chan interface{}),
 		incomingRequestsCh: make(chan *request, 10),

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -32,7 +32,6 @@ import (
 type LookupResult struct {
 	LogicalAddr            *url.URL
 	PhysicalAddr           *url.URL
-	ConnectingThroughProxy bool
 }
 
 // LookupService is a interface of lookup service.
@@ -106,7 +105,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 				RequestId:     &id,
 				Topic:         &topic,
 				Authoritative: lr.Authoritative,
-			}, false)
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -126,7 +125,6 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			return &LookupResult{
 				LogicalAddr:            logicalAddress,
 				PhysicalAddr:           physicalAddress,
-				ConnectingThroughProxy: lr.GetProxyThroughServiceUrl(),
 			}, nil
 
 		case pb.CommandLookupTopicResponse_Failed:

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -30,8 +30,8 @@ import (
 
 // LookupResult encapsulates a struct for lookup a request, containing two parts: LogicalAddr, PhysicalAddr.
 type LookupResult struct {
-	LogicalAddr            *url.URL
-	PhysicalAddr           *url.URL
+	LogicalAddr  *url.URL
+	PhysicalAddr *url.URL
 }
 
 // LookupService is a interface of lookup service.
@@ -123,8 +123,8 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			}
 
 			return &LookupResult{
-				LogicalAddr:            logicalAddress,
-				PhysicalAddr:           physicalAddress,
+				LogicalAddr:  logicalAddress,
+				PhysicalAddr: physicalAddress,
 			}, nil
 
 		case pb.CommandLookupTopicResponse_Failed:

--- a/pulsar/internal/lookup_service_test.go
+++ b/pulsar/internal/lookup_service_test.go
@@ -70,7 +70,7 @@ func (c *mockedRPCClient) RequestToAnyBroker(requestID uint64, cmdType pb.BaseCo
 }
 
 func (c *mockedRPCClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
-	cmdType pb.BaseCommand_Type, message proto.Message, connectingThroughProxy bool) (*RPCResult, error) {
+	cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
 	assert.Equal(c.t, cmdType, pb.BaseCommand_LOOKUP)
 	expectedRequest := &c.expectedRequests[0]
 	c.expectedRequests = c.expectedRequests[1:]

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -45,7 +45,7 @@ type RPCClient interface {
 	RequestToAnyBroker(requestID uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
 
 	Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
-		cmdType pb.BaseCommand_Type, message proto.Message, connectingThroughProxy bool) (*RPCResult, error)
+		cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
 
 	RequestOnCnxNoWait(cnx Connection, cmdType pb.BaseCommand_Type, message proto.Message)
 
@@ -71,13 +71,13 @@ func NewRPCClient(serviceURL *url.URL, pool ConnectionPool, requestTimeout time.
 
 func (c *rpcClient) RequestToAnyBroker(requestID uint64, cmdType pb.BaseCommand_Type,
 	message proto.Message) (*RPCResult, error) {
-	return c.Request(c.serviceURL, c.serviceURL, requestID, cmdType, message, false)
+	return c.Request(c.serviceURL, c.serviceURL, requestID, cmdType, message)
 }
 
 func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
-	cmdType pb.BaseCommand_Type, message proto.Message, connectingThroughProxy bool) (*RPCResult, error) {
+	cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
 	// TODO: Add retry logic in case of connection issues
-	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr, connectingThroughProxy)
+	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -140,8 +140,7 @@ func (p *partitionProducer) grabCnx() error {
 	if len(p.options.Properties) > 0 {
 		cmdProducer.Metadata = toKeyValues(p.options.Properties)
 	}
-	res, err := p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_PRODUCER, cmdProducer,
-		lr.ConnectingThroughProxy)
+	res, err := p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_PRODUCER, cmdProducer)
 	if err != nil {
 		p.log.WithError(err).Error("Failed to create producer")
 		return err


### PR DESCRIPTION
### Motivation

The PR #146 has completely broken the connection pool logic. Closed/failed connection are not being evicted from the pool anymore, resulting in permanent failures with no recovery.

The change in #146 added an unnecessary flag throughout the code. We just need to check whether the physical address is the same as the logical address. The only part missing was to the pass the hostname to the proxy when needed.