### PR TITLE
[Issue 177] feature: support multi host

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -69,6 +69,11 @@ func newClient(options ClientOptions) (Client, error) {
 		return nil, newError(ResultInvalidConfiguration, fmt.Sprintf("Invalid URL scheme '%s'", url.Scheme))
 	}
 
+	host, err := internal.NewHostResolve(options.URL)
+	if err != nil {
+		return nil, err
+	}
+
 	var authProvider auth.Provider
 	var ok bool
 
@@ -103,8 +108,8 @@ func newClient(options ClientOptions) (Client, error) {
 	c := &client{
 		cnxPool: internal.NewConnectionPool(tlsConfig, authProvider, connectionTimeout, maxConnectionsPerHost),
 	}
-	c.rpcClient = internal.NewRPCClient(url, c.cnxPool, operationTimeout)
-	c.lookupService = internal.NewLookupService(c.rpcClient, url, tlsConfig != nil)
+	c.rpcClient = internal.NewRPCClient(host, c.cnxPool, operationTimeout)
+	c.lookupService = internal.NewLookupService(c.rpcClient, host, tlsConfig != nil)
 	c.handlers = internal.NewClientHandlers()
 	return c, nil
 }

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -759,8 +759,7 @@ func (pc *partitionConsumer) grabConn() error {
 		cmdSubscribe.ForceTopicCreation = proto.Bool(false)
 	}
 
-	res, err := pc.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, requestID,
-		pb.BaseCommand_SUBSCRIBE, cmdSubscribe)
+	res, err := pc.client.rpcClient.Request(requestID, pb.BaseCommand_SUBSCRIBE, cmdSubscribe)
 
 	if err != nil {
 		pc.log.WithError(err).Error("Failed to create consumer")

--- a/pulsar/internal/host_resolve.go
+++ b/pulsar/internal/host_resolve.go
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"errors"
+	"math/rand"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// HostResolve is used to implement multihost
+type HostResolve interface {
+	GetServiceURL() string
+	GetHost() (*url.URL, error)
+	GetHostURL() (string, error)
+	ResolveHost() (*url.URL, error)
+}
+
+type hostResolve struct {
+	sync.Mutex
+
+	serviceURL   string
+	Host         []*url.URL
+	CurrentIndex int
+}
+
+func NewHostResolve(serviceURL string) (HostResolve, error) {
+	h := &hostResolve{
+		serviceURL: serviceURL,
+	}
+
+	// resolve host
+	hosts := strings.Split(h.serviceURL, ",")
+	if len(hosts) == 0 || !checkPrefix(hosts[0]) {
+		return nil, errors.New("invalid service URL")
+	}
+
+	for k := range hosts {
+		if !checkPrefix(hosts[k]) {
+			hosts[k] = h.Host[k-1].Scheme + `://` + hosts[k]
+		}
+		urlResolve, err := url.Parse(hosts[k])
+		if err != nil {
+			return nil, errors.New("invalid service URL")
+		}
+		h.Host = append(h.Host, urlResolve)
+	}
+
+	h.CurrentIndex = randomIndex(len(h.Host))
+	return h, nil
+}
+
+func (h *hostResolve) GetServiceURL() string {
+	return h.serviceURL
+}
+
+func (h *hostResolve) GetHostURL() (string, error) {
+	host, err := h.GetHost()
+	if err != nil {
+		return "", err
+	}
+	return host.String(), nil
+}
+
+// add lock, to avoid race from ResolveHost()
+func (h *hostResolve) GetHost() (*url.URL, error) {
+	h.Lock()
+	defer h.Unlock()
+
+	if len(h.Host) == 0 || h.CurrentIndex > len(h.Host) {
+		log.Debugf("h.host: %v, h.CurrentIndex: %d", h.Host, h.CurrentIndex)
+		return nil, errors.New("not find host")
+	}
+	return h.Host[h.CurrentIndex], nil
+}
+
+func (h *hostResolve) ResolveHost() (*url.URL, error) {
+	h.Lock()
+	defer h.Unlock()
+
+	if h.CurrentIndex >= len(h.Host) {
+		return nil, errors.New("index out of range length of h.Host")
+	}
+	h.CurrentIndex = (h.CurrentIndex + 1) % len(h.Host)
+	return h.Host[h.CurrentIndex], nil
+}
+
+func checkPrefix(url string) bool {
+	if strings.HasPrefix(url, "pulsar") || strings.HasPrefix(url, "pulsar+ssl") {
+		return true
+	}
+
+	return false
+}
+
+var r = &random{
+	R: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+type random struct {
+	sync.Mutex
+	R *rand.Rand
+}
+
+func randomIndex(numHost int) int {
+	r.Lock()
+	defer r.Unlock()
+
+	if numHost == 1 {
+		return 0
+	}
+	return r.R.Intn(numHost)
+}

--- a/pulsar/internal/host_resolve_test.go
+++ b/pulsar/internal/host_resolve_test.go
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostResolve_GetHost(t *testing.T) {
+
+	var (
+		h           HostResolve
+		err         error
+		urlString   string
+		resolveAddr *url.URL
+	)
+
+	// test single host
+	h, err = NewHostResolve("pulsar://localhost:6650")
+	assert.Nil(t, err)
+	urlString = h.GetServiceURL()
+	assert.Equal(t, urlString, "pulsar://localhost:6650")
+	resolveAddr, err = h.GetHost()
+	assert.Nil(t, err)
+	assert.Equal(t, resolveAddr.String(), "pulsar://localhost:6650")
+
+	// test multi host
+	h, err = NewHostResolve("pulsar://localhost:6650,pulsar://example:6650")
+	assert.Nil(t, err)
+	urlString = h.GetServiceURL()
+	assert.Equal(t, urlString, "pulsar://localhost:6650,pulsar://example:6650")
+	resolveAddr, err = h.GetHost()
+	assert.Nil(t, err)
+	assert.Equal(t, resolveAddr.Scheme, "pulsar")
+
+	h, err = NewHostResolve("pulsar+ssl://localhost:6650,example:6650")
+	assert.Nil(t, err)
+	urlString = h.GetServiceURL()
+	assert.Equal(t, urlString, "pulsar+ssl://localhost:6650,example:6650")
+	resolveAddr, err = h.GetHost()
+	assert.Nil(t, err)
+	assert.Equal(t, resolveAddr.Scheme, "pulsar+ssl")
+
+	// error test
+	_, err = NewHostResolve("pul://localhost:6650")
+	assert.NotNil(t, err)
+
+}
+
+func TestHostResolve_ResolveHost(t *testing.T) {
+
+	var (
+		h            HostResolve
+		err          error
+		resolveAddr  *url.URL
+		resolveAddr2 *url.URL
+	)
+
+	h, err = NewHostResolve("pulsar://localhost:6650")
+	assert.Nil(t, err)
+	resolveAddr, err = h.ResolveHost()
+	assert.Nil(t, err)
+	assert.Equal(t, resolveAddr.String(), "pulsar://localhost:6650")
+
+	h, err = NewHostResolve("pulsar://localhost:6650,example:6650")
+	assert.Nil(t, err)
+	resolveAddr, err = h.ResolveHost()
+	assert.Nil(t, err)
+	resolveAddr2, err = h.ResolveHost()
+	assert.Nil(t, err)
+	assert.NotEqual(t, resolveAddr.String(), resolveAddr2.String())
+	t.Logf("addr1: %s, addr2: %s", resolveAddr.String(), resolveAddr2.String())
+
+}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -145,7 +145,7 @@ func (p *partitionProducer) grabCnx() error {
 	if len(p.options.Properties) > 0 {
 		cmdProducer.Metadata = toKeyValues(p.options.Properties)
 	}
-	res, err := p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_PRODUCER, cmdProducer)
+	res, err := p.client.rpcClient.Request(id, pb.BaseCommand_PRODUCER, cmdProducer)
 	if err != nil {
 		p.log.WithError(err).Error("Failed to create producer")
 		return err


### PR DESCRIPTION
Fixes #177 

### Motivation

support multi host

### Modifications

1. add a struct `HostResolve` to complete this demand
2. modify RPCClient and LookupService, remove the old variable `ServiceURL *url.URL` to `host HostResolve`
3. modify the `request` function in`pulsar/consumer_partition.go`, I found the old fuction params `logicalAddr` and `phyiscalAddr` could be got in `func (c *rpcClient) getConn() (Connection, error)`, also in this function, we retry connection if failded.

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
