### PR TITLE
Fixes go.mod issue with invalid version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/DataDog/zstd v1.4.6-0.20200617134701-89f69fb7df32
-	github.com/apache/pulsar-client-go/oauth2 v0.0.0-00010101000000-000000000000
+	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20200715083626-b9f8c5cedefb
 	github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b
 	github.com/gogo/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This fixes an issue with the latest master's `go.mod`

```
go get github.com/apache/pulsar-client-go/pulsar@master
go: found github.com/apache/pulsar-client-go/pulsar in github.com/apache/pulsar-client-go v0.1.2-0.20200715083626-b9f8c5cedefb
go: github.com/apache/pulsar-client-go master => v0.1.2-0.20200715083626-b9f8c5cedefb
go get: github.com/apache/pulsar-client-go@v0.1.2-0.20200715083626-b9f8c5cedefb requires
        github.com/apache/pulsar-client-go/oauth2@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```

### Modifications

Remove the "invalid version" and readded it