### PR TITLE
support set logger of pulsar

### DIFF
--- a/examples/consumer-listener/consumer-listener.go
+++ b/examples/consumer-listener/consumer-listener.go
@@ -22,7 +22,19 @@ import (
 	"log"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/natefinch/lumberjack"
 )
+
+func init() {
+	logger := pulsar.GetLogger()
+	logger.SetOutput(&lumberjack.Logger{
+		Filename:   "pulsar.log",
+		MaxSize:    1024, // megabytes
+		MaxBackups: 3,
+		MaxAge:     5,
+		Compress:   true,
+	})
+}
 
 func main() {
 	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: "pulsar://localhost:6650"})

--- a/examples/consumer/consumer.go
+++ b/examples/consumer/consumer.go
@@ -23,7 +23,19 @@ import (
 	"log"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/natefinch/lumberjack"
 )
+
+func init() {
+	logger := pulsar.GetLogger()
+	logger.SetOutput(&lumberjack.Logger{
+		Filename:   "pulsar.log",
+		MaxSize:    1024, // megabytes
+		MaxBackups: 3,
+		MaxAge:     5,
+		Compress:   true,
+	})
+}
 
 func main() {
 	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: "pulsar://localhost:6650"})

--- a/examples/producer/producer.go
+++ b/examples/producer/producer.go
@@ -23,7 +23,19 @@ import (
 	"log"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/natefinch/lumberjack"
 )
+
+func init() {
+	logger := pulsar.GetLogger()
+	logger.SetOutput(&lumberjack.Logger{
+		Filename:   "pulsar.log",
+		MaxSize:    1024, // megabytes
+		MaxBackups: 3,
+		MaxAge:     5,
+		Compress:   true,
+	})
+}
 
 func main() {
 	client, err := pulsar.NewClient(pulsar.ClientOptions{

--- a/examples/reader/reader.go
+++ b/examples/reader/reader.go
@@ -23,7 +23,19 @@ import (
 	"log"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/natefinch/lumberjack"
 )
+
+func init() {
+	logger := pulsar.GetLogger()
+	logger.SetOutput(&lumberjack.Logger{
+		Filename:   "pulsar.log",
+		MaxSize:    1024, // megabytes
+		MaxBackups: 3,
+		MaxAge:     5,
+		Compress:   true,
+	})
+}
 
 func main() {
 	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: "pulsar://localhost:6650"})

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/yahoo/athenz v1.8.55
+	github.com/natefinch/lumberjack v2.0.0+incompatible
 )

--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -20,8 +20,15 @@ package pulsar
 import (
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/apache/pulsar-client-go/pulsar/internal/auth"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
+
+func GetLogger() *log.Logger {
+	return logger.Logger
+}
 
 func NewClient(options ClientOptions) (Client, error) {
 	return newClient(options)

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -25,10 +25,9 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/apache/pulsar-client-go/pulsar/internal/auth"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 )
 
@@ -51,7 +50,7 @@ func newClient(options ClientOptions) (Client, error) {
 
 	url, err := url.Parse(options.URL)
 	if err != nil {
-		log.WithError(err).Error("Failed to parse service URL")
+		logger.Logger.WithError(err).Error("Failed to parse service URL")
 		return nil, newError(ResultInvalidConfiguration, "Invalid service URL")
 	}
 

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 )
 
@@ -135,7 +136,7 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 		closeCh:                   make(chan struct{}),
 		errorCh:                   make(chan error),
 		dlq:                       dlq,
-		log:                       log.WithField("topic", topic),
+		log:                       logger.Logger.WithField("topic", topic),
 	}
 
 	if options.Name != "" {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pkgerrors "github.com/pkg/errors"
 
 	log "github.com/sirupsen/logrus"
@@ -51,7 +52,7 @@ func newMultiTopicConsumer(client *client, options ConsumerOptions, topics []str
 		consumers: make(map[string]Consumer, len(topics)),
 		closeCh:   make(chan struct{}),
 		dlq:       dlq,
-		log:       &log.Entry{},
+		log:       log.NewEntry(logger.Logger),
 	}
 
 	var errs error

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/apache/pulsar-client-go/pulsar/internal/compression"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 )
 
@@ -131,14 +132,14 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 		clearQueueCh:         make(chan func(id *messageID)),
 		compressionProviders: make(map[pb.CompressionType]compression.Provider),
 		dlq:                  dlq,
-		log:                  log.WithField("topic", options.topic),
+		log:                  logger.Logger.WithField("topic", options.topic),
 	}
 	pc.log = pc.log.WithField("name", pc.name).WithField("subscription", options.subscription)
 	pc.nackTracker = newNegativeAcksTracker(pc, options.nackRedeliveryDelay)
 
 	err := pc.grabConn()
 	if err != nil {
-		log.WithError(err).Errorf("Failed to create consumer")
+		logger.Logger.WithError(err).Errorf("Failed to create consumer")
 		return nil, err
 	}
 	pc.log.Info("Created consumer")

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -31,6 +31,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
 
 const (
@@ -78,7 +79,7 @@ func newRegexConsumer(c *client, opts ConsumerOptions, tn *internal.TopicName, p
 
 		closeCh: make(chan struct{}),
 
-		log: log.WithField("topic", tn.Name),
+		log: logger.Logger.WithField("topic", tn.Name),
 	}
 
 	topics, err := rc.topics()
@@ -263,7 +264,7 @@ func (c *regexConsumer) discover() {
 	newTopics := topicsDiff(topics, known)
 	staleTopics := topicsDiff(known, topics)
 
-	if log.GetLevel() == log.DebugLevel {
+	if logger.Logger.GetLevel() == log.DebugLevel {
 		l := c.log.WithFields(log.Fields{
 			"new_topics": newTopics,
 			"old_topics": staleTopics,
@@ -289,7 +290,7 @@ func (c *regexConsumer) knownTopics() []string {
 }
 
 func (c *regexConsumer) subscribe(topics []string, dlq *dlqRouter) {
-	if log.GetLevel() == log.DebugLevel {
+	if logger.Logger.GetLevel() == log.DebugLevel {
 		c.log.WithField("topics", topics).Debug("subscribe")
 	}
 	consumers := make(map[string]Consumer, len(topics))
@@ -309,7 +310,7 @@ func (c *regexConsumer) subscribe(topics []string, dlq *dlqRouter) {
 }
 
 func (c *regexConsumer) unsubscribe(topics []string) {
-	if log.GetLevel() == log.DebugLevel {
+	if logger.Logger.GetLevel() == log.DebugLevel {
 		c.log.WithField("topics", topics).Debug("unsubscribe")
 	}
 	consumers := make(map[string]Consumer, len(topics))
@@ -323,7 +324,7 @@ func (c *regexConsumer) unsubscribe(topics []string) {
 	c.consumersLock.Unlock()
 
 	for t, consumer := range consumers {
-		log.Debugf("unsubscribe from topic=%s subscription=%s", t, c.options.SubscriptionName)
+		logger.Logger.Debugf("unsubscribe from topic=%s subscription=%s", t, c.options.SubscriptionName)
 		if err := consumer.Unsubscribe(); err != nil {
 			c.log.Warnf("unable to unsubscribe from topic=%s subscription=%s",
 				t, c.options.SubscriptionName)

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -20,13 +20,13 @@ package pulsar
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,7 +72,7 @@ func TestProducerConsumer(t *testing.T) {
 				"key-1": "pulsar-1",
 			},
 		}); err != nil {
-			log.Fatal(err)
+			logger.Logger.Fatal(err)
 		}
 	}
 
@@ -80,7 +80,7 @@ func TestProducerConsumer(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		msg, err := consumer.Receive(context.Background())
 		if err != nil {
-			log.Fatal(err)
+			logger.Logger.Fatal(err)
 		}
 
 		expectMsg := fmt.Sprintf("hello-%d", i)
@@ -444,7 +444,7 @@ func TestConsumerShared(t *testing.T) {
 		if _, err := producer.Send(context.Background(), &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}); err != nil {
-			log.Fatal(err)
+			logger.Logger.Fatal(err)
 		}
 		fmt.Println("sending message:", fmt.Sprintf("hello-%d", i))
 	}
@@ -991,7 +991,7 @@ func TestDLQ(t *testing.T) {
 		if _, err := producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}); err != nil {
-			log.Fatal(err)
+			logger.Logger.Fatal(err)
 		}
 	}
 
@@ -1098,7 +1098,7 @@ func TestDLQMultiTopics(t *testing.T) {
 		if _, err := producers[i].Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}); err != nil {
-			log.Fatal(err)
+			logger.Logger.Fatal(err)
 		}
 	}
 
@@ -1178,7 +1178,7 @@ func TestGetDeliveryCount(t *testing.T) {
 		if _, err := producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}); err != nil {
-			log.Fatal(err)
+			logger.Logger.Fatal(err)
 		}
 	}
 

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -52,7 +53,7 @@ func newDlqRouter(client Client, policy *DLQPolicy) (*dlqRouter, error) {
 
 		r.messageCh = make(chan ConsumerMessage)
 		r.closeCh = make(chan interface{}, 1)
-		r.log = log.WithField("dlq-topic", policy.Topic)
+		r.log = logger.Logger.WithField("dlq-topic", policy.Topic)
 		go r.run()
 	}
 	return r, nil

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -21,10 +21,9 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/compression"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/gogo/protobuf/proto"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -161,7 +160,7 @@ func (bb *BatchBuilder) Flush() (batchData Buffer, sequenceID uint64, callbacks 
 		// No-Op for empty batch
 		return nil, 0, nil
 	}
-	log.Debug("BatchBuilder flush: messages: ", bb.numMessages)
+	logger.Logger.Debug("BatchBuilder flush: messages: ", bb.numMessages)
 
 	bb.msgMetadata.NumMessagesInBatch = proto.Int32(int32(bb.numMessages))
 	bb.cmdSend.Send.NumMessages = proto.Int32(int32(bb.numMessages))
@@ -197,7 +196,7 @@ func getCompressionProvider(compressionType pb.CompressionType,
 	case pb.CompressionType_ZSTD:
 		return compression.NewZStdProvider(level)
 	default:
-		log.Panic("unsupported compression type")
+		logger.Logger.Panic("unsupported compression type")
 		return nil
 	}
 }

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/compression"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 
 	"github.com/gogo/protobuf/proto"
-
-	log "github.com/sirupsen/logrus"
 
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 )
@@ -196,7 +195,7 @@ func baseCommand(cmdType pb.BaseCommand_Type, msg proto.Message) *pb.BaseCommand
 	case pb.BaseCommand_AUTH_RESPONSE:
 		cmd.AuthResponse = msg.(*pb.CommandAuthResponse)
 	default:
-		log.Panic("Missing command type: ", cmdType)
+		logger.Logger.Panic("Missing command type: ", cmdType)
 	}
 
 	return cmd
@@ -209,7 +208,7 @@ func addSingleMessageToBatch(wb Buffer, smm *pb.SingleMessageMetadata, payload [
 	wb.ResizeIfNeeded(metadataSize)
 	_, err := smm.MarshalToSizedBuffer(wb.WritableSlice()[:metadataSize])
 	if err != nil {
-		log.WithError(err).Fatal("Protobuf serialization error")
+		logger.Logger.WithError(err).Fatal("Protobuf serialization error")
 	}
 
 	wb.WrittenBytes(metadataSize)
@@ -235,7 +234,7 @@ func serializeBatch(wb Buffer,
 	wb.ResizeIfNeeded(cmdSize)
 	_, err := cmdSend.MarshalToSizedBuffer(wb.WritableSlice()[:cmdSize])
 	if err != nil {
-		log.WithError(err).Fatal("Protobuf error when serializing cmdSend")
+		logger.Logger.WithError(err).Fatal("Protobuf error when serializing cmdSend")
 	}
 	wb.WrittenBytes(cmdSize)
 
@@ -250,7 +249,7 @@ func serializeBatch(wb Buffer,
 	wb.ResizeIfNeeded(msgMetadataSize)
 	_, err = msgMetadata.MarshalToSizedBuffer(wb.WritableSlice()[:msgMetadataSize])
 	if err != nil {
-		log.WithError(err).Fatal("Protobuf error when serializing msgMetadata")
+		logger.Logger.WithError(err).Fatal("Protobuf error when serializing msgMetadata")
 	}
 	wb.WrittenBytes(msgMetadataSize)
 

--- a/pulsar/internal/compression/zstd_cgo.go
+++ b/pulsar/internal/compression/zstd_cgo.go
@@ -25,7 +25,7 @@ package compression
 
 import (
 	"github.com/DataDog/zstd"
-	log "github.com/sirupsen/logrus"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
 
 type zstdCGoProvider struct {
@@ -62,7 +62,7 @@ func (z *zstdCGoProvider) CompressMaxSize(originalSize int) int {
 func (z *zstdCGoProvider) Compress(dst, src []byte) []byte {
 	out, err := z.ctx.CompressLevel(dst, src, z.zstdLevel)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to compress")
+		logger.Logger.WithError(err).Fatal("Failed to compress")
 	}
 
 	return out

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -33,6 +33,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/auth"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 )
 
@@ -170,7 +171,7 @@ func newConnection(logicalAddr *url.URL, physicalAddr *url.URL, tlsOptions *TLSO
 		logicalAddr:          logicalAddr,
 		physicalAddr:         physicalAddr,
 		writeBuffer:          NewBuffer(4096),
-		log:                  log.WithField("remote_addr", physicalAddr),
+		log:                  logger.Logger.WithField("remote_addr", physicalAddr),
 		pendingReqs:          make(map[uint64]*request),
 		lastDataReceivedTime: time.Now(),
 		pingTicker:           time.NewTicker(keepAliveInterval),

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -25,8 +25,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/auth"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
 
 // ConnectionPool is a interface of connection pool.
@@ -66,7 +65,7 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 	cachedCnx, found := p.pool.Load(key)
 	if found {
 		cnx := cachedCnx.(*connection)
-		log.Debug("Found connection in cache:", cnx.logicalAddr, cnx.physicalAddr)
+		logger.Logger.Debug("Found connection in cache:", cnx.logicalAddr, cnx.physicalAddr)
 
 		if err := cnx.waitUntilReady(); err == nil {
 			// Connection is ready to be used
@@ -74,7 +73,7 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 		}
 		// The cached connection is failed
 		p.pool.Delete(key)
-		log.Debug("Removed failed connection from pool:", cnx.logicalAddr, cnx.physicalAddr)
+		logger.Logger.Debug("Removed failed connection from pool:", cnx.logicalAddr, cnx.physicalAddr)
 	}
 
 	// Try to create a new connection

--- a/pulsar/internal/logger/logger.go
+++ b/pulsar/internal/logger/logger.go
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logger
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	Logger = log.New()
+)

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/gogo/protobuf/proto"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // LookupResult encapsulates a struct for lookup a request, containing two parts: LogicalAddr, PhysicalAddr.
@@ -91,7 +90,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("Got topic{%s} lookup response: %+v", topic, res)
+	logger.Logger.Debugf("Got topic{%s} lookup response: %+v", topic, res)
 
 	for i := 0; i < lookupResultMaxRedirect; i++ {
 		lr := res.Response.LookupTopicResponse
@@ -103,7 +102,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 				return nil, err
 			}
 
-			log.Debugf("Follow topic{%s} redirect to broker. %v / %v - Use proxy: %v",
+			logger.Logger.Debugf("Follow topic{%s} redirect to broker. %v / %v - Use proxy: %v",
 				topic, lr.BrokerServiceUrl, lr.BrokerServiceUrlTls, lr.ProxyThroughServiceUrl)
 
 			id := ls.rpcClient.NewRequestID()
@@ -120,7 +119,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			continue
 
 		case pb.CommandLookupTopicResponse_Connect:
-			log.Debugf("Successfully looked up topic{%s} on broker. %s / %s - Use proxy: %t",
+			logger.Logger.Debugf("Successfully looked up topic{%s} on broker. %s / %s - Use proxy: %t",
 				topic, lr.GetBrokerServiceUrl(), lr.GetBrokerServiceUrlTls(), lr.GetProxyThroughServiceUrl())
 
 			logicalAddress, physicalAddress, err := ls.getBrokerAddress(lr)
@@ -138,7 +137,7 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			if lr.Error != nil {
 				errorMsg = lr.Error.String()
 			}
-			log.Warnf("Failed to lookup topic: %s, error msg: %s", topic, errorMsg)
+			logger.Logger.Warnf("Failed to lookup topic: %s, error msg: %s", topic, errorMsg)
 			return nil, fmt.Errorf("failed to lookup topic: %s", errorMsg)
 		}
 	}

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/gogo/protobuf/proto"
 
@@ -70,7 +71,7 @@ func NewRPCClient(serviceURL *url.URL, pool ConnectionPool, requestTimeout time.
 		serviceURL:     serviceURL,
 		pool:           pool,
 		requestTimeout: requestTimeout,
-		log:            log.WithField("serviceURL", serviceURL),
+		log:            logger.Logger.WithField("serviceURL", serviceURL),
 	}
 }
 

--- a/pulsar/internal/semaphore.go
+++ b/pulsar/internal/semaphore.go
@@ -20,7 +20,7 @@ package internal
 import (
 	"sync/atomic"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
 
 type Semaphore interface {
@@ -53,7 +53,7 @@ type semaphore struct {
 
 func NewSemaphore(maxPermits int32) Semaphore {
 	if maxPermits <= 0 {
-		log.Fatal("Max permits for semaphore needs to be > 0")
+		logger.Logger.Fatal("Max permits for semaphore needs to be > 0")
 	}
 
 	return &semaphore{

--- a/pulsar/negative_acks_tracker.go
+++ b/pulsar/negative_acks_tracker.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
 
 type redeliveryConsumer interface {
@@ -77,7 +77,7 @@ func (t *negativeAcksTracker) track() {
 	for {
 		select {
 		case <-t.doneCh:
-			log.Debug("Closing nack tracker")
+			logger.Logger.Debug("Closing nack tracker")
 			return
 
 		case <-t.tick.C:
@@ -87,9 +87,9 @@ func (t *negativeAcksTracker) track() {
 				now := time.Now()
 				msgIds := make([]messageID, 0)
 				for msgID, targetTime := range t.negativeAcks {
-					log.Debugf("MsgId: %v -- targetTime: %v -- now: %v", msgID, targetTime, now)
+					logger.Logger.Debugf("MsgId: %v -- targetTime: %v -- now: %v", msgID, targetTime, now)
 					if targetTime.Before(now) {
-						log.Debugf("Adding MsgId: %v", msgID)
+						logger.Logger.Debugf("Adding MsgId: %v", msgID)
 						msgIds = append(msgIds, msgID)
 						delete(t.negativeAcks, msgID)
 					}

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -27,6 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 )
 
 type producer struct {
@@ -67,7 +68,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 		options: options,
 		topic:   options.Topic,
 		client:  client,
-		log:     log.WithField("topic", options.Topic),
+		log:     logger.Logger.WithField("topic", options.Topic),
 	}
 
 	var batchingMaxPublishDelay time.Duration

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/compression"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 
 	"github.com/gogo/protobuf/proto"
 
@@ -91,7 +92,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 
 	p := &partitionProducer{
 		state:            producerInit,
-		log:              log.WithField("topic", topic),
+		log:              logger.Logger.WithField("topic", topic),
 		client:           client,
 		topic:            topic,
 		options:          options,
@@ -110,7 +111,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 
 	err := p.grabCnx()
 	if err != nil {
-		log.WithError(err).Errorf("Failed to create producer")
+		logger.Logger.WithError(err).Errorf("Failed to create producer")
 		return nil, err
 	}
 

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -27,9 +27,8 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	"github.com/stretchr/testify/assert"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func TestInvalidURL(t *testing.T) {
@@ -131,10 +130,10 @@ func TestProducerAsyncSend(t *testing.T) {
 			Payload: []byte("hello"),
 		}, func(id MessageID, message *ProducerMessage, e error) {
 			if e != nil {
-				log.WithError(e).Error("Failed to publish")
+				logger.Logger.WithError(e).Error("Failed to publish")
 				errors.Put(e)
 			} else {
-				log.Info("Published message ", id)
+				logger.Logger.Info("Published message ", id)
 			}
 			wg.Done()
 		})
@@ -301,10 +300,10 @@ func TestFlushInProducer(t *testing.T) {
 			Payload: []byte(messageContent),
 		}, func(id MessageID, producerMessage *ProducerMessage, e error) {
 			if e != nil {
-				log.WithError(e).Error("Failed to publish")
+				logger.Logger.WithError(e).Error("Failed to publish")
 				errors.Put(e)
 			} else {
-				log.Info("Published message ", id)
+				logger.Logger.Info("Published message ", id)
 			}
 			wg.Done()
 		})
@@ -342,10 +341,10 @@ func TestFlushInProducer(t *testing.T) {
 			Payload: []byte(messageContent),
 		}, func(id MessageID, producerMessage *ProducerMessage, e error) {
 			if e != nil {
-				log.WithError(e).Error("Failed to publish")
+				logger.Logger.WithError(e).Error("Failed to publish")
 				errors.Put(e)
 			} else {
-				log.Info("Published message ", id)
+				logger.Logger.Info("Published message ", id)
 			}
 			wg.Done()
 		})
@@ -412,10 +411,10 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 			Payload: []byte(messageContent),
 		}, func(id MessageID, producerMessage *ProducerMessage, e error) {
 			if e != nil {
-				log.WithError(e).Error("Failed to publish")
+				logger.Logger.WithError(e).Error("Failed to publish")
 				errors.Put(e)
 			} else {
-				log.Info("Published message: ", id)
+				logger.Logger.Info("Published message: ", id)
 			}
 			wg.Done()
 		})

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"context"
 
+	"github.com/apache/pulsar-client-go/pulsar/internal/logger"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -85,7 +86,7 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 
 	reader := &reader{
 		messageCh: make(chan ConsumerMessage),
-		log:       log.WithField("topic", options.Topic),
+		log:       logger.Logger.WithField("topic", options.Topic),
 	}
 
 	// Provide dummy dlq router with not dlq policy


### PR DESCRIPTION
From Issue   https://github.com/apache/pulsar-client-go/issues/228  

Modifications:
pulsar-client-go new a default logger instead of use `std`.