### PR TITLE
[Issue:173] Fix logrus crash

### DIFF
--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -84,7 +84,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Got topic{%s} lookup response: %s",topic, res)
+	log.Debugf("Got topic{%s} lookup response: %s", topic, res)
 
 	for i := 0; i < lookupResultMaxRedirect; i++ {
 		lr := res.Response.LookupTopicResponse
@@ -131,7 +131,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			if lr.Error != nil {
 				errorMsg = lr.Error.String()
 			}
-			log.Warn("Failed to lookup topic: %s, error msg: %s", topic, errorMsg)
+			log.Warnf("Failed to lookup topic: %s, error msg: %s", topic, errorMsg)
 			return nil, fmt.Errorf("failed to lookup topic: %s", errorMsg)
 		}
 	}

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -84,7 +84,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Got topic{%s} lookup response: %s", topic, res)
+	log.Debugf("Got topic{%s} lookup response: %+v", topic, res)
 
 	for i := 0; i < lookupResultMaxRedirect; i++ {
 		lr := res.Response.LookupTopicResponse

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -81,13 +81,12 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 		Topic:         &topic,
 		Authoritative: proto.Bool(false),
 	})
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Got topic{%s} lookup response: %s",topic, res)
 
 	for i := 0; i < lookupResultMaxRedirect; i++ {
-		if err != nil {
-			return nil, err
-		}
-
-		log.WithField("topic", topic).Debugf("Got topic lookup response: %s", res)
 		lr := res.Response.LookupTopicResponse
 		switch *lr.Response {
 
@@ -97,8 +96,8 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 				return nil, err
 			}
 
-			log.WithField("topic", topic).Debugf("Follow redirect to broker. %v / %v - Use proxy: %v",
-				lr.BrokerServiceUrl, lr.BrokerServiceUrlTls, lr.ProxyThroughServiceUrl)
+			log.Debugf("Follow topic{%s} redirect to broker. %v / %v - Use proxy: %v",
+				topic, lr.BrokerServiceUrl, lr.BrokerServiceUrlTls, lr.ProxyThroughServiceUrl)
 
 			id := ls.rpcClient.NewRequestID()
 			res, err = ls.rpcClient.Request(logicalAddress, physicalAddr, id, pb.BaseCommand_LOOKUP, &pb.CommandLookupTopic{
@@ -114,8 +113,8 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			continue
 
 		case pb.CommandLookupTopicResponse_Connect:
-			log.WithField("topic", topic).Debugf("Successfully looked up topic on broker. %s / %s - Use proxy: %t",
-				lr.GetBrokerServiceUrl(), lr.GetBrokerServiceUrlTls(), lr.GetProxyThroughServiceUrl())
+			log.Debugf("Successfully looked up topic{%s} on broker. %s / %s - Use proxy: %t",
+				topic, lr.GetBrokerServiceUrl(), lr.GetBrokerServiceUrlTls(), lr.GetProxyThroughServiceUrl())
 
 			logicalAddress, physicalAddress, err := ls.getBrokerAddress(lr)
 			if err != nil {
@@ -132,7 +131,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			if lr.Error != nil {
 				errorMsg = lr.Error.String()
 			}
-			log.WithField("topic", topic).Warn("Failed to lookup topic", errorMsg)
+			log.Warn("Failed to lookup topic: %s, error msg: %s", topic, errorMsg)
 			return nil, fmt.Errorf("failed to lookup topic: %s", errorMsg)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #173

### Motivation

Fix `logrus` crash, the error as follows:

```
panic: reflect: call of reflect.Value.Type on zero Value
```