### PR TITLE
Use maxPendingMessages for sizing producer eventsChan

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -92,7 +92,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 		topic:            topic,
 		options:          options,
 		producerID:       client.rpcClient.NewProducerID(),
-		eventsChan:       make(chan interface{}, 10),
+		eventsChan:       make(chan interface{}, maxPendingMessages),
 		batchFlushTicker: time.NewTicker(batchingMaxPublishDelay),
 		publishSemaphore: make(internal.Semaphore, maxPendingMessages),
 		pendingQueue:     internal.NewBlockingQueue(maxPendingMessages),


### PR DESCRIPTION
### Motivation

When multiple go-routines are sharing the same producer instance, there will be contention and blocking on the channel that is used to dispatch to the partition handler.