### PR TITLE
[Issue #282] Fix unable to close consumer after unsubscribe in Shared Subscription

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -184,6 +184,10 @@ func (pc *partitionConsumer) internalUnsubscribe(unsub *unsubscribeRequest) {
 	if err != nil {
 		pc.log.WithError(err).Error("Failed to unsubscribe consumer")
 		unsub.err = err
+		// Set the state to ready for closing the consumer
+		pc.state = consumerReady
+		// Should'nt remove the consumer handler
+		return
 	}
 
 	pc.conn.DeleteConsumeHandler(pc.consumerID)


### PR DESCRIPTION

Fixes #282 

### Motivation
In Shared Subscription, is is unable to unsubscribe the consumer(return an error). So 
it wasn't to mark the connection state to CLOSED.

### Modifications
Mark the connection state back to Ready when unsubscribe fails

