### PR TITLE
fix panic when creating consumer with ReceiverQueueSize set to -1

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -116,7 +116,6 @@ type ConsumerOptions struct {
 	// application calls `Consumer.receive()`. Using a higher value could potentially increase the consumer
 	// throughput at the expense of bigger memory utilization.
 	// Default value is `1000` messages and should be good for most use cases.
-	// Set to -1 to disable prefetching in consumer
 	ReceiverQueueSize int
 
 	// The delay after which to redeliver the messages that failed to be

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -70,13 +70,8 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		return nil, newError(SubscriptionNotFound, "subscription name is required for consumer")
 	}
 
-	if options.ReceiverQueueSize == 0 {
+	if options.ReceiverQueueSize <= 0 {
 		options.ReceiverQueueSize = 1000
-	}
-
-	// disable receiver queue if queue size is negative
-	if options.ReceiverQueueSize < 0 {
-		options.ReceiverQueueSize = 0
 	}
 
 	// did the user pass in a message channel?

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -74,7 +74,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		options.ReceiverQueueSize = 1000
 	}
 
-	// disable receiver queue if queuing size is negative
+	// disable receiver queue if queue size is negative
 	if options.ReceiverQueueSize < 0 {
 		options.ReceiverQueueSize = 0
 	}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -74,6 +74,11 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		options.ReceiverQueueSize = 1000
 	}
 
+	// disable receiver queue if queuing size is negative
+	if options.ReceiverQueueSize < 0 {
+		options.ReceiverQueueSize = 0
+	}
+
 	// did the user pass in a message channel?
 	messageCh := options.MessageChannel
 	if options.MessageChannel == nil {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1274,3 +1274,28 @@ func TestConsumerAddTopicPartitions(t *testing.T) {
 
 	assert.Equal(t, len(msgs), 10)
 }
+
+func TestConsumterNegativeRecieverQueueSize(t *testing.T) {
+	assert := assert.New(t)
+
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(err)
+	defer client.Close()
+
+	topic := newTopicName()
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:             topic,
+		SubscriptionName:  "my-sub",
+		ReceiverQueueSize: -1,
+	})
+	defer func() {
+		if consumer != nil {
+			consumer.Close()
+		}
+	}()
+
+	assert.Nil(err)
+}


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/288
