### PR TITLE
Removed blocking queue iterator

### DIFF
--- a/pulsar/internal/blocking_queue_test.go
+++ b/pulsar/internal/blocking_queue_test.go
@@ -119,17 +119,32 @@ func TestBlockingQueueWaitWhenFull(t *testing.T) {
 	close(ch)
 }
 
-func TestBlockingQueueIterator(t *testing.T) {
-	q := NewBlockingQueue(10)
+func TestBlockingQueue_ReadableSlice(t *testing.T) {
+	q := NewBlockingQueue(3)
 
 	q.Put(1)
 	q.Put(2)
 	q.Put(3)
 	assert.Equal(t, 3, q.Size())
 
-	i := 1
-	for it := q.Iterator(); it.HasNext(); {
-		assert.Equal(t, i, it.Next())
-		i++
-	}
+	items := q.ReadableSlice()
+	assert.Equal(t, len(items), 3)
+	assert.Equal(t, items[0], 1)
+	assert.Equal(t, items[1], 2)
+	assert.Equal(t, items[2], 3)
+
+	q.Poll()
+
+	items = q.ReadableSlice()
+	assert.Equal(t, len(items), 2)
+	assert.Equal(t, items[0], 2)
+	assert.Equal(t, items[1], 3)
+
+	q.Put(4)
+
+	items = q.ReadableSlice()
+	assert.Equal(t, len(items), 3)
+	assert.Equal(t, items[0], 2)
+	assert.Equal(t, items[1], 3)
+	assert.Equal(t, items[2], 4)
 }

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -170,10 +170,11 @@ func (p *partitionProducer) grabCnx() error {
 	p.cnx.RegisterListener(p.producerID, p)
 	p.log.WithField("cnx", res.Cnx.ID()).Debug("Connected producer")
 
-	if p.pendingQueue.Size() > 0 {
-		p.log.Infof("Resending %d pending batches", p.pendingQueue.Size())
-		for it := p.pendingQueue.Iterator(); it.HasNext(); {
-			p.cnx.WriteData(it.Next().(*pendingItem).batchData)
+	pendingItems := p.pendingQueue.ReadableSlice()
+	if len(pendingItems) > 0 {
+		p.log.Infof("Resending %d pending batches", len(pendingItems))
+		for _, pi := range pendingItems {
+			p.cnx.WriteData(pi.(*pendingItem).batchData)
 		}
 	}
 	return nil


### PR DESCRIPTION
### Motivation

The blocking queue iterator method is not really thread safe in the presence of other read/write operations on the queue. While it makes a snapshot of what's readable at one point, if there are `Poll()` operations, it might be ending up reading new items before the new ones.

For that, it's better to make a copy of the items in the queue, also considering that iterating over this queue is only done on reconnections and it's not performance sensitive.