### PR TITLE
[Issue 304][Reader] fixed panic in CreateReader API using custom MessageID for ReaderOptions

### DIFF
--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -402,7 +402,7 @@ func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	}
 
 	// custom start message ID
-	myStartMsgId := &myMessageID{
+	myStartMsgID := &myMessageID{
 		data: msgIDs[4].Serialize(),
 	}
 
@@ -411,7 +411,7 @@ func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	assert.NotPanics(t, func() {
 		reader, err = client.CreateReader(ReaderOptions{
 			Topic:          topic,
-			StartMessageID: myStartMsgId,
+			StartMessageID: myStartMsgID,
 		})
 	})
 
@@ -430,7 +430,7 @@ func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	// create reader on 5th message (included)
 	readerInclusive, err := client.CreateReader(ReaderOptions{
 		Topic:                   topic,
-		StartMessageID:          myStartMsgId,
+		StartMessageID:          myStartMsgID,
 		StartMessageIDInclusive: true,
 	})
 

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -362,3 +362,87 @@ func TestReaderHasNext(t *testing.T) {
 
 	assert.Equal(t, 10, i)
 }
+
+type myMessageID struct {
+	data []byte
+}
+
+func (id *myMessageID) Serialize() []byte {
+	return id.data
+}
+
+func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	ctx := context.Background()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 10 messages
+	msgIDs := [10]MessageID{}
+	for i := 0; i < 10; i++ {
+		msgID, err := producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, msgID)
+		msgIDs[i] = msgID
+	}
+
+	// custom start message ID
+	myStartMsgId := &myMessageID{
+		data: msgIDs[4].Serialize(),
+	}
+
+	// attempt to create reader on 5th message (not included)
+	var reader Reader
+	assert.NotPanics(t, func() {
+		reader, err = client.CreateReader(ReaderOptions{
+			Topic:          topic,
+			StartMessageID: myStartMsgId,
+		})
+	})
+
+	assert.Nil(t, err)
+	defer reader.Close()
+
+	// receive the remaining 5 messages
+	for i := 5; i < 10; i++ {
+		msg, err := reader.Next(context.Background())
+		assert.NoError(t, err)
+
+		expectMsg := fmt.Sprintf("hello-%d", i)
+		assert.Equal(t, []byte(expectMsg), msg.Payload())
+	}
+
+	// create reader on 5th message (included)
+	readerInclusive, err := client.CreateReader(ReaderOptions{
+		Topic:                   topic,
+		StartMessageID:          myStartMsgId,
+		StartMessageIDInclusive: true,
+	})
+
+	assert.Nil(t, err)
+	defer readerInclusive.Close()
+
+	// receive the remaining 6 messages
+	for i := 4; i < 10; i++ {
+		msg, err := readerInclusive.Next(context.Background())
+		assert.NoError(t, err)
+
+		expectMsg := fmt.Sprintf("hello-%d", i)
+		assert.Equal(t, []byte(expectMsg), msg.Payload())
+	}
+}


### PR DESCRIPTION
Fixes #304 


### Motivation

User of the client's client's [CreateReader](https://github.com/apache/pulsar-client-go/blob/master/pulsar/client.go#L109) API can use a custom type satisfying the [MessageID](https://github.com/apache/pulsar-client-go/blob/master/pulsar/message.go#L108) interface, when using it as a value for `StartMessageID` in [ReaderOptions](https://github.com/apache/pulsar-client-go/blob/master/pulsar/reader.go#L48) argument for the mentioned API.

The current reader creation does an untested type assertion here, when preparing the `consumerOptions` needed for creating a `partitionConsumer`.
https://github.com/apache/pulsar-client-go/blob/master/pulsar/reader_impl.go#L64 

This assertion of `MessageID` as `*messageID` will fail unless an instance of `MessageID` is created from one of these exported APIs because `messageID` is unexported
https://github.com/apache/pulsar-client-go/blob/master/pulsar/message.go#L114-#L126
Note: `newMessageID` returns `*messageID` which satisfies `MessageID` interface as well.


### Modifications

Test the type assertion of `MessageID` as `*messageID`, if it fails, re-create a new `MessageID` using this
https://github.com/apache/pulsar-client-go/blob/975eb3781644ebe588fc142e53eadf39fe50341a/pulsar/impl_message.go#L97
This will ensure that the custom type can be re-created as a `*messageID` which can be used by `partitionConsumerOpts`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

 Added unit test `TestReaderOnSpecificMessageWithCustomMessageID` in `github.com/apache/pulsar-client-go/pulsar` package.
Test uses a custom StartMessageID in ReaderOptions while creating a new reader to read from a specific message ID, rather than the pre-canned earliest/latest options.

CI script test result snippet below.
  ```bash
-- Ready to start tests
+ go test -race -coverprofile=/tmp/coverage -timeout=20m ./...
?       github.com/apache/pulsar-client-go/examples/consumer    [no test files]
?       github.com/apache/pulsar-client-go/examples/consumer-listener   [no test files]
?       github.com/apache/pulsar-client-go/examples/producer    [no test files]
?       github.com/apache/pulsar-client-go/examples/reader      [no test files]
ok      github.com/apache/pulsar-client-go/integration-tests    1.732s  coverage: 0.0% of statements
?       github.com/apache/pulsar-client-go/perf [no test files]

ok      github.com/apache/pulsar-client-go/pulsar       141.199s        coverage: 81.2% of statements
ok      github.com/apache/pulsar-client-go/pulsar/internal      1.658s  coverage: 30.7% of statements
ok      github.com/apache/pulsar-client-go/pulsar/internal/auth 1.028s  coverage: 31.3% of statements
ok      github.com/apache/pulsar-client-go/pulsar/internal/compression  1.041s  coverage: 55.7% of statements
?       github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto [no test files]
+ go tool cover -html=/tmp/coverage -o coverage.html
  ```

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: yes
  - The schema: no
  - The default values of configurations: no
  - The wire protocol:  no

### Documentation

  - Does this pull request introduce a new feature? : No
