### PR TITLE
Fixed race condition in producer Flush() operation

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -304,6 +304,7 @@ type pendingItem struct {
 	batchData    []byte
 	sequenceID   uint64
 	sendRequests []interface{}
+	completed    bool
 }
 
 func (p *partitionProducer) internalFlushCurrentBatch() {
@@ -329,6 +330,19 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		return
 	}
 
+	// lock the pending request while adding requests
+	// since the ReceivedSendReceipt func iterates over this list
+	pi.Lock()
+	defer pi.Unlock()
+
+	if pi.completed {
+		// The last item in the queue has been completed while we were
+		// looking at it. It's safe at this point to assume that every
+		// message enqueued before Flush() was called are now persisted
+		fr.waitGroup.Done()
+		return
+	}
+
 	sendReq := &sendRequest{
 		msg: nil,
 		callback: func(id MessageID, message *ProducerMessage, e error) {
@@ -337,11 +351,7 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		},
 	}
 
-	// lock the pending request while adding requests
-	// since the ReceivedSendReceipt func iterates over this list
-	pi.Lock()
 	pi.sendRequests = append(pi.sendRequests, sendReq)
-	pi.Unlock()
 }
 
 func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (MessageID, error) {
@@ -428,6 +438,9 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 			sr.callback(msgID, sr.msg, nil)
 		}
 	}
+
+	// Mark this pending item as done
+	pi.completed = true
 }
 
 func (p *partitionProducer) internalClose(req *closeProducer) {


### PR DESCRIPTION
### Motivation

There is a race condition that make `Producer.Flush()` to get stuck. 

The flush operation works by attaching itself as a callback on the last item in the pending messages queue. Once the (current) last message in the queue is published, then flush is completed. 

The problem is that we check the last item in queue and then we grab a mutex and add the flush request. If the the pending item is completed before we grab the mutex, then the flush callback will never be called. 