### PR TITLE
Implement TLS VerifyPeerCertificate callback to skip hostname verfication

### DIFF
--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -67,6 +67,24 @@ func TestTLSInsecureConnection(t *testing.T) {
 	client.Close()
 }
 
+func TestTLSInsecureConnectionWithCerts(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL:                        serviceURLTLS,
+		TLSAllowInsecureConnection: true,
+		TLSTrustCertsFilePath:      caCertsPath,
+	})
+	assert.NoError(t, err)
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: newTopicName(),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, producer)
+
+	client.Close()
+}
+
 func TestTLSConnection(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL:                   serviceURLTLS,

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -716,7 +716,7 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 	} else if !tlsConfig.InsecureSkipVerify {
 		// Solution is credited to https://github.com/golang/go/issues/21971
 		// Code is adapted from the original implementation of handshake_client.go at
-		// 		https://github.com/golang/go/blob/81555cb4f3521b53f9de4ce15f64b77cc9df61b9/src/crypto/tls/handshake_client.go#L327-L344,%20but%20adapted%20to%20skip%20the%20hostname%20verification
+		// https://github.com/golang/go/blob/master/src/crypto/tls/handshake_client.go#L804
 		// disable the default verification; use customized VerifyPeerCertificate
 		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, certChain [][]*x509.Certificate) error {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -713,6 +713,41 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 
 	if c.tlsOptions.ValidateHostname {
 		tlsConfig.ServerName = c.physicalAddr.Hostname()
+	} else if !tlsConfig.InsecureSkipVerify {
+		// Solution is credited to https://github.com/golang/go/issues/21971
+		// Code is adapted from the original implementation of handshake_client.go at
+		// 		https://github.com/golang/go/blob/81555cb4f3521b53f9de4ce15f64b77cc9df61b9/src/crypto/tls/handshake_client.go#L327-L344,%20but%20adapted%20to%20skip%20the%20hostname%20verification
+		// disable the default verification; use customized VerifyPeerCertificate
+		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, certChain [][]*x509.Certificate) error {
+			// If this is the first handshake on a connection, process and
+			// (optionally) verify the server's certificates.
+			certs := make([]*x509.Certificate, len(rawCerts))
+			for i, asn1Data := range rawCerts {
+				cert, err := x509.ParseCertificate(asn1Data)
+				if err != nil {
+					return fmt.Errorf("tls: failed to parse server certificate error: %s", err.Error())
+				}
+				certs[i] = cert
+			}
+
+			// Or we could pass c.physicalAddr.Hostname() so this becomes one code path for HostName verification
+			opts := x509.VerifyOptions{
+				Roots:         tlsConfig.RootCAs,
+				CurrentTime:   time.Now(),
+				DNSName:       "", // skip hostname verification
+				Intermediates: x509.NewCertPool(),
+			}
+
+			for i, cert := range certs {
+				if i == 0 {
+					continue
+				}
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := certs[0].Verify(opts)
+			return err
+		}
 	}
 
 	cert, err := c.auth.GetTLSCertificate()

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -730,7 +730,11 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 				certs[i] = cert
 			}
 
-			// Or we could pass c.physicalAddr.Hostname() so this becomes one code path for HostName verification
+			if tlsConfig.RootCAs == nil {
+				return nil
+			}
+
+			// Verify certs if they exist but skip ServerName validation
 			opts := x509.VerifyOptions{
 				Roots:         tlsConfig.RootCAs,
 				CurrentTime:   time.Now(),

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -711,14 +711,13 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 		}
 	}
 
-	if c.tlsOptions.ValidateHostname {
-		tlsConfig.ServerName = c.physicalAddr.Hostname()
-	} else if !tlsConfig.InsecureSkipVerify {
+	tlsConfig.ServerName = c.physicalAddr.Hostname()
+
+	if tlsConfig.InsecureSkipVerify {
 		// Solution is credited to https://github.com/golang/go/issues/21971
 		// Code is adapted from the original implementation of handshake_client.go at
 		// https://github.com/golang/go/blob/master/src/crypto/tls/handshake_client.go#L804
 		// disable the default verification; use customized VerifyPeerCertificate
-		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, certChain [][]*x509.Certificate) error {
 			// If this is the first handshake on a connection, process and
 			// (optionally) verify the server's certificates.


### PR DESCRIPTION
### Contribution Checklist
  
This PR addresses a problem how to disable TLS ValidateHostname. The current implementation with empty `tlsConfig.ServerName` would not work, because the connected server host will be inferred in absence of tlsConfig.ServerName by Go Tls library. One of the use cases is when DNS name in the server certificate returned does not match the broker host name that the client connects to. The client can be deployed within the same Pulsar kubernetes cluster if the client connects to the internal proxy or broker host directly instead of the public fqdn. This problem may also rise for self-signed cert.

This specific problem and solution are described by this issue report,  https://github.com/golang/go/issues/21971

This PR implements a TLS VerifyPeerCertificate callback to skip host name validation if any client chooses to disable TLSValidateHostname in ClientOption.

I understand TLSValidateHostname is false by default because Go initializes bool as `false`. There is an existing issue #171 that is tracking the problem. I think it will open up a discussion how to support backward compatibility that might require consensus from the community. Therefore, altering the current default is beyond the scope of this PR.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes) Yes the current implementation of skip hostname check is broken, this is a fix.
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

