### PR TITLE
Used pooled buffering for compression and batch serialization

### DIFF
--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,7 +35,8 @@ func TestClient(t *testing.T) {
 
 func TestTLSConnectionCAError(t *testing.T) {
 	client, err := NewClient(ClientOptions{
-		URL: serviceURLTLS,
+		URL:              serviceURLTLS,
+		OperationTimeout: 5 * time.Second,
 	})
 	assert.NoError(t, err)
 
@@ -105,6 +107,7 @@ func TestTLSConnectionHostNameVerification(t *testing.T) {
 func TestTLSConnectionHostNameVerificationError(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL:                   "pulsar+ssl://127.0.0.1:6651",
+		OperationTimeout:      5 * time.Second,
 		TLSTrustCertsFilePath: caCertsPath,
 		TLSValidateHostname:   true,
 	})

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -859,7 +859,7 @@ func (pc *partitionConsumer) Decompress(msgMeta *pb.MessageMetadata, payload int
 		pc.compressionProviders[msgMeta.GetCompression()] = provider
 	}
 
-	uncompressed, err := provider.Decompress(payload.ReadableSlice(), int(msgMeta.GetUncompressedSize()))
+	uncompressed, err := provider.Decompress(nil, payload.ReadableSlice(), int(msgMeta.GetUncompressedSize()))
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -63,6 +63,7 @@ type Buffer interface {
 	PutUint32(n uint32, writerIdx uint32)
 
 	Resize(newSize uint32)
+	ResizeIfNeeded(spaceNeeded uint32)
 
 	// Clear will clear the current buffer data.
 	Clear()
@@ -154,9 +155,9 @@ func (b *buffer) Resize(newSize uint32) {
 	b.writerIdx = size
 }
 
-func (b *buffer) resizeIfNeeded(spaceNeeded int) {
-	if b.WritableBytes() < uint32(spaceNeeded) {
-		capacityNeeded := uint32(cap(b.data) + spaceNeeded)
+func (b *buffer) ResizeIfNeeded(spaceNeeded uint32) {
+	if b.WritableBytes() < spaceNeeded {
+		capacityNeeded := uint32(cap(b.data)) + spaceNeeded
 		minCapacityIncrease := uint32(cap(b.data) * 3 / 2)
 		if capacityNeeded < minCapacityIncrease {
 			capacityNeeded = minCapacityIncrease
@@ -174,7 +175,7 @@ func (b *buffer) ReadUint16() uint16 {
 }
 
 func (b *buffer) WriteUint32(n uint32) {
-	b.resizeIfNeeded(4)
+	b.ResizeIfNeeded(4)
 	binary.BigEndian.PutUint32(b.WritableSlice(), n)
 	b.writerIdx += 4
 }
@@ -184,13 +185,13 @@ func (b *buffer) PutUint32(n uint32, idx uint32) {
 }
 
 func (b *buffer) WriteUint16(n uint16) {
-	b.resizeIfNeeded(2)
+	b.ResizeIfNeeded(2)
 	binary.BigEndian.PutUint16(b.WritableSlice(), n)
 	b.writerIdx += 2
 }
 
 func (b *buffer) Write(s []byte) {
-	b.resizeIfNeeded(len(s))
+	b.ResizeIfNeeded(uint32(len(s)))
 	copy(b.WritableSlice(), s)
 	b.writerIdx += uint32(len(s))
 }

--- a/pulsar/internal/compression/compression.go
+++ b/pulsar/internal/compression/compression.go
@@ -29,15 +29,18 @@ const (
 
 // Provider is a interface of compression providers
 type Provider interface {
+	// Return the max possible size for a compressed buffer given the uncompressed data size
+	CompressMaxSize(originalSize int) int
+
 	// Compress a []byte, the param is a []byte with the uncompressed content.
 	// The reader/writer indexes will not be modified. The return is a []byte
 	// with the compressed content.
-	Compress(data []byte) []byte
+	Compress(dst, src []byte) []byte
 
 	// Decompress a []byte. The buffer needs to have been compressed with the matching Encoder.
-	// The compressedData is compressed content, originalSize is the size of the original content.
+	// The src is compressed content. If dst is passed, the decompressed data will be written there
 	// The return were the result will be passed, if err is nil, the buffer was decompressed, no nil otherwise.
-	Decompress(compressedData []byte, originalSize int) ([]byte, error)
+	Decompress(dst, src []byte, originalSize int) ([]byte, error)
 
 	// Returns a new instance of the same provider, with the same exact configuration
 	Clone() Provider

--- a/pulsar/internal/compression/compression_bench_test.go
+++ b/pulsar/internal/compression/compression_bench_test.go
@@ -33,11 +33,12 @@ func testCompression(b *testing.B, provider Provider) {
 	}
 
 	dataLen := int64(len(data))
+	compressed := make([]byte, 1024*1024)
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		provider.Compress(data)
+		provider.Compress(compressed[:0], data)
 		b.SetBytes(dataLen)
 	}
 }
@@ -49,14 +50,15 @@ func testDecompression(b *testing.B, provider Provider) {
 		b.Error(err)
 	}
 
-	dataCompressed := provider.Compress(data)
+	dataCompressed := provider.Compress(nil, data)
+	dataDecompressed := make([]byte, 1024*1024)
 
 	dataLen := int64(len(data))
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		provider.Decompress(dataCompressed, int(dataLen))
+		provider.Decompress(dataDecompressed[:0], dataCompressed, int(dataLen))
 		b.SetBytes(dataLen)
 	}
 }
@@ -108,8 +110,10 @@ func BenchmarkCompressionParallel(b *testing.B) {
 		b.Run(p.name, func(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				localProvider := p.provider.Clone()
+				compressed := make([]byte, 1024*1024)
+
 				for pb.Next() {
-					localProvider.Compress(data)
+					localProvider.Compress(compressed[:0], data)
 					b.SetBytes(dataLen)
 				}
 			})

--- a/pulsar/internal/compression/compression_test.go
+++ b/pulsar/internal/compression/compression_test.go
@@ -43,8 +43,24 @@ func TestCompression(t *testing.T) {
 		p := provider
 		t.Run(p.name, func(t *testing.T) {
 			hello := []byte("test compression data")
-			compressed := p.provider.Compress(hello)
-			uncompressed, err := p.provider.Decompress(compressed, len(hello))
+			compressed := make([]byte, 1024)
+			compressed = p.provider.Compress(compressed, hello)
+
+			uncompressed := make([]byte, 1024)
+			uncompressed, err := p.provider.Decompress(uncompressed, compressed, len(hello))
+			assert.Nil(t, err)
+			assert.ElementsMatch(t, hello, uncompressed)
+		})
+	}
+}
+
+func TestCompressionNoBuffers(t *testing.T) {
+	for _, provider := range providers {
+		p := provider
+		t.Run(p.name, func(t *testing.T) {
+			hello := []byte("test compression data")
+			compressed := p.provider.Compress(nil, hello)
+			uncompressed, err := p.provider.Decompress(nil, compressed, len(hello))
 			assert.Nil(t, err)
 			assert.ElementsMatch(t, hello, uncompressed)
 		})
@@ -56,7 +72,7 @@ func TestJavaCompatibility(t *testing.T) {
 		p := provider
 		t.Run(p.name, func(t *testing.T) {
 			hello := []byte("hello")
-			uncompressed, err := p.provider.Decompress(p.compressedHello, len(hello))
+			uncompressed, err := p.provider.Decompress(nil, p.compressedHello, len(hello))
 			assert.Nil(t, err)
 			assert.ElementsMatch(t, hello, uncompressed)
 		})
@@ -67,7 +83,7 @@ func TestDecompressionError(t *testing.T) {
 	for _, provider := range providers {
 		p := provider
 		t.Run(p.name, func(t *testing.T) {
-			_, err := p.provider.Decompress([]byte{0x05}, 10)
+			_, err := p.provider.Decompress(nil, []byte{0x05}, 10)
 			assert.NotNil(t, err)
 		})
 	}

--- a/pulsar/internal/compression/noop.go
+++ b/pulsar/internal/compression/noop.go
@@ -17,6 +17,10 @@
 
 package compression
 
+import (
+	"bytes"
+)
+
 type noopProvider struct{}
 
 // NewNoopProvider returns a Provider interface that does not compress the data
@@ -24,12 +28,28 @@ func NewNoopProvider() Provider {
 	return &noopProvider{}
 }
 
-func (noopProvider) Compress(data []byte) []byte {
-	return data
+func (noopProvider) CompressMaxSize(originalSize int) int {
+	return originalSize
 }
 
-func (noopProvider) Decompress(compressedData []byte, originalSize int) ([]byte, error) {
-	return compressedData, nil
+func (noopProvider) Compress(dst, src []byte) []byte {
+	if dst == nil {
+		dst = make([]byte, len(src))
+	}
+
+	b := bytes.NewBuffer(dst[:0])
+	b.Write(src)
+	return dst[:len(src)]
+}
+
+func (noopProvider) Decompress(dst, src []byte, originalSize int) ([]byte, error) {
+	if dst == nil {
+		dst = make([]byte, len(src))
+	}
+
+	b := bytes.NewBuffer(dst[:0])
+	b.Write(src)
+	return dst[:len(src)], nil
 }
 
 func (noopProvider) Close() error {

--- a/pulsar/internal/compression/zstd_cgo.go
+++ b/pulsar/internal/compression/zstd_cgo.go
@@ -55,8 +55,12 @@ func NewZStdProvider(level Level) Provider {
 	return newCGoZStdProvider(level)
 }
 
-func (z *zstdCGoProvider) Compress(data []byte) []byte {
-	out, err := z.ctx.CompressLevel(nil, data, z.zstdLevel)
+func (z *zstdCGoProvider) CompressMaxSize(originalSize int) int {
+	return zstd.CompressBound(originalSize)
+}
+
+func (z *zstdCGoProvider) Compress(dst, src []byte) []byte {
+	out, err := z.ctx.CompressLevel(dst, src, z.zstdLevel)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to compress")
 	}
@@ -64,8 +68,8 @@ func (z *zstdCGoProvider) Compress(data []byte) []byte {
 	return out
 }
 
-func (z *zstdCGoProvider) Decompress(compressedData []byte, originalSize int) ([]byte, error) {
-	return z.ctx.Decompress(nil, compressedData)
+func (z *zstdCGoProvider) Decompress(dst, src []byte, originalSize int) ([]byte, error) {
+	return z.ctx.Decompress(dst, src)
 }
 
 func (z *zstdCGoProvider) Close() error {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -155,7 +155,8 @@ func (p *partitionProducer) grabCnx() error {
 	if p.batchBuilder == nil {
 		p.batchBuilder, err = internal.NewBatchBuilder(p.options.BatchingMaxMessages, p.options.BatchingMaxSize,
 			p.producerName, p.producerID, pb.CompressionType(p.options.CompressionType),
-			compression.Level(p.options.CompressionLevel))
+			compression.Level(p.options.CompressionLevel),
+			p)
 		if err != nil {
 			return err
 		}
@@ -179,6 +180,10 @@ func (p *partitionProducer) grabCnx() error {
 }
 
 type connectionClosed struct{}
+
+func (p *partitionProducer) GetConnection() internal.Connection {
+	return p.cnx
+}
 
 func (p *partitionProducer) ConnectionClosed() {
 	// Trigger reconnection in the produce goroutine
@@ -310,7 +315,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 
 type pendingItem struct {
 	sync.Mutex
-	batchData    []byte
+	batchData    internal.Buffer
 	sequenceID   uint64
 	sendRequests []interface{}
 	completed    bool


### PR DESCRIPTION
### Motivation

 * Used pooled buffers when serializing a batch of messages
 * Perform in-place compression into the batch buffer