### PR TITLE
Avoid producer deadlock on connection closing

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -416,8 +416,10 @@ func (c *connection) WriteData(data Buffer) {
 			// The channel is either:
 			// 1. blocked, in which case we need to wait until we have space
 			// 2. the connection is already closed, then we need to bail out
+			c.log.Debug("Couldn't write on connection channel immediately")
 			state := connectionState(atomic.LoadInt32(&c.state))
 			if state != connectionReady {
+				c.log.Debug("Connection was already closed")
 				return
 			}
 		}

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -107,14 +107,14 @@ type ConsumerHandler interface {
 	ConnectionClosed()
 }
 
-type connectionState int
+type connectionState int32
 
 const (
-	connectionInit connectionState = iota
-	connectionConnecting
-	connectionTCPConnected
-	connectionReady
-	connectionClosed
+	connectionInit         connectionState = 0
+	connectionConnecting                   = 1
+	connectionTCPConnected                 = 2
+	connectionReady                        = 3
+	connectionClosed                       = 4
 )
 
 func (s connectionState) String() string {
@@ -150,7 +150,7 @@ type incomingCmd struct {
 type connection struct {
 	sync.Mutex
 	cond              *sync.Cond
-	state             connectionState
+	state             int32
 	connectionTimeout time.Duration
 
 	logicalAddr  *url.URL
@@ -190,7 +190,7 @@ type connection struct {
 func newConnection(logicalAddr *url.URL, physicalAddr *url.URL, tlsOptions *TLSOptions,
 	connectionTimeout time.Duration, auth auth.Provider) *connection {
 	cnx := &connection{
-		state:                connectionInit,
+		state:                int32(connectionInit),
 		connectionTimeout:    connectionTimeout,
 		logicalAddr:          logicalAddr,
 		physicalAddr:         physicalAddr,
@@ -397,7 +397,23 @@ func (c *connection) runPingCheck() {
 }
 
 func (c *connection) WriteData(data Buffer) {
-	c.writeRequestsCh <- data
+	for {
+		select {
+		case c.writeRequestsCh <- data:
+			// Successfully wrote on the channel
+			return
+
+		case <-time.After(100 * time.Millisecond):
+			// The channel is either:
+			// 1. blocked, in which case we need to wait until we have space
+			// 2. the connection is already closed, then we need to bail out
+			state := connectionState(atomic.LoadInt32(&c.state))
+			if state != connectionReady {
+				return
+			}
+		}
+	}
+
 }
 
 func (c *connection) internalWriteData(data Buffer) {
@@ -729,7 +745,7 @@ func (c *connection) Close() {
 
 func (c *connection) changeState(state connectionState) {
 	c.Lock()
-	c.state = state
+	atomic.StoreInt32(&c.state, int32(state))
 	c.cond.Broadcast()
 	c.Unlock()
 }

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -397,6 +397,15 @@ func (c *connection) runPingCheck() {
 }
 
 func (c *connection) WriteData(data Buffer) {
+	select {
+	case c.writeRequestsCh <- data:
+		// Channel is not full
+		return
+
+	default:
+		// Channel full, fallback to probe if connection is closed
+	}
+
 	for {
 		select {
 		case c.writeRequestsCh <- data:

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -110,11 +110,11 @@ type ConsumerHandler interface {
 type connectionState int32
 
 const (
-	connectionInit         connectionState = 0
-	connectionConnecting                   = 1
-	connectionTCPConnected                 = 2
-	connectionReady                        = 3
-	connectionClosed                       = 4
+	connectionInit         = 0
+	connectionConnecting   = 1
+	connectionTCPConnected = 2
+	connectionReady        = 3
+	connectionClosed       = 4
 )
 
 func (s connectionState) String() string {


### PR DESCRIPTION
### Motivation

There's a condition in which a producer can remain deadlocked in the event of a connection failure. 

The sequence goes like: 
 1. Producer (or multiple producers) have several outstanding request to write on a connection
 2. The channel (used to pass buffers to write) has the buffer full and thus it's blocking
 3. When the connection is closed the channel is not drained
 4. The connection tries to notify the producers that it's time to reconnect
 5. The producer go-routine is not able to process that notification, since it's blocked on the connection channel 