### PR TITLE
Expose replicated from filed on message struct

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -424,6 +424,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 				msgID:               msgID,
 				payLoad:             payload,
 				replicationClusters: msgMeta.GetReplicateTo(),
+				replicatedFrom:      msgMeta.GetReplicatedFrom(),
 				redeliveryCount:     response.GetRedeliveryCount(),
 			}
 		} else {
@@ -436,6 +437,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 				msgID:               msgID,
 				payLoad:             payload,
 				replicationClusters: msgMeta.GetReplicateTo(),
+				replicatedFrom:      msgMeta.GetReplicatedFrom(),
 				redeliveryCount:     response.GetRedeliveryCount(),
 			}
 		}

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -145,6 +145,7 @@ type message struct {
 	properties          map[string]string
 	topic               string
 	replicationClusters []string
+	replicatedFrom      string
 	redeliveryCount     uint32
 }
 
@@ -178,6 +179,14 @@ func (msg *message) Key() string {
 
 func (msg *message) RedeliveryCount() uint32 {
 	return msg.redeliveryCount
+}
+
+func (msg *message) IsReplicated() bool {
+	return msg.replicatedFrom != ""
+}
+
+func (msg *message) GetReplicatedFrom() string {
+	return msg.replicatedFrom
 }
 
 func newAckTracker(size int) *ackTracker {

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -93,6 +93,12 @@ type Message interface {
 	// Message redelivery increases monotonically in a broker, when topic switch ownership to a another broker
 	// redelivery count will be recalculated.
 	RedeliveryCount() uint32
+
+	// Check whether the message is replicated from other cluster.
+	IsReplicated() bool
+
+	// Get name of cluster, from which the message is replicated.
+	GetReplicatedFrom() string
 }
 
 // MessageID identifier for a particular message


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Master Issue: #243 

### Motivation

- Expose isReplicated and replicatedFrom for Pulsar message

### Modifications

- Add `replicatedFrom` filed on message struct

