### PR TITLE
[Issue 211] Fix usage of MessageChannel in Reader

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -24,7 +24,7 @@ import (
 
 // Pair of a Consumer and Message
 type ConsumerMessage struct {
-	Consumer
+	Consumer interface{} // can be of type Consumer or Reader
 	Message
 }
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -82,7 +82,7 @@ type partitionConsumer struct {
 	client *client
 
 	// this is needed for sending ConsumerMessage on the messageCh
-	parentConsumer Consumer
+	parentConsumer interface{}
 	state          consumerState
 	options        *partitionConsumerOpts
 
@@ -116,7 +116,7 @@ type partitionConsumer struct {
 	log *log.Entry
 }
 
-func newPartitionConsumer(parent Consumer, client *client, options *partitionConsumerOpts,
+func newPartitionConsumer(parent interface{}, client *client, options *partitionConsumerOpts,
 	messageCh chan ConsumerMessage, dlq *dlqRouter) (*partitionConsumer, error) {
 	pc := &partitionConsumer{
 		state:          consumerInit,

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -101,7 +101,11 @@ func (r *dlqRouter) run() {
 				ReplicationClusters: msg.replicationClusters,
 			}, func(MessageID, *ProducerMessage, error) {
 				r.log.WithField("msgID", msgID).Debug("Sent message to DLQ")
-				cm.Consumer.AckID(msgID)
+
+				consumer, ok := cm.Consumer.(Consumer)
+				if ok {
+					consumer.AckID(msgID)
+				}
 			})
 
 		case <-r.closeCh:

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -19,12 +19,6 @@ package pulsar
 
 import "context"
 
-// ReaderMessage package Reader and Message as a struct to use
-type ReaderMessage struct {
-	Reader
-	Message
-}
-
 // ReaderOptions abstraction Reader options to use.
 type ReaderOptions struct {
 	// Topic specify the topic this consumer will subscribe on.
@@ -53,7 +47,7 @@ type ReaderOptions struct {
 
 	// MessageChannel sets a `MessageChannel` for the consumer
 	// When a message is received, it will be pushed to the channel for consumption
-	MessageChannel chan ReaderMessage
+	MessageChannel chan ConsumerMessage
 
 	// ReceiverQueueSize sets the size of the consumer receive queue.
 	// The consumer receive queue controls how many messages can be accumulated by the Reader before the

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -70,8 +70,14 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 		replicateSubscriptionState: false,
 	}
 
+	// did the user pass in a message channel?
+	messageCh := options.MessageChannel
+	if options.MessageChannel == nil {
+		messageCh = make(chan ConsumerMessage)
+	}
+
 	reader := &reader{
-		messageCh: make(chan ConsumerMessage),
+		messageCh: messageCh,
 		log:       log.WithField("topic", options.Topic),
 	}
 
@@ -80,7 +86,7 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	pc, err := newPartitionConsumer(nil, client, consumerOptions, reader.messageCh, dlq)
+	pc, err := newPartitionConsumer(reader, client, consumerOptions, reader.messageCh, dlq)
 
 	if err != nil {
 		close(reader.messageCh)


### PR DESCRIPTION
Fixes #211

### Motivation

- `ReaderOptions.MessageChannel` was never used
- `ReaderMessage.Reader` was never set

### Modifications

- removed `ReaderMessage` as it was not really used
- `ConsumerMessage.Consumer` type was changed to `interface{}` and can be set to `Consumer` or `Reader` now 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

CI is failing due to an unrelated race condition.

This change added tests and can be verified as follows:

- new unit tests can be added if the changes are accepted.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (**yes**)
  - The schema: (don't know)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no, actually implements a documented feature)
  - If yes, how is the feature documented? (GoDocs)
