### PR TITLE
Avoid contention on producer mutex on critical path

### DIFF
--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -215,7 +215,7 @@ func (p *producer) getPartition(msg *ProducerMessage) Producer {
 	// Since partitions can only increase, it's ok if the producers list
 	// is updated in between. The numPartition is updated only after the list.
 	partition := p.messageRouter(msg, p)
-	producers := *(*[]Producer) (atomic.LoadPointer(&p.producersPtr))
+	producers := *(*[]Producer)(atomic.LoadPointer(&p.producersPtr))
 	if partition >= len(producers) {
 		// We read the old producers list while the count was already
 		// updated


### PR DESCRIPTION
### Motivation

Multiple go-routines sharing a single producers are experiencing contention on the partitioned producer mutex that we acquire while using the router.

The mutex is there to protect the updates on the list of partitions, but we can optimize that away.