### PR TITLE
Allow to have multiple connections per broker

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -88,6 +88,9 @@ type ClientOptions struct {
 
 	// Configure whether the Pulsar client verify the validity of the host name from broker (default: false)
 	TLSValidateHostname bool
+
+	// Max number of connections to a single broker that will kept in the pool. (Default: 1 connection)
+	MaxConnectionsPerBroker int
 }
 
 type Client interface {

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -95,8 +95,13 @@ func newClient(options ClientOptions) (Client, error) {
 		operationTimeout = defaultOperationTimeout
 	}
 
+	maxConnectionsPerHost := options.MaxConnectionsPerBroker
+	if maxConnectionsPerHost <= 0 {
+		maxConnectionsPerHost = 1
+	}
+
 	c := &client{
-		cnxPool: internal.NewConnectionPool(tlsConfig, authProvider, connectionTimeout),
+		cnxPool: internal.NewConnectionPool(tlsConfig, authProvider, connectionTimeout, maxConnectionsPerHost),
 	}
 	c.rpcClient = internal.NewRPCClient(url, c.cnxPool, operationTimeout)
 	c.lookupService = internal.NewLookupService(c.rpcClient, url, tlsConfig != nil)


### PR DESCRIPTION
### Motivation

Similar to what we do in Java client, in certain conditions it might be useful to have more than one TCP connection to each broker. This increase the parallelism in client (more Go routines), brokers (connections get assigned to different IO threads) and also can improve the throughput at TCP level when the client is talking to a small number of brokers. 