### PR TITLE
Fix CompressMaxSize() for ZLib provider

### DIFF
--- a/pulsar/internal/compression/zlib.go
+++ b/pulsar/internal/compression/zlib.go
@@ -31,7 +31,9 @@ func NewZLibProvider() Provider {
 }
 
 func (zlibProvider) CompressMaxSize(originalSize int) int {
-	return int(float32(originalSize) * 1.10)
+	// Use formula from ZLib: https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/deflate.c#L659
+	return originalSize +
+		((originalSize + 7) >> 3) + ((originalSize + 63) >> 6) + 11
 }
 
 func (zlibProvider) Compress(dst, src []byte) []byte {


### PR DESCRIPTION
### Motivation

As seen in tests for #310, there's a panic caused by having the wrong max buffer size estimate from the ZLib provider, because we're not considering the headers size for incompressible data.