### PR TITLE
Fix perf-producer target

### DIFF
--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -132,7 +132,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 	// Print stats of the publish rate and latencies
 	tick := time.NewTicker(10 * time.Second)
-	q := quantile.NewTargeted(0.90, 0.95, 0.99, 0.999, 1.0)
+	q := quantile.NewTargeted(0.50, 0.95, 0.99, 0.999, 1.0)
 	messagesPublished := 0
 
 	for {


### PR DESCRIPTION
Signed-off-by: jonyhy96 <hy352144278@gmail.com>

### Motivation

Fix the wrong target in perf-producer

### Modifications

- Change the target of quantile in perf-producer from 0.90 to 0.50