### PR TITLE
[Issue 345] Add a new method to create auth provider from tls cert supplier

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -60,7 +60,7 @@ func NewAuthenticationTLS(certificatePath string, privateKeyPath string) Authent
 
 // Create new Authentication provider with specified TLS certificate supplier
 func NewAuthenticationFromTLSCertSupplier(tlsCertSupplier func() (*tls.Certificate, error)) Authentication {
-	return auth.NewAuthenticationFromTLSCertSupplier(tlsCertSupplier())
+	return auth.NewAuthenticationFromTLSCertSupplier(tlsCertSupplier)
 }
 
 func NewAuthenticationAthenz(authParams map[string]string) Authentication {

--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/auth"
@@ -55,6 +56,11 @@ func NewAuthenticationTokenFromFile(tokenFilePath string) Authentication {
 // Create new Authentication provider with specified TLS certificate and private key
 func NewAuthenticationTLS(certificatePath string, privateKeyPath string) Authentication {
 	return auth.NewAuthenticationTLS(certificatePath, privateKeyPath)
+}
+
+// Create new Authentication provider with specified TLS certificate supplier
+func NewAuthenticationFromTLSCertSupplier(tlsCertSupplier func() (*tls.Certificate, error)) Authentication {
+	return auth.NewAuthenticationFromTLSCertSupplier(tlsCertSupplier())
 }
 
 func NewAuthenticationAthenz(authParams map[string]string) Authentication {

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -149,6 +150,28 @@ func TestTLSAuth(t *testing.T) {
 		URL:                   serviceURLTLS,
 		TLSTrustCertsFilePath: caCertsPath,
 		Authentication:        NewAuthenticationTLS(tlsClientCertPath, tlsClientKeyPath),
+	})
+	assert.NoError(t, err)
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: newAuthTopicName(),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, producer)
+
+	client.Close()
+}
+
+func TestTLSAuthWithCertSupplier(t *testing.T) {
+	supplier := func() (*tls.Certificate, error) {
+		cert, err := tls.LoadX509KeyPair(tlsClientCertPath, tlsClientKeyPath)
+		return &cert, err
+	}
+	client, err := NewClient(ClientOptions{
+		URL:                   serviceURLTLS,
+		TLSTrustCertsFilePath: caCertsPath,
+		Authentication:        NewAuthenticationFromTLSCertSupplier(supplier),
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This PR partially fixed ISSUE #345 by adding a method to create the auth provider from a tls cert supplier.
So users don't have to provide the path to the key/cert.
