### PR TITLE
Support retry letter topic 

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -66,7 +66,10 @@ type DLQPolicy struct {
 	MaxDeliveries uint32
 
 	// Name of the topic where the failing messages will be sent.
-	Topic string
+	DeadLetterTopic string
+
+	// Name of the topic where the retry messages will be sent.
+	RetryLetterTopic string
 }
 
 // ConsumerOptions is used to configure and create instances of Consumer
@@ -106,6 +109,10 @@ type ConsumerOptions struct {
 	// eg. route the message to topic X after N failed attempts at processing it
 	// By default is nil and there's no DLQ
 	DLQ *DLQPolicy
+
+	// Auto retry send messages to default filled DLQPolicy topics
+	// Default is false
+	RetryEnable bool
 
 	// Sets a `MessageChannel` for the consumer
 	// When a message is received, it will be pushed to the channel for consumption
@@ -162,6 +169,9 @@ type Consumer interface {
 
 	// AckID the consumption of a single message, identified by its MessageID
 	AckID(MessageID)
+
+	// ReconsumeLater mark a message for redelivery after custom delay
+	ReconsumeLater(msg Message, delay time.Duration)
 
 	// Acknowledge the failure to process a single message.
 	//

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -152,7 +152,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
-	rlq, err := newRetryRouter(client, options.DLQ)
+	rlq, err := newRetryRouter(client, options.DLQ, options.RetryEnable)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -425,7 +425,7 @@ func (c *consumer) ReconsumeLater(msg Message, delay time.Duration) {
 	if delay < 0 {
 		delay = 0
 	}
-	msgId, ok := c.messageID(msg.ID())
+	msgID, ok := c.messageID(msg.ID())
 	if !ok {
 		return
 	}
@@ -440,10 +440,10 @@ func (c *consumer) ReconsumeLater(msg Message, delay time.Duration) {
 		reconsumeTimes++
 	} else {
 		props[SysPropertyRealTopic] = msg.Topic()
-		props[SysPropertyOriginMessageId] = msgId.messageID.String()
+		props[SysPropertyOriginMessageID] = msgID.messageID.String()
 	}
 	props[SysPropertyReconsumeTimes] = strconv.Itoa(reconsumeTimes)
-	props[SysPropertyDelayTime] = fmt.Sprintf("%d", delay.Milliseconds())
+	props[SysPropertyDelayTime] = fmt.Sprintf("%d", int64(delay)/1e6)
 
 	consumerMsg := ConsumerMessage{
 		Consumer: c,

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"sync"
 	"time"
 
@@ -73,6 +74,7 @@ type consumer struct {
 	messageCh chan ConsumerMessage
 
 	dlq       *dlqRouter
+	rlq       *retryRouter
 	closeOnce sync.Once
 	closeCh   chan struct{}
 	errorCh   chan error
@@ -108,7 +110,49 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		messageCh = make(chan ConsumerMessage, 10)
 	}
 
+	if options.RetryEnable {
+		usingTopic := ""
+		if options.Topic != "" {
+			usingTopic = options.Topic
+		} else if len(options.Topics) > 0 {
+			usingTopic = options.Topics[0]
+		} else {
+			usingTopic = options.TopicsPattern
+		}
+		tn, err := internal.ParseTopicName(usingTopic)
+		if err != nil {
+			return nil, err
+		}
+
+		retryTopic := tn.Domain + "://" + tn.Namespace + "/" + options.SubscriptionName + RetryTopicSuffix
+		dlqTopic := tn.Domain + "://" + tn.Namespace + "/" + options.SubscriptionName + DlqTopicSuffix
+		if options.DLQ == nil {
+			options.DLQ = &DLQPolicy{
+				MaxDeliveries:    MaxReconsumeTimes,
+				DeadLetterTopic:  dlqTopic,
+				RetryLetterTopic: retryTopic,
+			}
+		} else {
+			if options.DLQ.DeadLetterTopic == "" {
+				options.DLQ.DeadLetterTopic = dlqTopic
+			}
+			if options.DLQ.RetryLetterTopic == "" {
+				options.DLQ.RetryLetterTopic = retryTopic
+			}
+		}
+		if options.Topic != "" && len(options.Topics) == 0 {
+			options.Topics = []string{options.Topic, options.DLQ.RetryLetterTopic}
+			options.Topic = ""
+		} else {
+			options.Topics = append(options.Topics, options.DLQ.RetryLetterTopic)
+		}
+	}
+
 	dlq, err := newDlqRouter(client, options.DLQ)
+	if err != nil {
+		return nil, err
+	}
+	rlq, err := newRetryRouter(client, options.DLQ)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +168,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 			return nil, err
 		}
 
-		return topicSubscribe(client, options, topic, messageCh, dlq)
+		return topicSubscribe(client, options, topic, messageCh, dlq, rlq)
 	}
 
 	if len(options.Topics) > 1 {
@@ -132,7 +176,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 			return nil, err
 		}
 
-		return newMultiTopicConsumer(client, options, options.Topics, messageCh, dlq)
+		return newMultiTopicConsumer(client, options, options.Topics, messageCh, dlq, rlq)
 	}
 
 	if options.TopicsPattern != "" {
@@ -145,14 +189,14 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newRegexConsumer(client, options, tn, pattern, messageCh, dlq)
+		return newRegexConsumer(client, options, tn, pattern, messageCh, dlq, rlq)
 	}
 
 	return nil, newError(ResultInvalidTopicName, "topic name is required for consumer")
 }
 
 func newInternalConsumer(client *client, options ConsumerOptions, topic string,
-	messageCh chan ConsumerMessage, dlq *dlqRouter, disableForceTopicCreation bool) (*consumer, error) {
+	messageCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter, disableForceTopicCreation bool) (*consumer, error) {
 
 	consumer := &consumer{
 		topic:                     topic,
@@ -163,6 +207,7 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 		closeCh:                   make(chan struct{}),
 		errorCh:                   make(chan error),
 		dlq:                       dlq,
+		rlq:                       rlq,
 		log:                       log.WithField("topic", topic),
 		consumerName:              options.Name,
 	}
@@ -306,8 +351,8 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 }
 
 func topicSubscribe(client *client, options ConsumerOptions, topic string,
-	messageCh chan ConsumerMessage, dlqRouter *dlqRouter) (Consumer, error) {
-	c, err := newInternalConsumer(client, options, topic, messageCh, dlqRouter, false)
+	messageCh chan ConsumerMessage, dlqRouter *dlqRouter, retryRouter *retryRouter) (Consumer, error) {
+	c, err := newInternalConsumer(client, options, topic, messageCh, dlqRouter, retryRouter, false)
 	if err == nil {
 		consumersOpened.Inc()
 	}
@@ -375,6 +420,53 @@ func (c *consumer) AckID(msgID MessageID) {
 	c.consumers[mid.partitionIdx].AckID(mid)
 }
 
+// ReconsumeLater mark a message for redelivery after custom delay
+func (c *consumer) ReconsumeLater(msg Message, delay time.Duration) {
+	if delay < 0 {
+		delay = 0
+	}
+	msgId, ok := c.messageID(msg.ID())
+	if !ok {
+		return
+	}
+	props := make(map[string]string)
+	for k, v := range msg.Properties() {
+		props[k] = v
+	}
+
+	reconsumeTimes := 1
+	if s, ok := props[SysPropertyReconsumeTimes]; ok {
+		reconsumeTimes, _ = strconv.Atoi(s)
+		reconsumeTimes++
+	} else {
+		props[SysPropertyRealTopic] = msg.Topic()
+		props[SysPropertyOriginMessageId] = msgId.messageID.String()
+	}
+	props[SysPropertyReconsumeTimes] = strconv.Itoa(reconsumeTimes)
+	props[SysPropertyDelayTime] = fmt.Sprintf("%d", delay.Milliseconds())
+
+	msg.(*message).properties = props
+	msg.(*message).redeliveryCount = uint32(reconsumeTimes)
+	consumerMsg := ConsumerMessage{
+		Consumer: c,
+		Message:  msg,
+	}
+	if uint32(reconsumeTimes) > c.dlq.policy.MaxDeliveries {
+		c.dlq.Chan() <- consumerMsg
+	} else {
+		c.rlq.Chan() <- RetryMessage{
+			consumerMsg: consumerMsg,
+			producerMsg: ProducerMessage{
+				Payload:      msg.Payload(),
+				Key:          msg.Key(),
+				Properties:   props,
+				EventTime:    msg.EventTime(),
+				DeliverAfter: delay,
+			},
+		}
+	}
+}
+
 func (c *consumer) Nack(msg Message) {
 	c.NackID(msg.ID())
 }
@@ -411,6 +503,7 @@ func (c *consumer) Close() {
 		c.ticker.Stop()
 		c.client.handlers.Del(c)
 		c.dlq.close()
+		c.rlq.close()
 		consumersClosed.Inc()
 		consumersPartitions.Sub(float64(len(c.consumers)))
 	})

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -116,8 +116,6 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 			usingTopic = options.Topic
 		} else if len(options.Topics) > 0 {
 			usingTopic = options.Topics[0]
-		} else {
-			usingTopic = options.TopicsPattern
 		}
 		tn, err := internal.ParseTopicName(usingTopic)
 		if err != nil {
@@ -450,6 +448,7 @@ func (c *consumer) ReconsumeLater(msg Message, delay time.Duration) {
 		Message: &message{
 			payLoad:    msg.Payload(),
 			properties: props,
+			msgID:      msgID,
 		},
 	}
 	if uint32(reconsumeTimes) > c.dlq.policy.MaxDeliveries {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -38,6 +38,7 @@ type multiTopicConsumer struct {
 	consumers map[string]Consumer
 
 	dlq       *dlqRouter
+	rlq       *retryRouter
 	closeOnce sync.Once
 	closeCh   chan struct{}
 
@@ -45,19 +46,20 @@ type multiTopicConsumer struct {
 }
 
 func newMultiTopicConsumer(client *client, options ConsumerOptions, topics []string,
-	messageCh chan ConsumerMessage, dlq *dlqRouter) (Consumer, error) {
+	messageCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter) (Consumer, error) {
 	mtc := &multiTopicConsumer{
 		options:      options,
 		messageCh:    messageCh,
 		consumers:    make(map[string]Consumer, len(topics)),
 		closeCh:      make(chan struct{}),
 		dlq:          dlq,
+		rlq:          rlq,
 		log:          &log.Entry{},
 		consumerName: options.Name,
 	}
 
 	var errs error
-	for ce := range subscriber(client, topics, options, messageCh, dlq) {
+	for ce := range subscriber(client, topics, options, messageCh, dlq, rlq) {
 		if ce.err != nil {
 			errs = pkgerrors.Wrapf(ce.err, "unable to subscribe to topic=%s", ce.topic)
 		} else {
@@ -134,6 +136,15 @@ func (c *multiTopicConsumer) AckID(msgID MessageID) {
 	mid.Ack()
 }
 
+func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {
+	consumer, ok := c.consumers[msg.Topic()]
+	if !ok {
+		c.log.Warnf("consumer of topic %s not exist unexpectedly", msg.Topic())
+		return
+	}
+	consumer.ReconsumeLater(msg, delay)
+}
+
 func (c *multiTopicConsumer) Nack(msg Message) {
 	c.NackID(msg.ID())
 }
@@ -166,6 +177,7 @@ func (c *multiTopicConsumer) Close() {
 		wg.Wait()
 		close(c.closeCh)
 		c.dlq.close()
+		c.rlq.close()
 		consumersClosed.Inc()
 	})
 }

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -167,7 +167,6 @@ func (c *regexConsumer) Ack(msg Message) {
 
 func (c *regexConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 	c.log.Warnf("regexp consumer not support ReconsumeLater yet.")
-	return
 }
 
 // Ack the consumption of a single message, identified by its MessageID

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -166,12 +166,8 @@ func (c *regexConsumer) Ack(msg Message) {
 }
 
 func (c *regexConsumer) ReconsumeLater(msg Message, delay time.Duration) {
-	consumer, ok := c.consumers[msg.Topic()]
-	if !ok {
-		c.log.Warnf("consumer of topic %s not exist unexpectedly", msg.Topic())
-		return
-	}
-	consumer.ReconsumeLater(msg, delay)
+	c.log.Warnf("regexp consumer not support ReconsumeLater yet.")
+	return
 }
 
 // Ack the consumption of a single message, identified by its MessageID

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -154,7 +154,7 @@ func runRegexConsumerDiscoverPatternAll(t *testing.T, c Client, namespace string
 	}
 
 	dlq, _ := newDlqRouter(c.(*client), nil)
-	rlq, _ := newRetryRouter(c.(*client), nil)
+	rlq, _ := newRetryRouter(c.(*client), nil, false)
 	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
 	if err != nil {
 		t.Fatal(err)
@@ -203,7 +203,7 @@ func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string
 	}
 
 	dlq, _ := newDlqRouter(c.(*client), nil)
-	rlq, _ := newRetryRouter(c.(*client), nil)
+	rlq, _ := newRetryRouter(c.(*client), nil, false)
 	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
 	if err != nil {
 		t.Fatal(err)

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -154,7 +154,8 @@ func runRegexConsumerDiscoverPatternAll(t *testing.T, c Client, namespace string
 	}
 
 	dlq, _ := newDlqRouter(c.(*client), nil)
-	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq)
+	rlq, _ := newRetryRouter(c.(*client), nil)
+	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +203,8 @@ func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string
 	}
 
 	dlq, _ := newDlqRouter(c.(*client), nil)
-	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq)
+	rlq, _ := newRetryRouter(c.(*client), nil)
+	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1313,8 +1313,9 @@ func TestRLQByCustomTopicName(t *testing.T) {
 }
 
 func TestRLQWithMultiTopics(t *testing.T) {
-	topic01 := fmt.Sprintf("persistent://public/default/topic-new-%d", time.Now().Unix())
-	topic02 := fmt.Sprintf("persistent://public/default/topic-new-%d", time.Now().Unix()+1)
+	now := time.Now().Unix()
+	topic01 := fmt.Sprintf("persistent://public/default/topic-%d-1", now)
+	topic02 := fmt.Sprintf("persistent://public/default/topic-%d-2", now)
 	topics := []string{topic01, topic02}
 
 	subName := fmt.Sprintf("sub01-%d", time.Now().Unix())
@@ -1380,6 +1381,7 @@ func TestRLQWithMultiTopics(t *testing.T) {
 	dlqRecv := 0
 	for dlqRecv < sentMsgs {
 		msg, err := dlqConsumer.Receive(ctx)
+		fmt.Printf("dlq received: %s, total: %d\n", string(msg.Payload()), recv)
 		assert.Nil(t, err)
 		dlqConsumer.Ack(msg)
 		dlqRecv++

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -46,13 +46,13 @@ func newDlqRouter(client Client, policy *DLQPolicy) (*dlqRouter, error) {
 			return nil, errors.New("DLQPolicy.MaxDeliveries needs to be > 0")
 		}
 
-		if policy.Topic == "" {
+		if policy.DeadLetterTopic == "" {
 			return nil, errors.New("DLQPolicy.Topic needs to be set to a valid topic name")
 		}
 
 		r.messageCh = make(chan ConsumerMessage)
 		r.closeCh = make(chan interface{}, 1)
-		r.log = log.WithField("dlq-topic", policy.Topic)
+		r.log = log.WithField("dlq-topic", policy.DeadLetterTopic)
 		go r.run()
 	}
 	return r, nil
@@ -132,7 +132,7 @@ func (r *dlqRouter) getProducer() Producer {
 	backoff := &internal.Backoff{}
 	for {
 		producer, err := r.client.CreateProducer(ProducerOptions{
-			Topic:                   r.policy.Topic,
+			Topic:                   r.policy.DeadLetterTopic,
 			CompressionType:         LZ4,
 			BatchingMaxPublishDelay: 100 * time.Millisecond,
 		})

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 	"sync"
@@ -101,6 +102,10 @@ func (id messageID) Serialize() []byte {
 	}
 	data, _ := proto.Marshal(msgID)
 	return data
+}
+
+func (id messageID) String() string {
+	return fmt.Sprintf("%d:%d:%d", id.ledgerID, id.entryID, id.partitionIdx)
 }
 
 func deserializeMessageID(data []byte) (MessageID, error) {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -176,6 +176,7 @@ type connection struct {
 	closeCh            chan interface{}
 	writeRequestsCh    chan Buffer
 
+	pendingLock sync.Mutex
 	pendingReqs map[uint64]*request
 	listeners   map[uint64]ConnectionListener
 
@@ -356,23 +357,34 @@ func (c *connection) run() {
 	defer func() {
 		// all the accesses to the pendingReqs should be happened in this run loop thread,
 		// including the final cleanup, to avoid the issue https://github.com/apache/pulsar-client-go/issues/239
+		c.pendingLock.Lock()
 		for id, req := range c.pendingReqs {
 			req.callback(nil, errors.New("connection closed"))
 			delete(c.pendingReqs, id)
 		}
+		c.pendingLock.Unlock()
 		c.Close()
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-c.closeCh:
+				return
+
+			case req := <-c.incomingRequestsCh:
+				if req == nil {
+					return // TODO: this never gonna be happen
+				}
+				c.internalSendRequest(req)
+			}
+		}
 	}()
 
 	for {
 		select {
 		case <-c.closeCh:
 			return
-
-		case req := <-c.incomingRequestsCh:
-			if req == nil {
-				return
-			}
-			c.internalSendRequest(req)
 
 		case cmd := <-c.incomingCmdCh:
 			c.internalReceivedCommand(cmd.cmd, cmd.headersAndPayload)
@@ -556,33 +568,41 @@ func (c *connection) SendRequestNoWait(req *pb.BaseCommand) {
 }
 
 func (c *connection) internalSendRequest(req *request) {
+	c.pendingLock.Lock()
 	if req.id != nil {
 		c.pendingReqs[*req.id] = req
 	}
+	c.pendingLock.Unlock()
 	c.writeCommand(req.cmd)
 }
 
 func (c *connection) handleResponse(requestID uint64, response *pb.BaseCommand) {
+	c.pendingLock.Lock()
 	request, ok := c.pendingReqs[requestID]
 	if !ok {
 		c.log.Warnf("Received unexpected response for request %d of type %s", requestID, response.Type)
+		c.pendingLock.Unlock()
 		return
 	}
 
 	delete(c.pendingReqs, requestID)
+	c.pendingLock.Unlock()
 	request.callback(response, nil)
 }
 
 func (c *connection) handleResponseError(serverError *pb.CommandError) {
 	requestID := serverError.GetRequestId()
+	c.pendingLock.Lock()
 	request, ok := c.pendingReqs[requestID]
 	if !ok {
 		c.log.Warnf("Received unexpected error response for request %d of type %s",
 			requestID, serverError.GetError())
+		c.pendingLock.Unlock()
 		return
 	}
 
 	delete(c.pendingReqs, requestID)
+	c.pendingLock.Unlock()
 
 	errMsg := fmt.Sprintf("server error: %s: %s", serverError.GetError(), serverError.GetMessage())
 	request.callback(nil, errors.New(errMsg))

--- a/pulsar/internal/topic_name.go
+++ b/pulsar/internal/topic_name.go
@@ -26,8 +26,9 @@ import (
 
 // TopicName abstract a struct contained in a Topic
 type TopicName struct {
-	Name      string
+	Domain    string
 	Namespace string
+	Name      string
 	Partition int
 }
 
@@ -68,6 +69,7 @@ func ParseTopicName(topic string) (*TopicName, error) {
 	if domain != "persistent" && domain != "non-persistent" {
 		return nil, errors.New("Invalid topic domain: " + domain)
 	}
+	tn.Domain = domain
 
 	rest := parts[1]
 	var err error

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -286,8 +286,8 @@ func (p *producer) Flush() error {
 }
 
 func (p *producer) Close() {
-	p.RLock()
-	defer p.RUnlock()
+	p.Lock()
+	defer p.Unlock()
 	if p.ticker != nil {
 		p.ticker.Stop()
 		close(p.tickerStop)

--- a/pulsar/retry_router.go
+++ b/pulsar/retry_router.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package pulsar
 
 import (
@@ -35,13 +52,13 @@ type retryRouter struct {
 	log       *log.Entry
 }
 
-func newRetryRouter(client Client, policy *DLQPolicy) (*retryRouter, error) {
+func newRetryRouter(client Client, policy *DLQPolicy, retryEnabled bool) (*retryRouter, error) {
 	r := &retryRouter{
 		client: client,
 		policy: policy,
 	}
 
-	if policy != nil {
+	if policy != nil && retryEnabled {
 		if policy.MaxDeliveries <= 0 {
 			return nil, errors.New("DLQPolicy.MaxDeliveries needs to be > 0")
 		}

--- a/pulsar/retry_router.go
+++ b/pulsar/retry_router.go
@@ -3,9 +3,10 @@ package pulsar
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 const (
@@ -17,7 +18,7 @@ const (
 	SysPropertyRealTopic       = "REAL_TOPIC"
 	SysPropertyRetryTopic      = "RETRY_TOPIC"
 	SysPropertyReconsumeTimes  = "RECONSUMETIMES"
-	SysPropertyOriginMessageId = "ORIGIN_MESSAGE_IDY_TIME"
+	SysPropertyOriginMessageID = "ORIGIN_MESSAGE_IDY_TIME"
 )
 
 type RetryMessage struct {

--- a/pulsar/retry_router.go
+++ b/pulsar/retry_router.go
@@ -1,0 +1,120 @@
+package pulsar
+
+import (
+	"context"
+	"errors"
+	"github.com/apache/pulsar-client-go/pulsar/internal"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+const (
+	DlqTopicSuffix    = "-DLQ"
+	RetryTopicSuffix  = "-RETRY"
+	MaxReconsumeTimes = 16
+
+	SysPropertyDelayTime       = "DELAY_TIME"
+	SysPropertyRealTopic       = "REAL_TOPIC"
+	SysPropertyRetryTopic      = "RETRY_TOPIC"
+	SysPropertyReconsumeTimes  = "RECONSUMETIMES"
+	SysPropertyOriginMessageId = "ORIGIN_MESSAGE_IDY_TIME"
+)
+
+type RetryMessage struct {
+	producerMsg ProducerMessage
+	consumerMsg ConsumerMessage
+}
+
+type retryRouter struct {
+	client    Client
+	producer  Producer
+	policy    *DLQPolicy
+	messageCh chan RetryMessage
+	closeCh   chan interface{}
+	log       *log.Entry
+}
+
+func newRetryRouter(client Client, policy *DLQPolicy) (*retryRouter, error) {
+	r := &retryRouter{
+		client: client,
+		policy: policy,
+	}
+
+	if policy != nil {
+		if policy.MaxDeliveries <= 0 {
+			return nil, errors.New("DLQPolicy.MaxDeliveries needs to be > 0")
+		}
+
+		if policy.RetryLetterTopic == "" {
+			return nil, errors.New("DLQPolicy.RetryLetterTopic needs to be set to a valid topic name")
+		}
+
+		r.messageCh = make(chan RetryMessage)
+		r.closeCh = make(chan interface{}, 1)
+		r.log = log.WithField("rlq-topic", policy.RetryLetterTopic)
+		go r.run()
+	}
+	return r, nil
+}
+
+func (r *retryRouter) Chan() chan RetryMessage {
+	return r.messageCh
+}
+
+func (r *retryRouter) run() {
+	for {
+		select {
+		case rm := <-r.messageCh:
+			r.log.WithField("msgID", rm.consumerMsg.ID()).Debug("Got message for RLQ")
+			producer := r.getProducer()
+
+			msgID := rm.consumerMsg.ID()
+			producer.SendAsync(context.Background(), &rm.producerMsg, func(MessageID, *ProducerMessage, error) {
+				// TODO: if router produce failed, should Nack this message
+				r.log.WithField("msgID", msgID).Debug("Sent message to RLQ")
+				rm.consumerMsg.Consumer.AckID(msgID)
+			})
+
+		case <-r.closeCh:
+			if r.producer != nil {
+				r.producer.Close()
+			}
+			r.log.Debug("Closed RLQ router")
+			return
+		}
+	}
+}
+
+func (r *retryRouter) close() {
+	// Attempt to write on the close channel, without blocking
+	select {
+	case r.closeCh <- nil:
+	default:
+	}
+}
+
+func (r *retryRouter) getProducer() Producer {
+	if r.producer != nil {
+		// Producer was already initialized
+		return r.producer
+	}
+
+	// Retry to create producer indefinitely
+	backoff := &internal.Backoff{}
+	for {
+		producer, err := r.client.CreateProducer(ProducerOptions{
+			Topic:                   r.policy.RetryLetterTopic,
+			CompressionType:         LZ4,
+			BatchingMaxPublishDelay: 100 * time.Millisecond,
+		})
+
+		if err != nil {
+			r.log.WithError(err).Error("Failed to create RLQ producer")
+			time.Sleep(backoff.Next())
+			continue
+		} else {
+			r.producer = producer
+			return producer
+		}
+	}
+}


### PR DESCRIPTION
Fixes #353 

### Motivation

Follow [pulsar#6449](https://github.com/apache/pulsar/pull/6449) to support retry letter topic in go client

### Modifications

- Add `retryRouter` for sending reconsume messages to retry letter topic
- Add `ReconsumeLater(msg Message, delay time.Duration)` to Consumer interface
- Add configureable retry letter topic name in `DLQPolicy`
    ```go
	type DLQPolicy struct {
		// ...
		// Name of the topic where the retry messages will be sent.
		RetryLetterTopic string
	}
	```
    enable it explicitly while creating consumer, default unenable
   
     ```go
    type ConsumerOptions struct {
	    // ...
		// Auto retry send messages to default filled DLQPolicy topics
		RetryEnable bool
	}
    ```
- Add 2 `TestRLQ*`  test cases



### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
[pulsar doc: retry-letter-topic](http://pulsar.apache.org/docs/en/concepts-messaging/#retry-letter-topic)