### PR TITLE
Improve go client sending performance

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -34,7 +34,7 @@ const (
 	// MaxBatchSize will be the largest size for a batch sent from this particular producer.
 	// This is used as a baseline to allocate a new buffer that can hold the entire batch
 	// without needing costly re-allocations.
-	MaxBatchSize = 128 * 1024
+	MaxBatchSize = 1024 * 1024
 	// DefaultMaxMessagesPerBatch init default num of entries in per batch.
 	DefaultMaxMessagesPerBatch = 1000
 )
@@ -66,7 +66,7 @@ func NewBatchBuilder(maxMessages uint, producerName string, producerID uint64,
 		maxMessages = DefaultMaxMessagesPerBatch
 	}
 	bb := &BatchBuilder{
-		buffer:       NewBuffer(4096),
+		buffer:       NewBuffer(MaxBatchSize),
 		numMessages:  0,
 		maxMessages:  maxMessages,
 		producerName: producerName,
@@ -162,7 +162,7 @@ func (bb *BatchBuilder) Flush() (batchData []byte, sequenceID uint64, callbacks 
 	compressed := bb.compressionProvider.Compress(bb.buffer.ReadableSlice())
 	bb.msgMetadata.UncompressedSize = &uncompressedSize
 
-	buffer := NewBuffer(4096)
+	buffer := NewBuffer(MaxBatchSize)
 	serializeBatch(buffer, bb.cmdSend, bb.msgMetadata, compressed)
 
 	callbacks = bb.callbacks

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	memorySegmentPool = make(map[int]chan []byte)
+	memorySegmentPool     = make(map[int]chan []byte)
 	memorySegmentPoolLock sync.RWMutex
 )
 
@@ -90,7 +90,7 @@ func NewBuffer(size int) Buffer {
 	memSegmentQueue := getMemorySegmentQueue(size)
 
 	select {
-	case existMemSeg := <- memSegmentQueue:
+	case existMemSeg := <-memSegmentQueue:
 		if cap(existMemSeg) == size {
 			sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&existMemSeg))
 			sliceHeader.Len = size
@@ -110,7 +110,7 @@ func NewBuffer(size int) Buffer {
 	}
 }
 
-func RecoverMemory(memSeg []byte)  {
+func RecoverMemory(memSeg []byte) {
 	if cap(memSeg) < 1024 {
 		return
 	}

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -166,7 +166,7 @@ func newConnection(logicalAddr *url.URL, physicalAddr *url.URL, tlsOptions *TLSO
 		connectionTimeout:    connectionTimeout,
 		logicalAddr:          logicalAddr,
 		physicalAddr:         physicalAddr,
-		writeBuffer:          NewBuffer(512*1024),
+		writeBuffer:          NewBuffer(512 * 1024),
 		log:                  log.WithField("remote_addr", physicalAddr),
 		pendingReqs:          make(map[uint64]*request),
 		lastDataReceivedTime: time.Now(),

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -533,7 +533,7 @@ func (c *connection) handleMessage(response *pb.CommandMessage, payload Buffer) 
 	if consumer, ok := c.consumerHandler(consumerID); ok {
 		err := consumer.MessageReceived(response, payload)
 		if err != nil {
-			c.log.WithField("consumerID", consumerID).Error("handle message err: ", response.MessageId)
+			c.log.WithField("consumerID", consumerID).WithError(err).Error("handle message Id: ", response.MessageId)
 		}
 	} else {
 		c.log.WithField("consumerID", consumerID).Warn("Got unexpected message: ", response.MessageId)

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -36,7 +36,7 @@ func newConnectionReader(cnx *connection) *connectionReader {
 	return &connectionReader{
 		cnx:    cnx,
 		reader: bufio.NewReader(cnx.cnx),
-		buffer: NewBuffer(4*1024*1024),
+		buffer: NewBuffer(4 * 1024 * 1024),
 	}
 }
 

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -36,7 +36,7 @@ func newConnectionReader(cnx *connection) *connectionReader {
 	return &connectionReader{
 		cnx:    cnx,
 		reader: bufio.NewReader(cnx.cnx),
-		buffer: NewBuffer(4096),
+		buffer: NewBuffer(1024*1024*4),
 	}
 }
 
@@ -66,8 +66,8 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 			// If the buffer is empty, just go back to write at the beginning
 			r.buffer.Clear()
 		}
-		if err := r.readAtLeast(4); err != nil {
-			return nil, nil, errors.Errorf("Short read when reading frame size: %s", err)
+		if !r.readAtLeast(4) {
+			return nil, nil, errors.New("Short read when reading frame size")
 		}
 	}
 
@@ -82,8 +82,8 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 	// Next, we read the rest of the frame
 	if r.buffer.ReadableBytes() < frameSize {
 		remainingBytes := frameSize - r.buffer.ReadableBytes()
-		if err := r.readAtLeast(remainingBytes); err != nil {
-			return nil, nil, errors.Errorf("Short read when reading frame: %s", err)
+		if !r.readAtLeast(remainingBytes) {
+			return nil, nil, errors.New("Short read when reading frame")
 		}
 	}
 
@@ -103,7 +103,7 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 	return cmd, headersAndPayload, nil
 }
 
-func (r *connectionReader) readAtLeast(size uint32) error {
+func (r *connectionReader) readAtLeast(size uint32) (ok bool) {
 	if r.buffer.WritableBytes() < size {
 		// There's not enough room in the current buffer to read the requested amount of data
 		totalFrameSize := r.buffer.ReadableBytes() + size
@@ -120,11 +120,11 @@ func (r *connectionReader) readAtLeast(size uint32) error {
 	n, err := io.ReadAtLeast(r.cnx.cnx, r.buffer.WritableSlice(), int(size))
 	if err != nil {
 		r.cnx.TriggerClose()
-		return err
+		return false
 	}
 
 	r.buffer.WrittenBytes(uint32(n))
-	return nil
+	return true
 }
 
 func (r *connectionReader) deserializeCmd(data []byte) (*pb.BaseCommand, error) {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -64,6 +64,8 @@ type partitionProducer struct {
 	partitionIdx int
 }
 
+const defaultBatchingMaxPublishDelay = 10 * time.Millisecond
+
 func newPartitionProducer(client *client, topic string, options *ProducerOptions, partitionIdx int) (
 	*partitionProducer, error) {
 	var batchingMaxPublishDelay time.Duration
@@ -241,7 +243,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 
 	sendAsBatch := !p.options.DisableBatching &&
 		msg.ReplicationClusters == nil &&
-		deliverAt.UnixNano() < 0
+		deliverAt.UnixNano() <= 0
 
 	smm := &pb.SingleMessageMetadata{
 		PayloadSize: proto.Int(len(msg.Payload)),
@@ -304,7 +306,6 @@ type pendingItem struct {
 	batchData    []byte
 	sequenceID   uint64
 	sendRequests []interface{}
-	completed    bool
 }
 
 func (p *partitionProducer) internalFlushCurrentBatch() {
@@ -330,19 +331,6 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		return
 	}
 
-	// lock the pending request while adding requests
-	// since the ReceivedSendReceipt func iterates over this list
-	pi.Lock()
-	defer pi.Unlock()
-
-	if pi.completed {
-		// The last item in the queue has been completed while we were
-		// looking at it. It's safe at this point to assume that every
-		// message enqueued before Flush() was called are now persisted
-		fr.waitGroup.Done()
-		return
-	}
-
 	sendReq := &sendRequest{
 		msg: nil,
 		callback: func(id MessageID, message *ProducerMessage, e error) {
@@ -351,7 +339,11 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		},
 	}
 
+	// lock the pending request while adding requests
+	// since the ReceivedSendReceipt func iterates over this list
+	pi.Lock()
 	pi.sendRequests = append(pi.sendRequests, sendReq)
+	pi.Unlock()
 }
 
 func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (MessageID, error) {
@@ -366,6 +358,12 @@ func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (Mes
 		msgID = ID
 		wg.Done()
 	}, true)
+
+	// When sending synchronously we flush immediately to avoid
+	// the increased latency and reduced throughput of batching
+	if err = p.Flush(); err != nil {
+		return nil, err
+	}
 
 	wg.Wait()
 	return msgID, err
@@ -432,9 +430,6 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 			sr.callback(msgID, sr.msg, nil)
 		}
 	}
-
-	// Mark this pending item as done
-	pi.completed = true
 }
 
 func (p *partitionProducer) internalClose(req *closeProducer) {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -241,7 +241,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 
 	sendAsBatch := !p.options.DisableBatching &&
 		msg.ReplicationClusters == nil &&
-		deliverAt.UnixNano() <= 0
+		deliverAt.UnixNano() < 0
 
 	smm := &pb.SingleMessageMetadata{
 		PayloadSize: proto.Int(len(msg.Payload)),


### PR DESCRIPTION
Improve the sending performance to 50000 message per second, by

  - Add buffer pool, avoid make slice every time need getting buffer;
  - Increased buffer size in various place.

