### PR TITLE
Fix Consumer Seek not returning a potential error

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -265,7 +265,7 @@ func (c *consumer) Ack(msg Message) {
 
 // Ack the consumption of a single message, identified by its MessageID
 func (c *consumer) AckID(msgID MessageID) {
-	mid, err := newMessageIDFromInterface(msgID, len(c.consumers))
+	mid, err := messageIDFromInterface(msgID, len(c.consumers))
 	if err != nil {
 		c.log.Warnf(err.Error())
 		return
@@ -284,7 +284,7 @@ func (c *consumer) Nack(msg Message) {
 }
 
 func (c *consumer) NackID(msgID MessageID) {
-	mid, err := newMessageIDFromInterface(msgID, len(c.consumers))
+	mid, err := messageIDFromInterface(msgID, len(c.consumers))
 	if err != nil {
 		c.log.Warnf(err.Error())
 		return
@@ -320,7 +320,7 @@ func (c *consumer) Seek(msgID MessageID) error {
 		return errors.New("for partition topic, seek command should perform on the individual partitions")
 	}
 
-	mid, err := newMessageIDFromInterface(msgID, len(c.consumers))
+	mid, err := messageIDFromInterface(msgID, len(c.consumers))
 	if err != nil {
 		return err
 	}

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -18,6 +18,8 @@
 package pulsar
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"sync"
@@ -116,6 +118,24 @@ func newMessageID(ledgerID int64, entryID int64, batchIdx int, partitionIdx int)
 		batchIdx:     batchIdx,
 		partitionIdx: partitionIdx,
 	}
+}
+
+// creates a new messageID object from the given MessageID, consumers is the amount of
+// consumers, 1+ for Consumer, 1 for Reader.
+func newMessageIDFromInterface(msgID MessageID, consumers int) (*messageID, error) {
+	mid, ok := msgID.(*messageID)
+	if !ok {
+		return nil, errors.New("invalid message id type")
+	}
+
+	partition := mid.partitionIdx
+	// did we receive a valid partition index?
+	if partition < 0 || partition >= consumers {
+		return nil, fmt.Errorf("invalid partition index %d expected a partition between [0-%d]",
+			partition, consumers)
+	}
+
+	return mid, nil
 }
 
 func newTrackingMessageID(ledgerID int64, entryID int64, batchIdx int, partitionIdx int,

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -120,9 +120,9 @@ func newMessageID(ledgerID int64, entryID int64, batchIdx int, partitionIdx int)
 	}
 }
 
-// creates a new messageID object from the given MessageID, consumers is the amount of
-// consumers, 1+ for Consumer, 1 for Reader.
-func newMessageIDFromInterface(msgID MessageID, consumers int) (*messageID, error) {
+// casts the given messageID interface to the internal struct.
+// consumers is the amount of consumers, 1+ for Consumer, 1 for Reader.
+func messageIDFromInterface(msgID MessageID, consumers int) (*messageID, error) {
 	mid, ok := msgID.(*messageID)
 	if !ok {
 		return nil, errors.New("invalid message id type")


### PR DESCRIPTION
### Motivation

Review of Consumer Seek() did reveal a potential error that is not returned as such.

### Modifications

- refactored `messageID()` to not use a logger but as a helper function that returns an error. It can later be used by a currently missing `Reader` `Seek()` implementation.
- return a potential error from `Consumer.Seek()`
- log the error in `AckID()` and `NackID()` - changing the interface to return an error for those function should be a better approach

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
