### PR TITLE
[Issue: 201] Expose GetDeliveryCount method from Message interface

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1143,3 +1143,67 @@ func TestDLQMultiTopics(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, msg)
 }
+
+func TestGetDeliveryCount(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	ctx := context.Background()
+
+	// create consumer
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:               topic,
+		SubscriptionName:    "my-sub",
+		NackRedeliveryDelay: 1 * time.Second,
+		Type:                Shared,
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: topic,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 10 messages
+	for i := 0; i < 10; i++ {
+		if _, err := producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		}); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// receive 10 messages and only ack half-of-them
+	for i := 0; i < 10; i++ {
+		msg, _ := consumer.Receive(context.Background())
+
+		if i%2 == 0 {
+			// ack message
+			consumer.Ack(msg)
+		} else {
+			consumer.Nack(msg)
+		}
+	}
+
+	// Receive the unacked messages other 2 times, failing at processing
+	for i := 0; i < 2; i++ {
+		var msg Message
+		for i := 0; i < 5; i++ {
+			msg, err = consumer.Receive(context.Background())
+			assert.Nil(t, err)
+			consumer.Nack(msg)
+		}
+		assert.Equal(t, uint32(i+1), msg.GetDeliveryCount())
+	}
+
+	msg, err := consumer.Receive(context.Background())
+	assert.Equal(t, uint32(3), msg.GetDeliveryCount())
+}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1201,10 +1201,10 @@ func TestGetDeliveryCount(t *testing.T) {
 			assert.Nil(t, err)
 			consumer.Nack(msg)
 		}
-		assert.Equal(t, uint32(i+1), msg.GetDeliveryCount())
+		assert.Equal(t, uint32(i+1), msg.RedeliveryCount())
 	}
 
 	msg, err := consumer.Receive(context.Background())
 	assert.Nil(t, err)
-	assert.Equal(t, uint32(3), msg.GetDeliveryCount())
+	assert.Equal(t, uint32(3), msg.RedeliveryCount())
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1205,5 +1205,6 @@ func TestGetDeliveryCount(t *testing.T) {
 	}
 
 	msg, err := consumer.Receive(context.Background())
+	assert.Nil(t, err)
 	assert.Equal(t, uint32(3), msg.GetDeliveryCount())
 }

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -76,7 +76,8 @@ func (r *dlqRouter) shouldSendToDlq(cm *ConsumerMessage) bool {
 	//  * when we receive the message and redeliveryCount == 10, it means
 	//    that the application has already got (and Nack())  the message 10
 	//    times, so this time we should just go to DLQ.
-	return cm.Message.(*message).redeliveryCount >= r.policy.MaxDeliveries
+
+	return msg.redeliveryCount >= r.policy.MaxDeliveries
 }
 
 func (r *dlqRouter) Chan() chan ConsumerMessage {

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -176,6 +176,10 @@ func (msg *message) Key() string {
 	return msg.key
 }
 
+func (msg *message) GetDeliveryCount() uint32 {
+	return msg.redeliveryCount
+}
+
 func newAckTracker(size int) *ackTracker {
 	var batchIDs *big.Int
 	if size <= 64 {

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -176,7 +176,7 @@ func (msg *message) Key() string {
 	return msg.key
 }
 
-func (msg *message) GetDeliveryCount() uint32 {
+func (msg *message) RedeliveryCount() uint32 {
 	return msg.redeliveryCount
 }
 

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -86,6 +86,13 @@ type Message interface {
 
 	// Key get the key of the message, if any
 	Key() string
+
+    // Get message redelivery count, redelivery count maintain in pulsar broker. When client nack acknowledge messages,
+    // broker will dispatch message again with message redelivery count in CommandMessage defined.
+    //
+    // Message redelivery increases monotonically in a broker, when topic switch ownership to a another broker
+    // redelivery count will be recalculated.
+	GetDeliveryCount() uint32
 }
 
 // MessageID identifier for a particular message

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -87,11 +87,11 @@ type Message interface {
 	// Key get the key of the message, if any
 	Key() string
 
-    // Get message redelivery count, redelivery count maintain in pulsar broker. When client nack acknowledge messages,
-    // broker will dispatch message again with message redelivery count in CommandMessage defined.
-    //
-    // Message redelivery increases monotonically in a broker, when topic switch ownership to a another broker
-    // redelivery count will be recalculated.
+	// Get message redelivery count, redelivery count maintain in pulsar broker. When client nack acknowledge messages,
+	// broker will dispatch message again with message redelivery count in CommandMessage defined.
+	//
+	// Message redelivery increases monotonically in a broker, when topic switch ownership to a another broker
+	// redelivery count will be recalculated.
 	GetDeliveryCount() uint32
 }
 

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -92,7 +92,7 @@ type Message interface {
 	//
 	// Message redelivery increases monotonically in a broker, when topic switch ownership to a another broker
 	// redelivery count will be recalculated.
-	GetDeliveryCount() uint32
+	RedeliveryCount() uint32
 }
 
 // MessageID identifier for a particular message


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Master Issue: #201 

### Modifications

- Expose `GetDeliveryCount()` method from `Message` interface
- Add test case to verfiy