### PR TITLE
[Issue 271][Producer]Stop partition discovery on Close

### DIFF
--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -247,6 +247,9 @@ func (p *producer) Flush() error {
 func (p *producer) Close() {
 	p.Lock()
 	defer p.Unlock()
+	if p.ticker != nil {
+		p.ticker.Stop()
+	}
 
 	for _, pp := range p.producers {
 		pp.Close()


### PR DESCRIPTION
Fixes #271 


### Motivation

This fixes a race when a producer is closed and the number of partitions changed i.e. the topic is deleted just after the producer is closed.

### Modifications

It consists of stopping the ticker that controls the partition discovery in the background.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This is a trivial rework.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
