### PR TITLE
Fix nil pointer dereference of PartitionMetadataResponse

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -143,17 +143,20 @@ func (c *client) TopicPartitions(topic string) ([]string, error) {
 	}
 
 	r := res.Response.PartitionMetadataResponse
-	if r.Error != nil {
-		return nil, newError(ResultLookupError, r.GetError().String())
+	if r != nil {
+		if r.Error != nil {
+			return nil, newError(ResultLookupError, r.GetError().String())
+		}
+
+		if r.GetPartitions() > 0 {
+			partitions := make([]string, r.GetPartitions())
+			for i := 0; i < int(r.GetPartitions()); i++ {
+				partitions[i] = fmt.Sprintf("%s-partition-%d", topic, i)
+			}
+			return partitions, nil
+		}
 	}
 
-	if r.GetPartitions() > 0 {
-		partitions := make([]string, r.GetPartitions())
-		for i := 0; i < int(r.GetPartitions()); i++ {
-			partitions[i] = fmt.Sprintf("%s-partition-%d", topic, i)
-		}
-		return partitions, nil
-	}
 	// Non-partitioned topic
 	return []string{topicName.Name}, nil
 }


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes #181 

### Motivation

When the topic is non-partitioned topic, the  `res.Response.PartitionMetadataResponse` value is nil, so we can't get `Error` or `GetPartitions` of `PartitionMetadataResponse`, Otherwise it will cause:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x84f47a]
```

### Modifications

- Fix nil pointer dereference of PartitionMetadataResponse