### PR TITLE
res channel causes connection.Run() to block When request timeout occuers

### DIFF
--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -90,7 +90,7 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 		*RPCResult
 		error
 	}
-	ch := make(chan Res, 1)
+	ch := make(chan Res, 10)
 
 	// TODO: in here, the error of callback always nil
 	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -90,7 +90,7 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 		*RPCResult
 		error
 	}
-	ch := make(chan Res)
+	ch := make(chan Res, 1)
 
 	// TODO: in here, the error of callback always nil
 	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {


### PR DESCRIPTION
Change the RPCResultChannel to a buffer channel to avoid blocking connection.Run() when request timeout occuers

https://github.com/apache/pulsar-client-go/issues/144
https://github.com/apache/pulsar-client-go/issues/151


Signed-off-by: dsmlily <dsmlily_2008@126.com>
