### PR TITLE
[Issue 190] RequestTimeout bound client connection backoff

### DIFF
--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -111,12 +111,13 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 
 func (c *rpcClient) getConn(logicalAddr *url.URL, physicalAddr *url.URL) (Connection, error) {
 	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr)
-	backoff := new(Backoff)
+	backoff := Backoff{1 * time.Second}
+	startTime := time.Now()
 	var retryTime time.Duration
 	if err != nil {
-		for retryTime < c.requestTimeout {
+		for time.Now().Sub(startTime) < c.requestTimeout {
 			retryTime = backoff.Next()
-			c.log.Debugf("Reconnecting to broker in {%v}", retryTime)
+			c.log.Debugf("Reconnecting to broker in {%v} with timeout in {%v}", retryTime, c.requestTimeout)
 			time.Sleep(retryTime)
 			cnx, err = c.pool.GetConnection(logicalAddr, physicalAddr)
 			if err == nil {

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -115,7 +115,7 @@ func (c *rpcClient) getConn(logicalAddr *url.URL, physicalAddr *url.URL) (Connec
 	startTime := time.Now()
 	var retryTime time.Duration
 	if err != nil {
-		for time.Now().Sub(startTime) < c.requestTimeout {
+		for time.Since(startTime) < c.requestTimeout {
 			retryTime = backoff.Next()
 			c.log.Debugf("Reconnecting to broker in {%v} with timeout in {%v}", retryTime, c.requestTimeout)
 			time.Sleep(retryTime)


### PR DESCRIPTION
Fix issue #190 
https://github.com/apache/pulsar-client-go/issues/190

### Motivation
Make sure the client connection retry is bound to OperationTimeout, instead of the current implementation is the next retry backoff time is no more than OperationTimeout, thus we can reduce the number retries.

### Modifications

The total time spent on retry won't be over OperationTimeout.

The first retry will be one second later instead of the current immediate retry with only very small increment at 100ms in the second retry. The new implementation basically increase the gaps to 1, 2, 4, 8 ... seconds

### Verifying this change

Manual test verification

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no )
  - The public API: ( no )
  - The schema: ( no )
  - The default values of configurations: ( no )
  - The wire protocol: ( no )

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
