### PR TITLE
Remove MessageChannel from consumer options

### DIFF
--- a/examples/consumer-listener/consumer-listener.go
+++ b/examples/consumer-listener/consumer-listener.go
@@ -42,7 +42,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	defer consumer.Close()
 
 	// Receive messages from channel. The channel returns a struct which contains message and the consumer from where

--- a/examples/consumer-listener/consumer-listener.go
+++ b/examples/consumer-listener/consumer-listener.go
@@ -32,15 +32,11 @@ func main() {
 
 	defer client.Close()
 
-	channel := make(chan pulsar.ConsumerMessage, 100)
-
 	options := pulsar.ConsumerOptions{
 		Topic:            "topic-1",
 		SubscriptionName: "my-subscription",
 		Type:             pulsar.Shared,
 	}
-
-	options.MessageChannel = channel
 
 	consumer, err := client.Subscribe(options)
 	if err != nil {
@@ -52,7 +48,7 @@ func main() {
 	// Receive messages from channel. The channel returns a struct which contains message and the consumer from where
 	// the message was received. It's not necessary here since we have 1 single consumer, but the channel could be
 	// shared across multiple consumers as well
-	for cm := range channel {
+	for cm := range consumer.Chan() {
 		msg := cm.Message
 		fmt.Printf("Received message  msgId: %v -- content: '%s'\n",
 			msg.ID(), string(msg.Payload()))

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -107,10 +107,6 @@ type ConsumerOptions struct {
 	// By default is nil and there's no DLQ
 	DLQ *DLQPolicy
 
-	// Sets a `MessageChannel` for the consumer
-	// When a message is received, it will be pushed to the channel for consumption
-	MessageChannel chan ConsumerMessage
-
 	// Sets the size of the consumer receive queue.
 	// The consumer receive queue controls how many messages can be accumulated by the `Consumer` before the
 	// application calls `Consumer.receive()`. Using a higher value could potentially increase the consumer

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -74,11 +74,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		options.ReceiverQueueSize = 1000
 	}
 
-	// did the user pass in a message channel?
-	messageCh := options.MessageChannel
-	if options.MessageChannel == nil {
-		messageCh = make(chan ConsumerMessage, 10)
-	}
+	messageCh := make(chan ConsumerMessage, 10)
 
 	dlq, err := newDlqRouter(client, options.DLQ)
 	if err != nil {


### PR DESCRIPTION
### Motivation

It is a dangerous operation to expose the `MessageChannel` to the user, and the user may write data and other series of custom operations to the chan. This may interfere with `messageCh` correctly receiving data from the broker. We should recommend users to use `consumer.Chan()` instead of it, instead of directly exposing a readable and writable channel

### Modifications

remove MessageChannel from consumer options

