### PR TITLE
Fix the keyfile unmarshal error

### DIFF
--- a/oauth2/client_credentials_provider.go
+++ b/oauth2/client_credentials_provider.go
@@ -19,12 +19,7 @@ package oauth2
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-)
-
-const (
-	KeyFileTypeServiceAccount = "sn_service_account"
 )
 
 type KeyFileProvider struct {
@@ -57,9 +52,6 @@ func (k *KeyFileProvider) GetClientCredentials() (*KeyFile, error) {
 	err = json.Unmarshal(keyFile, &v)
 	if err != nil {
 		return nil, err
-	}
-	if v.Type != KeyFileTypeServiceAccount {
-		return nil, fmt.Errorf("open %s: unsupported format", k.KeyFile)
 	}
 
 	return &v, nil

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -266,7 +266,7 @@ func mockKeyFile(server string) (string, error) {
 		return "", err
 	}
 	_, err = kf.WriteString(fmt.Sprintf(`{
-  "type":"sn_service_account",
+  "type":"resource",
   "client_id":"client-id",
   "client_secret":"client-secret",
   "client_email":"oauth@test.org",

--- a/pulsar/internal/auth/oauth2_test.go
+++ b/pulsar/internal/auth/oauth2_test.go
@@ -69,7 +69,7 @@ func mockKeyFile(server string) (string, error) {
 		return "", err
 	}
 	_, err = kf.WriteString(fmt.Sprintf(`{
-  "type":"sn_service_account",
+  "type":"resource",
   "client_id":"client-id",
   "client_secret":"client-secret",
   "client_email":"oauth@test.org",


### PR DESCRIPTION
---

*Motivation*

Fix the keyfile unmarshal error:
```
open test_credential.json: unsupported format
```

We should support any type of credential to authentication with pulsar.
