### PR TITLE
[Issue 242][pulsar-client-go] feature: add send timeout 

### DIFF
--- a/pulsar/internal/blocking_queue_test.go
+++ b/pulsar/internal/blocking_queue_test.go
@@ -118,18 +118,3 @@ func TestBlockingQueueWaitWhenFull(t *testing.T) {
 
 	close(ch)
 }
-
-func TestBlockingQueueIterator(t *testing.T) {
-	q := NewBlockingQueue(10)
-
-	q.Put(1)
-	q.Put(2)
-	q.Put(3)
-	assert.Equal(t, 3, q.Size())
-
-	i := 1
-	for it := q.Iterator(); it.HasNext(); {
-		assert.Equal(t, i, it.Next())
-		i++
-	}
-}

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -20,6 +20,8 @@ package pulsar
 import (
 	"context"
 	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar/internal/pb"
 )
 
 type HashingScheme int
@@ -111,6 +113,19 @@ type ProducerOptions struct {
 	// If set to a value greater than 1, messages will be queued until this threshold is reached or
 	// batch interval has elapsed.
 	BatchingMaxMessages uint
+
+	// BatchingMaxPublishDelay set the time period within which the messages sent will be
+	// checked for timeout (default: 10ms)
+	SendTimeoutCheckInterval time.Duration
+
+	// SendTimeout set the soft bound for send message timeout. if batch is enabled. only check the first message
+	// in batch. if first message timeout then all message in batch will timeout.
+	// default (0) means no send time out. you can check the option with SendTimeoutNotSet
+	// if timeout an ErrSendTimeout will return
+	SendTimeout time.Duration
+
+	// only for test usage. not exported
+	beforeReceiveResponseCallback func(receipt *pb.CommandSendReceipt)
 }
 
 // Producer is used to publish messages on a topic

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -42,6 +42,7 @@ type producer struct {
 }
 
 const defaultBatchingMaxPublishDelay = 10 * time.Millisecond
+const defaultSendTimeoutCheckInterval = 10 * time.Millisecond
 
 var partitionsAutoDiscoveryInterval = 1 * time.Minute
 


### PR DESCRIPTION
Fixes #242 


### Motivation
add send timeout

### Modifications

1. ProduceOptions
add SendTimeout and SendTimeoutCheckInterval in ProducerOptions

2. BlockingQueue
unexported BlockingQueue.Iterator
and add methods to avoid race condition.
BlockingQueue.IterateIfNonEmpty and BlockingQueue.PollIfSatisfy

3. partitionProducer
add a ticker to check if pendingItem in pendingQueue has expired.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

add some tiny test in producer_test.go

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API: no
  - The schema:  no 
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
