### PR TITLE
allow empty payload for nonbatch message

### DIFF
--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -114,7 +114,7 @@ func (r *MessageReader) ReadMessageMetadata() (*pb.MessageMetadata, error) {
 }
 
 func (r *MessageReader) ReadMessage() (*pb.SingleMessageMetadata, []byte, error) {
-	if r.buffer.ReadableBytes() == 0 {
+	if r.buffer.ReadableBytes() == 0 && r.buffer.Capacity() > 0 {
 		return nil, nil, ErrEOM
 	}
 	if !r.batched {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -527,7 +527,7 @@ func (c *connection) handleMessage(response *pb.CommandMessage, payload Buffer) 
 	if consumer, ok := c.consumerHandler(consumerID); ok {
 		err := consumer.MessageReceived(response, payload)
 		if err != nil {
-			c.log.WithField("consumerID", consumerID).Error("handle message err: ", response.MessageId)
+			c.log.WithField("consumerID", consumerID).WithError(err).Error("handle message Id: ", response.MessageId)
 		}
 	} else {
 		c.log.WithField("consumerID", consumerID).Warn("Got unexpected message: ", response.MessageId)


### PR DESCRIPTION

### Motivation
This PR will fix a problem preventing consumer receiving empty payload with properties in non-batch mode; and empty payload without key and properties in batch mode. Error messages are prompted currently as such:
```
ERRO[0004] Discarding corrupted message                  msgID="ledgerId:92658 entryId:1458 partition:-1 " name=hwmiw subscription=consumer topic="<pulsar topic>" validationError=BatchDeSerializeError
ERRO[0004] handle message Id: ledgerId:92658 entryId:1458 partition:-1   consumerID=1 local_addr="192.168.1.111:33444" remote_addr="<pulsar URL>"
```
In addition, error will be printed out from MessageReceived instead of masking the real error reported.

### Modifications
The buffer capacity is validated instead of solely replying on ReadableBytes to determine EOF is reached.

### Verifying this change
Tested against batch and nonbatch mode to consume empty payload with and without properties.

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: ( no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

