### PR TITLE
Support specified the oauth2 private key with prefix 'file://' and 'data://'

### DIFF
--- a/oauth2/client_credentials_provider.go
+++ b/oauth2/client_credentials_provider.go
@@ -20,6 +20,12 @@ package oauth2
 import (
 	"encoding/json"
 	"io/ioutil"
+	"strings"
+)
+
+const (
+	FILE = "file://"
+	DATA = "data://"
 )
 
 type KeyFileProvider struct {
@@ -43,7 +49,17 @@ func NewClientCredentialsProviderFromKeyFile(keyFile string) *KeyFileProvider {
 var _ ClientCredentialsProvider = &KeyFileProvider{}
 
 func (k *KeyFileProvider) GetClientCredentials() (*KeyFile, error) {
-	keyFile, err := ioutil.ReadFile(k.KeyFile)
+	var keyFile []byte
+	var err error
+	switch {
+	case strings.HasPrefix(k.KeyFile, FILE):
+		filename := strings.TrimPrefix(k.KeyFile, FILE)
+		keyFile, err = ioutil.ReadFile(filename)
+	case strings.HasPrefix(k.KeyFile, "data://"):
+		keyFile = []byte(strings.TrimPrefix(k.KeyFile, DATA))
+	default:
+		keyFile, err = ioutil.ReadFile(k.KeyFile)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/internal/auth/oauth2_test.go
+++ b/pulsar/internal/auth/oauth2_test.go
@@ -91,27 +91,52 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
 		t.Fatal(errors.Wrap(err, "create mocked key file failed"))
 	}
 
-	params := map[string]string{
-		ConfigParamType:      ConfigParamTypeClientCredentials,
-		ConfigParamIssuerURL: server.URL,
-		ConfigParamClientID:  "client-id",
-		ConfigParamAudience:  "audience",
-		ConfigParamKeyFile:   kf,
+	testData := []map[string]string{
+		{
+			ConfigParamType:      ConfigParamTypeClientCredentials,
+			ConfigParamIssuerURL: server.URL,
+			ConfigParamClientID:  "client-id",
+			ConfigParamAudience:  "audience",
+			ConfigParamKeyFile:   kf,
+		},
+		{
+			ConfigParamType:      ConfigParamTypeClientCredentials,
+			ConfigParamIssuerURL: server.URL,
+			ConfigParamClientID:  "client-id",
+			ConfigParamAudience:  "audience",
+			ConfigParamKeyFile:   fmt.Sprintf("file://%s", kf),
+		},
+		{
+			ConfigParamType:      ConfigParamTypeClientCredentials,
+			ConfigParamIssuerURL: server.URL,
+			ConfigParamClientID:  "client-id",
+			ConfigParamAudience:  "audience",
+			ConfigParamKeyFile: "data://" + fmt.Sprintf(`{
+  "type":"resource",
+  "client_id":"client-id",
+  "client_secret":"client-secret",
+  "client_email":"oauth@test.org",
+  "issuer_url":"%s"
+}`, server.URL),
+		},
 	}
 
-	auth, err := NewAuthenticationOAuth2WithParams(params)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = auth.Init()
-	if err != nil {
-		t.Fatal(err)
-	}
+	for i := range testData {
+		params := testData[i]
+		auth, err := NewAuthenticationOAuth2WithParams(params)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = auth.Init()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	token, err := auth.GetData()
-	if err != nil {
-		t.Fatal(err)
-	}
+		token, err := auth.GetData()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	assert.Equal(t, "token-content", string(token))
+		assert.Equal(t, "token-content", string(token))
+	}
 }


### PR DESCRIPTION
---

*Motivation*

Make the oauth2 read the private key can handle with  'file://' schema and 'data://' schema.
