### PR TITLE
[Issue-148][pulsar-client-go] add seek by messageID

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -167,4 +167,11 @@ type Consumer interface {
 
 	// Close the consumer and stop the broker to push more messages
 	Close()
+
+	// Reset the subscription associated with this consumer to a specific message id.
+	// The message id can either be a specific message or represent the first or last messages in the topic.
+	//
+	// Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+	//       seek() on the individual partitions.
+	Seek(MessageID) error
 }

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -303,6 +303,10 @@ func (c *consumer) Close() {
 }
 
 func (c *consumer) Seek(msgID MessageID) error {
+	if len(c.consumers) > 1 {
+		return errors.New("for partition topic, seek command should perform on the individual partitions")
+	}
+
 	mid, ok := c.messageID(msgID)
 	if !ok {
 		return nil

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -162,12 +163,5 @@ func (c *multiTopicConsumer) Close() {
 }
 
 func (c *multiTopicConsumer) Seek(msgID MessageID) error {
-	var errs error
-	for topic, consumer := range c.consumers {
-		if err := consumer.Seek(msgID); err != nil {
-			msg := fmt.Sprintf("unable to apply seek, topic=%s msg=%s", topic, msgID.Serialize())
-			errs = pkgerrors.Wrap(err, msg)
-		}
-	}
-	return errs
+	return errors.New("seek command not allowed for multi topic consumer")
 }

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -160,3 +160,14 @@ func (c *multiTopicConsumer) Close() {
 		close(c.closeCh)
 	})
 }
+
+func (c *multiTopicConsumer) Seek(msgID MessageID) error {
+	var errs error
+	for topic, consumer := range c.consumers {
+		if err := consumer.Seek(msgID); err != nil {
+			msg := fmt.Sprintf("unable to apply seek, topic=%s msg=%s", topic, msgID.Serialize())
+			errs = pkgerrors.Wrap(err, msg)
+		}
+	}
+	return errs
+}

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -272,10 +272,8 @@ func (pc *partitionConsumer) internalSeek(seek *seekRequest) {
 	defer close(seek.doneCh)
 
 	if pc.state == consumerClosing || pc.state == consumerClosed {
-		err := fmt.Errorf("the consumer %s was already closed when seeking the subscription %s of the topic "+
-			"%s to the message %s", pc.name, pc.options.subscription, pc.topic, seek.msgID.Serialize())
-		pc.log.WithError(err).Error("Consumer was already closed")
-		seek.err = err
+		pc.log.Error("Consumer was already closed")
+		return
 	}
 
 	id := &pb.MessageIdData{}
@@ -291,6 +289,7 @@ func (pc *partitionConsumer) internalSeek(seek *seekRequest) {
 		RequestId:  proto.Uint64(requestID),
 		MessageId:  id,
 	}
+
 	_, err = pc.client.rpcClient.RequestOnCnx(pc.conn, requestID, pb.BaseCommand_SEEK, cmdSeek)
 	if err != nil {
 		pc.log.WithError(err).Error("Failed to reset to message id")

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -211,17 +212,7 @@ func (c *regexConsumer) Close() {
 }
 
 func (c *regexConsumer) Seek(msgID MessageID) error {
-	c.consumersLock.Lock()
-	defer c.consumersLock.Unlock()
-
-	var errs error
-	for topic, consumer := range c.consumers {
-		if err := consumer.Seek(msgID); err != nil {
-			msg := fmt.Sprintf("unable to apply seek, topic=%s msg=%s", topic, msgID.Serialize())
-			errs = pkgerrors.Wrap(err, msg)
-		}
-	}
-	return errs
+	return errors.New("seek command not allowed for regex consumer")
 }
 
 func (c *regexConsumer) closed() bool {

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -210,6 +210,20 @@ func (c *regexConsumer) Close() {
 	})
 }
 
+func (c *regexConsumer) Seek(msgID MessageID) error {
+	c.consumersLock.Lock()
+	defer c.consumersLock.Unlock()
+
+	var errs error
+	for topic, consumer := range c.consumers {
+		if err := consumer.Seek(msgID); err != nil {
+			msg := fmt.Sprintf("unable to apply seek, topic=%s msg=%s", topic, msgID.Serialize())
+			errs = pkgerrors.Wrap(err, msg)
+		}
+	}
+	return errs
+}
+
 func (c *regexConsumer) closed() bool {
 	select {
 	case <-c.closeCh:

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -417,6 +417,7 @@ func (c *connection) internalReceivedCommand(cmd *pb.BaseCommand, headersAndPayl
 
 	case pb.BaseCommand_CLOSE_PRODUCER:
 		c.handleCloseProducer(cmd.GetCloseProducer())
+
 	case pb.BaseCommand_CLOSE_CONSUMER:
 		c.handleCloseConsumer(cmd.GetCloseConsumer())
 


### PR DESCRIPTION
Master Issue: [#148](https://github.com/apache/pulsar-client-go/issues/148)

### Motivation


*Add seek by messageID*

### Modifications

*Add seek by messageID*
*Refactor some UT code*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for seek by messageID*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (*yes* / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
