### PR TITLE
Do not allocate MessageIDs on the heap

### DIFF
--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -117,9 +117,9 @@ func (c *multiTopicConsumer) Ack(msg Message) {
 
 // Ack the consumption of a single message, identified by its MessageID
 func (c *multiTopicConsumer) AckID(msgID MessageID) {
-	mid, ok := msgID.(*messageID)
+	mid, ok := msgID.(messageID)
 	if !ok {
-		c.log.Warnf("invalid message id type")
+		c.log.Warnf("invalid message id type %T", msgID)
 		return
 	}
 
@@ -136,9 +136,9 @@ func (c *multiTopicConsumer) Nack(msg Message) {
 }
 
 func (c *multiTopicConsumer) NackID(msgID MessageID) {
-	mid, ok := msgID.(*messageID)
+	mid, ok := msgID.(messageID)
 	if !ok {
-		c.log.Warnf("invalid message id type")
+		c.log.Warnf("invalid message id type %T", msgID)
 		return
 	}
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -63,7 +63,7 @@ type partitionConsumerOpts struct {
 	nackRedeliveryDelay        time.Duration
 	metadata                   map[string]string
 	replicateSubscriptionState bool
-	startMessageID             *messageID
+	startMessageID             messageID
 	startMessageIDInclusive    bool
 	subscriptionMode           subscriptionMode
 	readCompacted              bool
@@ -94,13 +94,13 @@ type partitionConsumer struct {
 	// the size of the queue channel for buffering messages
 	queueSize       int32
 	queueCh         chan []*message
-	startMessageID  *messageID
-	lastDequeuedMsg *messageID
+	startMessageID  messageID
+	lastDequeuedMsg messageID
 
 	eventsCh     chan interface{}
 	connectedCh  chan struct{}
 	closeCh      chan struct{}
-	clearQueueCh chan func(id *messageID)
+	clearQueueCh chan func(id messageID)
 
 	nackTracker *negativeAcksTracker
 	dlq         *dlqRouter
@@ -128,7 +128,7 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 		connectedCh:          make(chan struct{}),
 		messageCh:            messageCh,
 		closeCh:              make(chan struct{}),
-		clearQueueCh:         make(chan func(id *messageID)),
+		clearQueueCh:         make(chan func(id messageID)),
 		compressionProviders: make(map[pb.CompressionType]compression.Provider),
 		dlq:                  dlq,
 		log:                  log.WithField("topic", options.topic),
@@ -192,7 +192,7 @@ func (pc *partitionConsumer) internalUnsubscribe(unsub *unsubscribeRequest) {
 	pc.state = consumerClosed
 }
 
-func (pc *partitionConsumer) getLastMessageID() (*messageID, error) {
+func (pc *partitionConsumer) getLastMessageID() (messageID, error) {
 	req := &getLastMsgIDRequest{doneCh: make(chan struct{})}
 	pc.eventsCh <- req
 
@@ -220,8 +220,8 @@ func (pc *partitionConsumer) internalGetLastMessageID(req *getLastMsgIDRequest) 
 	}
 }
 
-func (pc *partitionConsumer) AckID(msgID *messageID) {
-	if msgID != nil && msgID.ack() {
+func (pc *partitionConsumer) AckID(msgID messageID) {
+	if !msgID.IsZero() && msgID.ack() {
 		req := &ackRequest{
 			msgID: msgID,
 		}
@@ -229,7 +229,7 @@ func (pc *partitionConsumer) AckID(msgID *messageID) {
 	}
 }
 
-func (pc *partitionConsumer) NackID(msgID *messageID) {
+func (pc *partitionConsumer) NackID(msgID messageID) {
 	pc.nackTracker.Add(msgID)
 }
 
@@ -268,7 +268,7 @@ func (pc *partitionConsumer) Close() {
 	<-req.doneCh
 }
 
-func (pc *partitionConsumer) Seek(msgID *messageID) error {
+func (pc *partitionConsumer) Seek(msgID messageID) error {
 	req := &seekRequest{
 		doneCh: make(chan struct{}),
 		msgID:  msgID,
@@ -450,8 +450,8 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 	return nil
 }
 
-func (pc *partitionConsumer) messageShouldBeDiscarded(msgID *messageID) bool {
-	if pc.startMessageID == nil {
+func (pc *partitionConsumer) messageShouldBeDiscarded(msgID messageID) bool {
+	if pc.startMessageID.IsZero() {
 		return false
 	}
 
@@ -571,7 +571,7 @@ func (pc *partitionConsumer) dispatcher() {
 		case clearQueueCb := <-pc.clearQueueCh:
 			// drain the message queue on any new connection by sending a
 			// special nil message to the channel so we know when to stop dropping messages
-			var nextMessageInQueue *messageID
+			var nextMessageInQueue messageID
 			go func() {
 				pc.queueCh <- nil
 			}()
@@ -579,8 +579,8 @@ func (pc *partitionConsumer) dispatcher() {
 				// the queue has been drained
 				if m == nil {
 					break
-				} else if nextMessageInQueue == nil {
-					nextMessageInQueue = m[0].msgID.(*messageID)
+				} else if nextMessageInQueue.IsZero() {
+					nextMessageInQueue = m[0].msgID.(messageID)
 				}
 			}
 
@@ -590,7 +590,7 @@ func (pc *partitionConsumer) dispatcher() {
 }
 
 type ackRequest struct {
-	msgID *messageID
+	msgID messageID
 }
 
 type unsubscribeRequest struct {
@@ -608,13 +608,13 @@ type redeliveryRequest struct {
 
 type getLastMsgIDRequest struct {
 	doneCh chan struct{}
-	msgID  *messageID
+	msgID  messageID
 	err    error
 }
 
 type seekRequest struct {
 	doneCh chan struct{}
-	msgID  *messageID
+	msgID  messageID
 	err    error
 }
 
@@ -794,15 +794,15 @@ func (pc *partitionConsumer) grabConn() error {
 	}
 }
 
-func (pc *partitionConsumer) clearQueueAndGetNextMessage() *messageID {
+func (pc *partitionConsumer) clearQueueAndGetNextMessage() messageID {
 	if pc.state != consumerReady {
-		return nil
+		return messageID{}
 	}
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	var msgID *messageID
+	var msgID messageID
 
-	pc.clearQueueCh <- func(id *messageID) {
+	pc.clearQueueCh <- func(id messageID) {
 		msgID = id
 		wg.Done()
 	}
@@ -815,12 +815,12 @@ func (pc *partitionConsumer) clearQueueAndGetNextMessage() *messageID {
  * Clear the internal receiver queue and returns the message id of what was the 1st message in the queue that was
  * not seen by the application
  */
-func (pc *partitionConsumer) clearReceiverQueue() *messageID {
+func (pc *partitionConsumer) clearReceiverQueue() messageID {
 	nextMessageInQueue := pc.clearQueueAndGetNextMessage()
 
-	if nextMessageInQueue != nil {
+	if !nextMessageInQueue.IsZero() {
 		return getPreviousMessage(nextMessageInQueue)
-	} else if pc.lastDequeuedMsg != nil {
+	} else if !pc.lastDequeuedMsg.IsZero() {
 		// If the queue was empty we need to restart from the message just after the last one that has been dequeued
 		// in the past
 		return pc.lastDequeuedMsg
@@ -830,9 +830,9 @@ func (pc *partitionConsumer) clearReceiverQueue() *messageID {
 	}
 }
 
-func getPreviousMessage(mid *messageID) *messageID {
+func getPreviousMessage(mid messageID) messageID {
 	if mid.batchIdx >= 0 {
-		return &messageID{
+		return messageID{
 			ledgerID:     mid.ledgerID,
 			entryID:      mid.entryID,
 			batchIdx:     mid.batchIdx - 1,
@@ -841,7 +841,7 @@ func getPreviousMessage(mid *messageID) *messageID {
 	}
 
 	// Get on previous message in previous entry
-	return &messageID{
+	return messageID{
 		ledgerID:     mid.ledgerID,
 		entryID:      mid.entryID - 1,
 		batchIdx:     mid.batchIdx,
@@ -901,8 +901,8 @@ func (pc *partitionConsumer) discardCorruptedMessage(msgID *pb.MessageIdData,
 		})
 }
 
-func convertToMessageIDData(msgID *messageID) *pb.MessageIdData {
-	if msgID == nil {
+func convertToMessageIDData(msgID messageID) *pb.MessageIdData {
+	if msgID.IsZero() {
 		return nil
 	}
 
@@ -912,16 +912,15 @@ func convertToMessageIDData(msgID *messageID) *pb.MessageIdData {
 	}
 }
 
-func convertToMessageID(id *pb.MessageIdData) *messageID {
+func convertToMessageID(id *pb.MessageIdData) messageID {
 	if id == nil {
-		return nil
+		return messageID{}
 	}
 
-	msgID := &messageID{
+	msgID := messageID{
 		ledgerID: int64(*id.LedgerId),
 		entryID:  int64(*id.EntryId),
 	}
-
 	if id.BatchIndex != nil {
 		msgID.batchIdx = *id.BatchIndex
 	}

--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -44,11 +44,11 @@ func TestSingleMessageIDNoAckTracker(t *testing.T) {
 	// ensure the tracker was set on the message id
 	messages := <-pc.queueCh
 	for _, m := range messages {
-		assert.Nil(t, m.ID().(*messageID).tracker)
+		assert.Nil(t, m.ID().(messageID).tracker)
 	}
 
 	// ack the message id
-	pc.AckID(messages[0].msgID.(*messageID))
+	pc.AckID(messages[0].msgID.(messageID))
 
 	select {
 	case <-eventsCh:
@@ -73,11 +73,11 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 	// ensure the tracker was set on the message id
 	messages := <-pc.queueCh
 	for _, m := range messages {
-		assert.Nil(t, m.ID().(*messageID).tracker)
+		assert.Nil(t, m.ID().(messageID).tracker)
 	}
 
 	// ack the message id
-	pc.AckID(messages[0].msgID.(*messageID))
+	pc.AckID(messages[0].msgID.(messageID))
 
 	select {
 	case <-eventsCh:
@@ -102,12 +102,12 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 	// ensure the tracker was set on the message id
 	messages := <-pc.queueCh
 	for _, m := range messages {
-		assert.NotNil(t, m.ID().(*messageID).tracker)
+		assert.NotNil(t, m.ID().(messageID).tracker)
 	}
 
 	// ack all message ids except the last one
 	for i := 0; i < 9; i++ {
-		pc.AckID(messages[i].msgID.(*messageID))
+		pc.AckID(messages[i].msgID.(messageID))
 	}
 
 	select {
@@ -117,7 +117,7 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 	}
 
 	// ack last message
-	pc.AckID(messages[9].msgID.(*messageID))
+	pc.AckID(messages[9].msgID.(messageID))
 
 	select {
 	case <-eventsCh:

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -161,9 +161,9 @@ func (c *regexConsumer) Ack(msg Message) {
 
 // Ack the consumption of a single message, identified by its MessageID
 func (c *regexConsumer) AckID(msgID MessageID) {
-	mid, ok := msgID.(*messageID)
+	mid, ok := msgID.(messageID)
 	if !ok {
-		c.log.Warnf("invalid message id type")
+		c.log.Warnf("invalid message id type %T", msgID)
 		return
 	}
 
@@ -180,9 +180,9 @@ func (c *regexConsumer) Nack(msg Message) {
 }
 
 func (c *regexConsumer) NackID(msgID MessageID) {
-	mid, ok := msgID.(*messageID)
+	mid, ok := msgID.(messageID)
 	if !ok {
-		c.log.Warnf("invalid message id type")
+		c.log.Warnf("invalid message id type %T", msgID)
 		return
 	}
 

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -31,10 +31,10 @@ func TestMessageId(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, id2)
 
-	assert.Equal(t, int64(1), id2.(*messageID).ledgerID)
-	assert.Equal(t, int64(2), id2.(*messageID).entryID)
-	assert.Equal(t, int32(3), id2.(*messageID).batchIdx)
-	assert.Equal(t, int32(4), id2.(*messageID).partitionIdx)
+	assert.Equal(t, int64(1), id2.(messageID).ledgerID)
+	assert.Equal(t, int64(2), id2.(messageID).entryID)
+	assert.Equal(t, int32(3), id2.(messageID).batchIdx)
+	assert.Equal(t, int32(4), id2.(messageID).partitionIdx)
 
 	id, err = DeserializeMessageID(nil)
 	assert.Error(t, err)
@@ -82,7 +82,7 @@ func TestAckingMessageIDBatchOne(t *testing.T) {
 
 func TestAckingMessageIDBatchTwo(t *testing.T) {
 	tracker := newAckTracker(2)
-	ids := []*messageID{
+	ids := []messageID{
 		newTrackingMessageID(1, 1, 0, 0, tracker),
 		newTrackingMessageID(1, 1, 1, 0, tracker),
 	}
@@ -93,7 +93,7 @@ func TestAckingMessageIDBatchTwo(t *testing.T) {
 
 	// try reverse order
 	tracker = newAckTracker(2)
-	ids = []*messageID{
+	ids = []messageID{
 		newTrackingMessageID(1, 1, 0, 0, tracker),
 		newTrackingMessageID(1, 1, 1, 0, tracker),
 	}

--- a/pulsar/negative_acks_tracker.go
+++ b/pulsar/negative_acks_tracker.go
@@ -51,7 +51,7 @@ func newNegativeAcksTracker(rc redeliveryConsumer, delay time.Duration) *negativ
 	return t
 }
 
-func (t *negativeAcksTracker) Add(msgID *messageID) {
+func (t *negativeAcksTracker) Add(msgID messageID) {
 	// Always clear up the batch index since we want to track the nack
 	// for the entire batch
 	batchMsgID := messageID{

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -76,13 +76,13 @@ func TestNacksTracker(t *testing.T) {
 	nmc := newNackMockedConsumer()
 	nacks := newNegativeAcksTracker(nmc, testNackDelay)
 
-	nacks.Add(&messageID{
+	nacks.Add(messageID{
 		ledgerID: 1,
 		entryID:  1,
 		batchIdx: 1,
 	})
 
-	nacks.Add(&messageID{
+	nacks.Add(messageID{
 		ledgerID: 2,
 		entryID:  2,
 		batchIdx: 1,
@@ -107,25 +107,25 @@ func TestNacksWithBatchesTracker(t *testing.T) {
 	nmc := newNackMockedConsumer()
 	nacks := newNegativeAcksTracker(nmc, testNackDelay)
 
-	nacks.Add(&messageID{
+	nacks.Add(messageID{
 		ledgerID: 1,
 		entryID:  1,
 		batchIdx: 1,
 	})
 
-	nacks.Add(&messageID{
+	nacks.Add(messageID{
 		ledgerID: 1,
 		entryID:  1,
 		batchIdx: 2,
 	})
 
-	nacks.Add(&messageID{
+	nacks.Add(messageID{
 		ledgerID: 1,
 		entryID:  1,
 		batchIdx: 3,
 	})
 
-	nacks.Add(&messageID{
+	nacks.Add(messageID{
 		ledgerID: 2,
 		entryID:  2,
 		batchIdx: 1,

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -322,7 +322,7 @@ func TestFlushInProducer(t *testing.T) {
 		assert.Nil(t, err)
 		msgCount++
 
-		msgID := msg.ID().(*messageID)
+		msgID := msg.ID().(messageID)
 		// Since messages are batched, they will be sharing the same ledgerId/entryId
 		if ledgerID == -1 {
 			ledgerID = msgID.ledgerID


### PR DESCRIPTION
Passing a function parameter by pointer (or writing a pointer into a
channel) will cause the Go escape analysis to allocate the parameter on
the heap.

This change passes messageID struct instances by value instead of by
pointer; this keeps messageID structs on the stack.

Each message produced or consumed by the library is associated with
a MessageID; keeping instances of the MessageID structure on the stack
reduces heap allocation and associated GC cost.

Signed-off-by: Daniel Ferstay <dferstay@splunk.com>

### Motivation

Reduce the amount of per-Message heap allocation performed by the library

### Modifications

This change modifies the Consumer and Producer code paths to pass messageID struct instances by value instead of by
pointer; this keeps the messageID structures on the stack and off of the heap.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as:
* pulsar/consumer_multitopic_test.go
* pulsar/consumer_partition_test.go
* pulsar/consumer_regex_test.go
* pulsar/consumer_test.go
* pulsar/impl_message_test.go
* pulsar/negative_acks_tracker_test.go
* pulsar/producer_test.go
* pulsar/reader_test.go

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
