### PR TITLE
Add seek logic for reader

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -665,8 +665,8 @@ func (c *connection) handleAuthChallenge(authChallenge *pb.CommandAuthChallenge)
 }
 
 func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer) {
-	c.log.Infof("Broker notification of Closed consumer: %d", closeConsumer.GetConsumerId())
 	consumerID := closeConsumer.GetConsumerId()
+	c.log.Infof("Broker notification of Closed consumer: %d", consumerID)
 
 	c.Lock()
 	defer c.Unlock()

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -17,7 +17,10 @@
 
 package pulsar
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // ReaderMessage package Reader and Message as a struct to use
 type ReaderMessage struct {
@@ -88,4 +91,21 @@ type Reader interface {
 
 	// Close the reader and stop the broker to push more messages
 	Close()
+
+	// Reset the subscription associated with this reader to a specific message id.
+	// The message id can either be a specific message or represent the first or last messages in the topic.
+	//
+	// Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+	//       seek() on the individual partitions.
+	Seek(MessageID) error
+
+	// Reset the subscription associated with this reader to a specific message publish time.
+	//
+	// Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the seek() on
+	// the individual partitions.
+	//
+	// @param timestamp
+	//            the message publish time where to reposition the subscription
+	//
+	SeekByTime(time time.Time) error
 }

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -199,7 +199,7 @@ func (r *reader) messageID(msgID MessageID) (trackingMessageID, bool) {
 
 	partition := int(mid.partitionIdx)
 	// did we receive a valid partition index?
-	if partition < 0  {
+	if partition < 0 {
 		r.log.Warnf("invalid partition index %d expected", partition)
 		return trackingMessageID{}, false
 	}
@@ -215,7 +215,6 @@ func (r *reader) Seek(msgID MessageID) error {
 	if !ok {
 		return nil
 	}
-
 
 	return r.pc.Seek(mid)
 }

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -499,6 +499,7 @@ func TestReaderSeek(t *testing.T) {
 		StartMessageID:          seekID,
 		StartMessageIDInclusive: true,
 	})
+	assert.Nil(t, err)
 
 	msg, err := readerOfSeek.Next(ctx)
 	assert.Nil(t, err)

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -557,14 +557,10 @@ func TestReaderLatestInclusiveHasNext(t *testing.T) {
 	assert.Nil(t, err)
 	defer reader.Close()
 
-	var msgID MessageID
 	if reader.HasNext() {
 		msg, err := reader.Next(context.Background())
 		assert.NoError(t, err)
 
 		assert.Equal(t, []byte("hello-9"), msg.Payload())
-		msgID = msg.ID()
 	}
-
-	assert.Equal(t, lastMsgID.Serialize(), msgID.Serialize())
 }

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -470,7 +470,7 @@ func TestReaderSeek(t *testing.T) {
 	assert.Nil(t, err)
 	defer reader.Close()
 
-	const N= 10
+	const N = 10
 	var seekID MessageID
 	for i := 0; i < N; i++ {
 		id, err := producer.Send(ctx, &ProducerMessage{

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -446,3 +446,61 @@ func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 		assert.Equal(t, []byte(expectMsg), msg.Payload())
 	}
 }
+
+func TestReaderSeek(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topicName := newTopicName()
+	ctx := context.Background()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: topicName,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	reader, err := client.CreateReader(ReaderOptions{
+		Topic:          topicName,
+		StartMessageID: EarliestMessageID(),
+	})
+	assert.Nil(t, err)
+	defer reader.Close()
+
+	const N = 10
+	var seekID MessageID
+	for i := 0; i < N; i++ {
+		id, err := producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		})
+		assert.Nil(t, err)
+
+		if i == 4 {
+			seekID = id
+		}
+	}
+	err = producer.Flush()
+	assert.NoError(t, err)
+
+	for i := 0; i < N; i++ {
+		msg, err := reader.Next(ctx)
+		assert.Nil(t, err)
+		assert.Equal(t, fmt.Sprintf("hello-%d", i), string(msg.Payload()))
+	}
+
+	err = reader.Seek(seekID)
+	assert.Nil(t, err)
+
+	readerOfSeek, err := client.CreateReader(ReaderOptions{
+		Topic:                   topicName,
+		StartMessageID:          seekID,
+		StartMessageIDInclusive: true,
+	})
+
+	msg, err := readerOfSeek.Next(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "hello-4", string(msg.Payload()))
+}


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>



Fixes #218 


### Motivation


Follow https://github.com/apache/pulsar-client-go/pull/222 and add the seek logic for reader 

### Modifications

- Add `seek by msgID` interface
- Add `seek by time` interface
- Add test case

### Verifying this change

- [x] Make sure that the change passes the CI checks.
