### PR TITLE
Fix Go Producer produce to only one partition

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -327,7 +327,7 @@ func TestPartitionTopicsConsumerPubSub(t *testing.T) {
 	topic := "persistent://public/default/testGetPartitions"
 	testURL := adminURL + "/" + "admin/v2/persistent/public/default/testGetPartitions/partitions"
 
-	makeHTTPCall(t, http.MethodPut, testURL, "64")
+	makeHTTPCall(t, testURL, "64")
 
 	// create producer
 	producer, err := client.CreateProducer(ProducerOptions{
@@ -411,7 +411,7 @@ func TestConsumerShared(t *testing.T) {
 	topic := "persistent://public/default/testMultiPartitionConsumerShared"
 	testURL := adminURL + "/" + "admin/v2/persistent/public/default/testMultiPartitionConsumerShared/partitions"
 
-	makeHTTPCall(t, http.MethodPut, testURL, "3")
+	makeHTTPCall(t, testURL, "3")
 
 	sub := "sub-shared-1"
 	consumer1, err := client.Subscribe(ConsumerOptions{

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"testing"
 	"time"
 

--- a/pulsar/internal/default_router.go
+++ b/pulsar/internal/default_router.go
@@ -68,13 +68,13 @@ func NewDefaultRouter(clock Clock, hashFunc func(string) uint32,
 		// of batching of the messages.
 		//
 		//currentMs / maxBatchingDelayMs + startPtnIdx
-		if disableBatching == false && maxBatchingDelay.Nanoseconds() > 0 {
+		if !disableBatching && maxBatchingDelay.Nanoseconds() > 0 {
 			n := uint32(state.clock()/uint64(maxBatchingDelay.Nanoseconds())) + state.shiftIdx
 			return int(n % numPartitions)
-		} else {
-			p := int(state.msgCounter % numPartitions)
-			atomic.AddUint32(&state.msgCounter,1)
-			return p
 		}
+
+		p := int(state.msgCounter % numPartitions)
+		atomic.AddUint32(&state.msgCounter, 1)
+		return p
 	}
 }

--- a/pulsar/internal/default_router_test.go
+++ b/pulsar/internal/default_router_test.go
@@ -71,7 +71,7 @@ func TestDefaultRouter(t *testing.T) {
 
 	// should round robin partitions
 	for i := 0; i < 200; i++ {
-		assert.Equal(t, router("", 100), i % 100)
+		assert.Equal(t, router("", 100), i%100)
 	}
 
 	// test batching is disabled
@@ -81,7 +81,7 @@ func TestDefaultRouter(t *testing.T) {
 
 	// should round robin partitions
 	for i := 0; i < 200; i++ {
-		assert.Equal(t, router("", 100), i % 100)
+		assert.Equal(t, router("", 100), i%100)
 	}
 }
 

--- a/pulsar/internal/default_router_test.go
+++ b/pulsar/internal/default_router_test.go
@@ -30,7 +30,7 @@ func TestDefaultRouter(t *testing.T) {
 
 	router := NewDefaultRouter(func() uint64 {
 		return currentClock
-	}, JavaStringHash, 10*time.Nanosecond)
+	}, JavaStringHash, 10*time.Nanosecond, false)
 
 	// partition index should not change with time
 	p1 := router("my-key", 100)
@@ -63,11 +63,31 @@ func TestDefaultRouter(t *testing.T) {
 	currentClock = 112
 	pr6 := router("", 100)
 	assert.Equal(t, pr5, pr6)
+
+	// test batching delay is 0
+	router = NewDefaultRouter(func() uint64 {
+		return currentClock
+	}, JavaStringHash, 0, true)
+
+	// should round robin partitions
+	for i := 0; i < 200; i++ {
+		assert.Equal(t, router("", 100), i % 100)
+	}
+
+	// test batching is disabled
+	router = NewDefaultRouter(func() uint64 {
+		return currentClock
+	}, JavaStringHash, 10*time.Nanosecond, true)
+
+	// should round robin partitions
+	for i := 0; i < 200; i++ {
+		assert.Equal(t, router("", 100), i % 100)
+	}
 }
 
 func TestDefaultRouterNoPartitions(t *testing.T) {
 
-	router := NewDefaultRouter(NewSystemClock(), JavaStringHash, 10*time.Nanosecond)
+	router := NewDefaultRouter(NewSystemClock(), JavaStringHash, 10*time.Nanosecond, false)
 
 	// partition index should not change with time
 	p1 := router("", 1)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -64,8 +64,6 @@ type partitionProducer struct {
 	partitionIdx int
 }
 
-const defaultBatchingMaxPublishDelay = 10 * time.Millisecond
-
 func newPartitionProducer(client *client, topic string, options *ProducerOptions, partitionIdx int) (
 	*partitionProducer, error) {
 	var batchingMaxPublishDelay time.Duration

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -356,7 +356,7 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 
 	// call admin api to make it partitioned
 	url := adminURL + "/" + "admin/v2/persistent/" + topicName + "/partitions"
-	makeHTTPCall(t, http.MethodPut, url, "5")
+	makeHTTPCall(t, url, "5")
 
 	numberOfPartitions := 5
 	numOfMessages := 10
@@ -434,7 +434,7 @@ func TestRoundRobinRouterPartitionedProducer(t *testing.T) {
 
 	// call admin api to make it partitioned
 	url := adminURL + "/" + "admin/v2/persistent/" + topicName + "/partitions"
-	makeHTTPCall(t, http.MethodPut, url, strconv.Itoa(numberOfPartitions))
+	makeHTTPCall(t, url, strconv.Itoa(numberOfPartitions))
 
 	numOfMessages := 10
 	ctx := context.Background()

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -20,7 +20,6 @@ package pulsar
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
 	"sync"
 	"testing"

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -457,8 +457,8 @@ func TestRoundRobinRouterPartitionedProducer(t *testing.T) {
 
 	// create producer
 	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   topicName,
-		DisableBatching:         true,
+		Topic:           topicName,
+		DisableBatching: true,
 	})
 	assert.Nil(t, err)
 	defer producer.Close()
@@ -489,7 +489,7 @@ func TestRoundRobinRouterPartitionedProducer(t *testing.T) {
 	assert.Equal(t, msgCount, numOfMessages)
 	assert.Equal(t, numberOfPartitions, len(msgPartitionMap))
 	for _, count := range msgPartitionMap {
-		assert.Equal(t, count, numOfMessages / numberOfPartitions)
+		assert.Equal(t, count, numOfMessages/numberOfPartitions)
 	}
 }
 

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -351,10 +352,10 @@ func TestFlushInProducer(t *testing.T) {
 }
 
 func TestFlushInPartitionedProducer(t *testing.T) {
-	topicName := "persistent://public/default/partition-testFlushInPartitionedProducer"
+	topicName := "public/default/partition-testFlushInPartitionedProducer"
 
 	// call admin api to make it partitioned
-	url := adminURL + "/" + "admin/v2/" + topicName + "/partitions"
+	url := adminURL + "/" + "admin/v2/persistent/" + topicName + "/partitions"
 	makeHTTPCall(t, http.MethodPut, url, "5")
 
 	numberOfPartitions := 5
@@ -425,6 +426,71 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 		msgCount++
 	}
 	assert.Equal(t, msgCount, numOfMessages/2)
+}
+
+func TestRoundRobinRouterPartitionedProducer(t *testing.T) {
+	topicName := "public/default/partition-testRoundRobinRouterPartitionedProducer"
+	numberOfPartitions := 5
+
+	// call admin api to make it partitioned
+	url := adminURL + "/" + "admin/v2/persistent/" + topicName + "/partitions"
+	makeHTTPCall(t, http.MethodPut, url, strconv.Itoa(numberOfPartitions))
+
+	numOfMessages := 10
+	ctx := context.Background()
+
+	// creat client connection
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	// create consumer
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            topicName,
+		SubscriptionName: "my-sub",
+		Type:             Exclusive,
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:                   topicName,
+		DisableBatching:         true,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 5 messages
+	prefix := "msg-"
+
+	for i := 0; i < numOfMessages; i++ {
+		messageContent := prefix + fmt.Sprintf("%d", i)
+		_, err = producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(messageContent),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Receive all messages
+	msgCount := 0
+	msgPartitionMap := make(map[string]int)
+	for i := 0; i < numOfMessages; i++ {
+		msg, err := consumer.Receive(ctx)
+		fmt.Printf("Received message msgId: %#v topic: %s-- content: '%s'\n",
+			msg.ID(), msg.Topic(), string(msg.Payload()))
+		assert.Nil(t, err)
+		consumer.Ack(msg)
+		msgCount++
+		msgPartitionMap[msg.Topic()]++
+	}
+	assert.Equal(t, msgCount, numOfMessages)
+	assert.Equal(t, numberOfPartitions, len(msgPartitionMap))
+	for _, count := range msgPartitionMap {
+		assert.Equal(t, count, numOfMessages / numberOfPartitions)
+	}
 }
 
 func TestMessageRouter(t *testing.T) {

--- a/pulsar/test_helper.go
+++ b/pulsar/test_helper.go
@@ -118,10 +118,10 @@ func httpDo(method string, requestPath string, in interface{}, out interface{}) 
 	return nil
 }
 
-func makeHTTPCall(t *testing.T, method string, url string, body string) {
+func makeHTTPCall(t *testing.T, url string, body string) {
 	client := http.Client{}
 
-	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Motivation

Currently, the Go producer will only produce to a single partition if BatchingMaxPublishDelay is not specified.  BatchingMaxPublishDelay will be zero and the logic in the DefaultRouter will always select partition 0.
