### PR TITLE
[Issue 240] Add check for max message size

### DIFF
--- a/integration-tests/standalone.conf
+++ b/integration-tests/standalone.conf
@@ -83,6 +83,9 @@ statusFilePath=/usr/local/apache/htdocs
 # Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
 maxUnackedMessagesPerConsumer=50000
 
+# Set maxMessageSize to 1MB rather than the default value 5MB for testing
+maxMessageSize=1048576
+
 ### --- Authentication --- ###
 
 # Enable TLS

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -29,8 +29,6 @@ import (
 )
 
 const (
-	// MaxMessageSize limit message size for transfer
-	MaxMessageSize = 5 * 1024 * 1024
 	// MaxBatchSize will be the largest size for a batch sent from this particular producer.
 	// This is used as a baseline to allocate a new buffer that can hold the entire batch
 	// without needing costly re-allocations.

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -30,8 +30,12 @@ import (
 
 const (
 	// MaxFrameSize limit the maximum size that pulsar allows for messages to be sent.
-	MaxFrameSize        = 5 * 1024 * 1024
-	magicCrc32c  uint16 = 0x0e01
+	MaxFrameSize = 5 * 1024 * 1024
+	// MessageFramePadding is for metadata and other frame headers
+	MessageFramePadding = 10 * 1024
+	// MaxMessageSize limit message size for transfer
+	MaxMessageSize        = MaxFrameSize - MessageFramePadding
+	magicCrc32c    uint16 = 0x0e01
 )
 
 // ErrCorruptedMessage is the error returned by ReadMessageData when it has detected corrupted data.

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -245,7 +245,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		request.callback(nil, request.msg, errMessageTooLarge)
 		p.log.WithField("size", len(msg.Payload)).
 			WithField("properties", msg.Properties).
-			Error("message size exceeds MaxMessageSize")
+			WithError(errMessageTooLarge).Error()
 		return
 	}
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -40,7 +40,10 @@ const (
 	producerClosed
 )
 
-var errFailAddBatch = errors.New("message send failed")
+var (
+	errFailAddBatch    = errors.New("message send failed")
+	errMessageTooLarge = errors.New("message size exceeds MaxMessageSize")
+)
 
 type partitionProducer struct {
 	state  int32
@@ -235,6 +238,16 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 	p.log.Debug("Received send request: ", *request)
 
 	msg := request.msg
+
+	// if msg is too large
+	if len(msg.Payload) > int(p.cnx.GetMaxMessageSize()) {
+		p.publishSemaphore.Release()
+		request.callback(nil, request.msg, errMessageTooLarge)
+		p.log.WithField("size", len(msg.Payload)).
+			WithField("properties", msg.Properties).
+			Error("message size exceeds MaxMessageSize")
+		return
+	}
 
 	deliverAt := msg.DeliverAt
 	if msg.DeliverAfter.Nanoseconds() > 0 {


### PR DESCRIPTION
Fixes #240 

### Motivation

Issue #240: Add client-side check for max message size

### Modifications

1. When creating a connection, try to get maxMessageSize from handshake
response command. If it's not set, then use the default maxMessageSize
value defined in the client side.

2. When sending a message, check whether the size of payload exceeds
maxMessageSize. If so, return error immediately without adding this
meesage into sending queue.

3. To implement these, I made some tiny modifications in Connection
interface and added a field in its implementation struct.
