### PR TITLE
Fixed reading from connection

### DIFF
--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -50,7 +50,11 @@ func (r *connectionReader) readFromConnection() {
 		}
 
 		// Process
-		r.cnx.log.Debug("Got command! ", cmd, " with payload ", headersAndPayload)
+		var payloadLen uint32 = 0
+		if headersAndPayload != nil {
+			payloadLen = headersAndPayload.ReadableBytes()
+		}
+		r.cnx.log.Debug("Got command! ", cmd, " with payload size: ", payloadLen)
 		r.cnx.receivedCommand(cmd, headersAndPayload)
 	}
 }
@@ -77,7 +81,8 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 
 	// Next, we read the rest of the frame
 	if r.buffer.ReadableBytes() < frameSize {
-		if !r.readAtLeast(frameSize) {
+		remainingBytes := frameSize - r.buffer.ReadableBytes()
+		if !r.readAtLeast(remainingBytes) {
 			return nil, nil, errors.New("Short read when reading frame")
 		}
 	}


### PR DESCRIPTION

### Motivation

Fixes #147

There is bug in the `connection_reader` routine. If a frame is spanning multiple IP packets, it might get the case where we have read a partial frame into the current buffer and then we have to read the remainder of the frame from the socket. 

Instead of reading the remainder, we were trying to read the full frame size, which in turn will lead to the connection reader getting stuck. The connection eventually will fail the ping probe and will get closed though new connections incur in the same issue.