### PR TITLE
Fix perf-produce cannot be closed

### DIFF
--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -106,7 +106,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 		for {
 			select {
-			case <-stop:
+			case <-stopCh:
 				return
 			default:
 			}

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -98,7 +98,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 	ch := make(chan float64)
 
-	go func() {
+	go func(stop <-chan struct{}) {
 		var rateLimiter *rate.RateLimiter
 		if produceArgs.Rate > 0 {
 			rateLimiter = rate.New(produceArgs.Rate, time.Second)
@@ -128,7 +128,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 				ch <- latency
 			})
 		}
-	}()
+	}(stop)
 
 	// Print stats of the publish rate and latencies
 	tick := time.NewTicker(10 * time.Second)

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -98,7 +98,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 	ch := make(chan float64)
 
-	go func(stop <-chan struct{}) {
+	go func(stopCh <-chan struct{}) {
 		var rateLimiter *rate.RateLimiter
 		if produceArgs.Rate > 0 {
 			rateLimiter = rate.New(produceArgs.Rate, time.Second)


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Motivation

Due to the use of goroutine, `stop <-chan struct {}` cannot be seen.



### Modifications

- Fix perf-produce cannot be closed
