### PR TITLE
Expose BatchingMaxSize from ProducerOptions

### DIFF
--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -109,8 +109,13 @@ type ProducerOptions struct {
 
 	// BatchingMaxMessages set the maximum number of messages permitted in a batch. (default: 1000)
 	// If set to a value greater than 1, messages will be queued until this threshold is reached or
-	// batch interval has elapsed.
+	// BatchingMaxSize (see below) has been reached or the batch interval has elapsed.
 	BatchingMaxMessages uint
+
+	// BatchingMaxSize sets the maximum number of bytes permitted in a batch. (default 128 KB)
+	// If set to a value greater than 1, messages will be queued until this threshold is reached or
+	// BatchingMaxMessages (see above) has been reached or the batch interval has elapsed.
+	BatchingMaxSize uint
 }
 
 // Producer is used to publish messages on a topic

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -151,8 +151,8 @@ func (p *partitionProducer) grabCnx() error {
 
 	p.producerName = res.Response.ProducerSuccess.GetProducerName()
 	if p.batchBuilder == nil {
-		p.batchBuilder, err = internal.NewBatchBuilder(p.options.BatchingMaxMessages, p.producerName,
-			p.producerID, pb.CompressionType(p.options.CompressionType))
+		p.batchBuilder, err = internal.NewBatchBuilder(p.options.BatchingMaxMessages, p.options.BatchingMaxSize,
+			p.producerName, p.producerID, pb.CompressionType(p.options.CompressionType))
 		if err != nil {
 			return err
 		}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -661,7 +661,7 @@ func TestBatchMessageFlushing(t *testing.T) {
 	}
 	defer producer.Close()
 
-	maxBytes := internal.MaxBatchSize
+	maxBytes := internal.DefaultMaxBatchSize
 	genbytes := func(n int) []byte {
 		c := []byte("a")[0]
 		bytes := make([]byte, n)


### PR DESCRIPTION
Previously, the producer maximum batch size was hard-coded to 128 KB.

Now, the produdcer maximum batch size is exposed via ProducerOptions
and defaults to 128 KB

### Motivation

Different applications producing to Pulsar require different batching policies.
Previously, users had control over the maximum batching delay and the maximum number of messages in a batch, but could not control the maximum number of bytes in a batch.  This change enables the latter. 

### Modifications

Expose a new `ProducerOption.BatchingMaxSize` (default: 128KB) that allows the user to configure the maximum batch size.  This option has been plumbed through `partition_producer` module to the `internal/batch_builder` module where it is used.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `producer_test.TestFlushInPartitionedProducer` and `producer_test.TestFlushInProducer`.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: The pulsar.ProducerOptions structure gains a new field: `BatchingMaxSize` 

### Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? GoDocs