### PR TITLE
Avoid double cnx close notification on graceful server side close

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -550,16 +550,19 @@ func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer)
 	consumerID := closeConsumer.GetConsumerId()
 	if consumer, ok := c.consumerHandler(consumerID); ok {
 		consumer.ConnectionClosed()
+		delete(c.listeners, consumerID)
 	} else {
 		c.log.WithField("consumerID", consumerID).Warnf("Consumer with ID not found while closing consumer")
 	}
 }
 
 func (c *connection) handleCloseProducer(closeProducer *pb.CommandCloseProducer) {
-	c.log.Infof("Broker notification of Closed consumer: %d", closeProducer.GetProducerId())
+	c.log.Infof("Broker notification of Closed producer: %d", closeProducer.GetProducerId())
 	producerID := closeProducer.GetProducerId()
+
 	if producer, ok := c.listeners[producerID]; ok {
 		producer.ConnectionClosed()
+		delete(c.listeners, producerID)
 	} else {
 		c.log.WithField("producerID", producerID).Warn("Producer with ID not found while closing producer")
 	}


### PR DESCRIPTION
### Motivation

We're processing the "connection closed" event twice when the broker sends a "producer closed" or "consumer closed" command. 

Basically after the producer reconnects, it will reconnect again on the same connection because it got the notification 2 times. One when the graceful close command and another when the connection is closed (eg: broker is shutting down).

This is not harmful, though it's logically wrong.