### PR TITLE
Fixed tls connection issue

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -95,7 +95,7 @@ func newClient(options ClientOptions) (Client, error) {
 		cnxPool: internal.NewConnectionPool(tlsConfig, authProvider, connectionTimeout),
 	}
 	c.rpcClient = internal.NewRPCClient(url, c.cnxPool, operationTimeout)
-	c.lookupService = internal.NewLookupService(c.rpcClient, url)
+	c.lookupService = internal.NewLookupService(c.rpcClient, url, tlsConfig != nil)
 	c.handlers = internal.NewClientHandlers()
 	return c, nil
 }

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -44,19 +44,26 @@ type LookupService interface {
 type lookupService struct {
 	rpcClient  RPCClient
 	serviceURL *url.URL
+	tlsEnabled bool
 }
 
 // NewLookupService init a lookup service struct and return an object of LookupService.
-func NewLookupService(rpcClient RPCClient, serviceURL *url.URL) LookupService {
+func NewLookupService(rpcClient RPCClient, serviceURL *url.URL, tlsEnabled bool) LookupService {
 	return &lookupService{
 		rpcClient:  rpcClient,
 		serviceURL: serviceURL,
+		tlsEnabled: tlsEnabled,
 	}
 }
 
 func (ls *lookupService) getBrokerAddress(lr *pb.CommandLookupTopicResponse) (logicalAddress *url.URL,
 	physicalAddress *url.URL, err error) {
-	logicalAddress, err = url.ParseRequestURI(lr.GetBrokerServiceUrl())
+	if ls.tlsEnabled {
+		logicalAddress, err = url.ParseRequestURI(lr.GetBrokerServiceUrlTls())
+	} else {
+		logicalAddress, err = url.ParseRequestURI(lr.GetBrokerServiceUrl())
+	}
+
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Motivation

I tried a tls connection but it failed.

Log:
```
$ go run producerForTls.go
pulsar.NewClient start.pulsar.NewClient end.INFO[0000] Connecting to broker                          remote_addr="pulsar+ssl://<hostname>:6651"
INFO[0000] TCP connection established                    local_addr="<ip>:<port>" remote_addr="pulsar+ssl://<hostname>:6651"
INFO[0000] Connection is ready                           local_addr="<ip>:<port>" remote_addr="pulsar+ssl://<hostname>:6651"
INFO[0000] Connecting to broker                          remote_addr="pulsar://<hostname>:6650"
WARN[0000] Failed to connect to broker.                  error=EOF remote_addr="pulsar://<hostname>:6650"
INFO[0000] Connection closed                             remote_addr="pulsar://<hostname>:6650"
INFO[0002] Connecting to broker                          remote_addr="pulsar://<hostname>:6650"
WARN[0002] Failed to connect to broker.                  error=EOF remote_addr="pulsar://<hostname>:6650"
INFO[0002] Connection closed                             remote_addr="pulsar://<hostname>:6650"
INFO[0006] Connecting to broker                          remote_addr="pulsar://<hostname>:6650"
WARN[0006] Failed to connect to broker.                  error=EOF remote_addr="pulsar://<hostname>:6650"
INFO[0006] Connection closed                             remote_addr="pulsar://<hostname>:6650"
```

After Lookup, the url seems to use `BrokerServiceUrl`.
If use tls connection, I think url will use `BrokerServiceUrlTls`.

### Modifications

* Fixed Lookup service.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API: (no)
- The schema: (no)
- The default values of configurations: (no)
- The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
