### PR TITLE
Expose EventTime consistently as a non-pointer

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -503,7 +503,7 @@ func TestConsumerEventTime(t *testing.T) {
 	et := timeFromUnixTimestampMillis(uint64(5))
 	_, err = producer.Send(ctx, &ProducerMessage{
 		Payload:   []byte("test"),
-		EventTime: &et,
+		EventTime: et,
 	})
 	assert.Nil(t, err)
 

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -92,12 +92,11 @@ func (r *dlqRouter) run() {
 
 			msg := cm.Message.(*message)
 			msgID := msg.ID()
-			eventTime := msg.EventTime()
 			producer.SendAsync(context.Background(), &ProducerMessage{
 				Payload:             msg.Payload(),
 				Key:                 msg.Key(),
 				Properties:          msg.Properties(),
-				EventTime:           &eventTime,
+				EventTime:           msg.EventTime(),
 				ReplicationClusters: msg.replicationClusters,
 			}, func(MessageID, *ProducerMessage, error) {
 				r.log.WithField("msgID", msgID).Debug("Sent message to DLQ")

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -34,7 +34,7 @@ type ProducerMessage struct {
 	Properties map[string]string
 
 	// EventTime set the event time for a given message
-	EventTime *time.Time
+	EventTime time.Time
 
 	// ReplicationClusters override the replication clusters for this message.
 	ReplicationClusters []string
@@ -77,7 +77,7 @@ type Message interface {
 
 	// EventTime get the event time associated with this message. It is typically set by the applications via
 	// `ProducerMessage.EventTime`.
-	// If there isn't any event time associated with this event, it will be nil.
+	// If there isn't any event time associated with this event, it will be 0.
 	EventTime() time.Time
 
 	// Key get the key of the message, if any

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -34,6 +34,10 @@ type ProducerMessage struct {
 	Properties map[string]string
 
 	// EventTime set the event time for a given message
+	// By default, messages don't have an event time associated, while the publish
+	// time will be be always present.
+	// Set the event time to a non-zero timestamp to explicitly declare the time
+	// that the event "happened", as opposed to when the message is being published.
 	EventTime time.Time
 
 	// ReplicationClusters override the replication clusters for this message.
@@ -77,7 +81,7 @@ type Message interface {
 
 	// EventTime get the event time associated with this message. It is typically set by the applications via
 	// `ProducerMessage.EventTime`.
-	// If there isn't any event time associated with this event, it will be 0.
+	// If EventTime is 0, it means there isn't any event time associated with this message.
 	EventTime() time.Time
 
 	// Key get the key of the message, if any

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -249,8 +249,8 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		PayloadSize: proto.Int(len(msg.Payload)),
 	}
 
-	if msg.EventTime != nil {
-		smm.EventTime = proto.Uint64(internal.TimestampMillis(*msg.EventTime))
+	if msg.EventTime.UnixNano() != 0 {
+		smm.EventTime = proto.Uint64(internal.TimestampMillis(msg.EventTime))
 	}
 
 	if msg.Key != "" {

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -244,7 +244,7 @@ func TestEventTime(t *testing.T) {
 	eventTime := timeFromUnixTimestampMillis(uint64(1565161612))
 	ID, err := producer.Send(context.Background(), &ProducerMessage{
 		Payload:   []byte(fmt.Sprintf("test-event-time")),
-		EventTime: &eventTime,
+		EventTime: eventTime,
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, ID)


### PR DESCRIPTION
### Motivation

When producing a message, we are currently accepting event time as a pointer:

```go
type ProducerMessage struct {
 /// .... 
    // EventTime set the event time for a given message
    EventTime *time.Time
}
```

though on a receiving message, we're exposing as a value: 

```go
type Message interface {
	/// ...
	// PublishTime get the publish time of this message. The publish time is the timestamp that a client
	// publish the message.
	PublishTime() time.Time

	// EventTime get the event time associated with this message. It is typically set by the applications via
	// `ProducerMessage.EventTime`.
	// If there isn't any event time associated with this event, it will be nil.
	EventTime() time.Time
```

We should unify these 2 and also with the same approach used for `PublishTime`.