### PR TITLE
Reduce the size of the MessageID structs by one word on 64-bit arch

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -459,7 +459,7 @@ func (c *consumer) messageID(msgID MessageID) (*messageID, bool) {
 		return nil, false
 	}
 
-	partition := mid.partitionIdx
+	partition := int(mid.partitionIdx)
 	// did we receive a valid partition index?
 	if partition < 0 || partition >= len(c.consumers) {
 		c.log.Warnf("invalid partition index %d expected a partition between [0-%d]",

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -83,7 +83,7 @@ type partitionConsumer struct {
 	topic        string
 	name         string
 	consumerID   uint64
-	partitionIdx int
+	partitionIdx int32
 
 	// shared channel
 	messageCh chan ConsumerMessage
@@ -120,7 +120,7 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 		topic:                options.topic,
 		name:                 options.consumerName,
 		consumerID:           client.rpcClient.NewConsumerID(),
-		partitionIdx:         options.partitionIdx,
+		partitionIdx:         int32(options.partitionIdx),
 		eventsCh:             make(chan interface{}, 3),
 		queueSize:            int32(options.receiverQueueSize),
 		queueCh:              make(chan []*message, options.receiverQueueSize),
@@ -400,7 +400,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		msgID := newTrackingMessageID(
 			int64(pbMsgID.GetLedgerId()),
 			int64(pbMsgID.GetEntryId()),
-			i,
+			int32(i),
 			pc.partitionIdx,
 			ackTracker)
 
@@ -923,7 +923,7 @@ func convertToMessageID(id *pb.MessageIdData) *messageID {
 	}
 
 	if id.BatchIndex != nil {
-		msgID.batchIdx = int(*id.BatchIndex)
+		msgID.batchIdx = *id.BatchIndex
 	}
 
 	return msgID

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -33,8 +33,8 @@ func TestMessageId(t *testing.T) {
 
 	assert.Equal(t, int64(1), id2.(*messageID).ledgerID)
 	assert.Equal(t, int64(2), id2.(*messageID).entryID)
-	assert.Equal(t, 3, id2.(*messageID).batchIdx)
-	assert.Equal(t, 4, id2.(*messageID).partitionIdx)
+	assert.Equal(t, int32(3), id2.(*messageID).batchIdx)
+	assert.Equal(t, int32(4), id2.(*messageID).partitionIdx)
 
 	id, err = DeserializeMessageID(nil)
 	assert.Error(t, err)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -69,7 +69,7 @@ type partitionProducer struct {
 	pendingQueue     internal.BlockingQueue
 	lastSequenceID   int64
 
-	partitionIdx int
+	partitionIdx int32
 }
 
 func newPartitionProducer(client *client, topic string, options *ProducerOptions, partitionIdx int) (
@@ -105,7 +105,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 		publishSemaphore: internal.NewSemaphore(int32(maxPendingMessages)),
 		pendingQueue:     internal.NewBlockingQueue(maxPendingMessages),
 		lastSequenceID:   -1,
-		partitionIdx:     partitionIdx,
+		partitionIdx:     int32(partitionIdx),
 	}
 
 	if options.Name != "" {
@@ -442,7 +442,7 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 			msgID := newMessageID(
 				int64(response.MessageId.GetLedgerId()),
 				int64(response.MessageId.GetEntryId()),
-				idx,
+				int32(idx),
 				p.partitionIdx,
 			)
 			sr.callback(msgID, sr.msg, nil)


### PR DESCRIPTION
An int occupies one word of memory; on 64-bit machines, this is 8 bytes.

As a result, the messageID struct is 56-bytes:
* ledgerID - 8 bytes
* entryID - 8 bytes
* batchIdx - 8 bytes
* partitionIdx - 8 bytes
* tracker - 8 bytes
* consumer - 16 bytes (1 word for type, 1 word for data address)

This commit changes the type of batchIdx and partitionIdx fields to int32,
which saves one word of memory and maintains alignment of struct fields.

Reducing the size of the MessageID structs is important as they are
currently allocated on the heap for every message produced or consumed.

Signed-off-by: Daniel Ferstay <dferstay@splunk.com>

### Motivation

The motivation is to reduce the amount of heap allocated memory for each message produced and consumed.

### Modifications

This commit changes the type batchIdx and partitionIdx fields to int32,
which saves one word of memory and maintains alignment of struct fields.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests that produce or consume messages.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
