### PR TITLE
Removed unnecessary flush in sync Send() operation

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -357,12 +357,6 @@ func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (Mes
 		wg.Done()
 	}, true)
 
-	// When sending synchronously we flush immediately to avoid
-	// the increased latency and reduced throughput of batching
-	if err = p.Flush(); err != nil {
-		return nil, err
-	}
-
 	wg.Wait()
 	return msgID, err
 }


### PR DESCRIPTION
### Motivation

In `Producer.Send()` we're unnecessarily forcing a flush operation. This piece of code was a remnant from an early prototype and should have been removed when the proper handling of batching was introduced.

In this case, since we're calling `internalSendAsync()` with `flushImmediately=true` the message will be immediately sent.