### PR TITLE
[Producer]Add functional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ client, err := pulsar.NewClient(pulsar.ClientOptions{
 
 defer client.Close()
 
-producer, err := client.CreateProducer(pulsar.ProducerOptions{
-	Topic: "my-topic",
-})
+producer, err := client.CreateProducer(
+    pulsar.SetTopic("my-topic"),
+)
 
 _, err = producer.Send(context.Background(), &pulsar.ProducerMessage{
 	Payload: []byte("hello"),

--- a/examples/producer/producer.go
+++ b/examples/producer/producer.go
@@ -36,9 +36,9 @@ func main() {
 
 	defer client.Close()
 
-	producer, err := client.CreateProducer(pulsar.ProducerOptions{
-		Topic: "topic-1",
-	})
+	producer, err := client.CreateProducer(
+		pulsar.SetTopic("topic-1"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -85,12 +85,12 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 	}
 	defer client.Close()
 
-	producer, err := client.CreateProducer(pulsar.ProducerOptions{
-		Topic:                   produceArgs.Topic,
-		MaxPendingMessages:      produceArgs.ProducerQueueSize,
-		BatchingMaxPublishDelay: time.Millisecond * time.Duration(produceArgs.BatchingTimeMillis),
-		BatchingMaxSize:         uint(produceArgs.BatchingMaxSize * 1024),
-	})
+	producer, err := client.CreateProducer(
+		pulsar.SetTopic(produceArgs.Topic),
+		pulsar.SetMaxPendingMessages(produceArgs.ProducerQueueSize),
+		pulsar.SetBatchingMaxPublishDelay(time.Millisecond * time.Duration(produceArgs.BatchingTimeMillis)),
+		pulsar.SetBatchingMaxSize(uint(produceArgs.BatchingMaxSize * 1024)),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -88,8 +88,8 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 	producer, err := client.CreateProducer(
 		pulsar.SetTopic(produceArgs.Topic),
 		pulsar.SetMaxPendingMessages(produceArgs.ProducerQueueSize),
-		pulsar.SetBatchingMaxPublishDelay(time.Millisecond * time.Duration(produceArgs.BatchingTimeMillis)),
-		pulsar.SetBatchingMaxSize(uint(produceArgs.BatchingMaxSize * 1024)),
+		pulsar.SetBatchingMaxPublishDelay(time.Millisecond*time.Duration(produceArgs.BatchingTimeMillis)),
+		pulsar.SetBatchingMaxSize(uint(produceArgs.BatchingMaxSize*1024)),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -107,7 +107,7 @@ type ClientOptions struct {
 type Client interface {
 	// Create the producer instance
 	// This method will block until the producer is created successfully
-	CreateProducer(ProducerOptions) (Producer, error)
+	CreateProducer(...ProducerOption) (Producer, error)
 
 	// Create a `Consumer` by subscribing to a topic.
 	//

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -109,8 +109,8 @@ func newClient(options ClientOptions) (Client, error) {
 	return c, nil
 }
 
-func (c *client) CreateProducer(options ProducerOptions) (Producer, error) {
-	producer, err := newProducer(c, &options)
+func (c *client) CreateProducer(opts ...ProducerOption) (Producer, error) {
+	producer, err := newProducer(c, opts...)
 	if err == nil {
 		c.handlers.Add(producer)
 	}

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -45,9 +45,9 @@ func TestTLSConnectionCAError(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	// The client should fail because it wouldn't trust the
 	// broker certificate
@@ -64,9 +64,9 @@ func TestTLSInsecureConnection(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -81,9 +81,9 @@ func TestTLSConnection(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -99,9 +99,9 @@ func TestTLSConnectionHostNameVerification(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -118,9 +118,9 @@ func TestTLSConnectionHostNameVerificationError(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	assert.Error(t, err)
 	assert.Nil(t, producer)
@@ -135,9 +135,9 @@ func TestTLSAuthError(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.Error(t, err)
 	assert.Nil(t, producer)
@@ -153,9 +153,9 @@ func TestTLSAuth(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -175,9 +175,9 @@ func TestTLSAuthWithCertSupplier(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -195,9 +195,9 @@ func TestTokenAuth(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -219,9 +219,9 @@ func TestTokenAuthWithSupplier(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -236,9 +236,9 @@ func TestTokenAuthFromFile(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -326,9 +326,9 @@ func TestOAuth2Auth(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newAuthTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newAuthTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -434,9 +434,9 @@ func TestNamespaceTopics(t *testing.T) {
 	assert.Nil(t, err)
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 
 	assert.Nil(t, err)
 	defer producer.Close()

--- a/pulsar/consumer_multitopic_test.go
+++ b/pulsar/consumer_multitopic_test.go
@@ -47,10 +47,10 @@ func TestMultiTopicConsumerReceive(t *testing.T) {
 
 	// produce messages
 	for i, topic := range topics {
-		p, err := client.CreateProducer(ProducerOptions{
-			Topic:           topic,
-			DisableBatching: true,
-		})
+		p, err := client.CreateProducer(
+			SetTopic(topic),
+			SetDisableBatching(true),
+		)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -263,19 +263,19 @@ func runRegexConsumerMatchOneTopic(t *testing.T, c Client, namespace string) {
 	topicNotInRegex := fmt.Sprintf("%s/my-topic", namespace)
 	topicInRegex := fmt.Sprintf("%s/foo-topic", namespace)
 
-	p1, err := c.CreateProducer(ProducerOptions{
-		Topic:           topicNotInRegex,
-		DisableBatching: true,
-	})
+	p1, err := c.CreateProducer(
+		SetTopic(topicNotInRegex),
+		SetDisableBatching(true),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer p1.Close()
 
-	p2, err := c.CreateProducer(ProducerOptions{
-		Topic:           topicInRegex,
-		DisableBatching: true,
-	})
+	p2, err := c.CreateProducer(
+		SetTopic(topicInRegex),
+		SetDisableBatching(true),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,10 +320,10 @@ func runRegexConsumerMatchOneTopic(t *testing.T, c Client, namespace string) {
 
 func runRegexConsumerAddMatchingTopic(t *testing.T, c Client, namespace string) {
 	topicInRegex := namespace + "/foo-topic"
-	p, err := c.CreateProducer(ProducerOptions{
-		Topic:           topicInRegex,
-		DisableBatching: true,
-	})
+	p, err := c.CreateProducer(
+		SetTopic(topicInRegex),
+		SetDisableBatching(true),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -740,7 +740,7 @@ func TestConsumerCompressionWithBatches(t *testing.T) {
 	producer, err := client.CreateProducer(
 		SetTopic(topicName),
 		SetCompressionType(ZLib),
-		SetBatchingMaxPublishDelay(1 * time.Minute),
+		SetBatchingMaxPublishDelay(1*time.Minute),
 	)
 	assert.Nil(t, err)
 	defer producer.Close()

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -57,10 +57,10 @@ func TestProducerConsumer(t *testing.T) {
 	defer consumer.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: false,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(false),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -135,11 +135,11 @@ func TestBatchMessageReceive(t *testing.T) {
 	batchSize, numOfMessages := 2, 100
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:               topicName,
-		BatchingMaxMessages: uint(batchSize),
-		DisableBatching:     false,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetBatchingMaxMessages(uint(batchSize)),
+		SetDisableBatching(false),
+	)
 	assert.Nil(t, err)
 	assert.Equal(t, topicName, producer.Topic())
 	defer producer.Close()
@@ -217,9 +217,9 @@ func TestConsumerSubscriptionEarliestPosition(t *testing.T) {
 	subName := "test-subscription-initial-earliest-position"
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -276,10 +276,10 @@ func TestConsumerKeyShared(t *testing.T) {
 	defer consumer2.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -332,9 +332,9 @@ func TestPartitionTopicsConsumerPubSub(t *testing.T) {
 	makeHTTPCall(t, http.MethodPut, testURL, "64")
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -433,10 +433,10 @@ func TestConsumerShared(t *testing.T) {
 	defer consumer2.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -489,9 +489,9 @@ func TestConsumerEventTime(t *testing.T) {
 	topicName := "test-event-time"
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -526,9 +526,9 @@ func TestConsumerFlow(t *testing.T) {
 	topicName := "test-received-since-flow"
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -566,9 +566,9 @@ func TestConsumerAck(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -632,9 +632,9 @@ func TestConsumerNack(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -694,10 +694,10 @@ func TestConsumerCompression(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topicName,
-		CompressionType: LZ4,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetCompressionType(LZ4),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -737,11 +737,11 @@ func TestConsumerCompressionWithBatches(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   topicName,
-		CompressionType:         ZLib,
-		BatchingMaxPublishDelay: 1 * time.Minute,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetCompressionType(ZLib),
+		SetBatchingMaxPublishDelay(1 * time.Minute),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -780,10 +780,10 @@ func TestConsumerSeek(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topicName,
-		DisableBatching: false,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetDisableBatching(false),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -832,10 +832,10 @@ func TestConsumerSeekByTime(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topicName,
-		DisableBatching: false,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetDisableBatching(false),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -981,9 +981,9 @@ func TestDLQ(t *testing.T) {
 	defer consumer.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -1086,9 +1086,9 @@ func TestDLQMultiTopics(t *testing.T) {
 	// create one producer for each topic
 	producers := make([]Producer, 10)
 	for i, topic := range topics {
-		producer, err := client.CreateProducer(ProducerOptions{
-			Topic: topic,
-		})
+		producer, err := client.CreateProducer(
+			SetTopic(topic),
+		)
 		assert.Nil(t, err)
 
 		producers[i] = producer
@@ -1168,9 +1168,9 @@ func TestGetDeliveryCount(t *testing.T) {
 	defer consumer.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -1224,15 +1224,16 @@ func TestConsumerAddTopicPartitions(t *testing.T) {
 
 	// create producer
 	partitionsAutoDiscoveryInterval = 100 * time.Millisecond
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-		MessageRouter: func(msg *ProducerMessage, topicMetadata TopicMetadata) int {
-			// The message key will contain the partition id where to route
-			i, err := strconv.Atoi(msg.Key)
-			assert.NoError(t, err)
-			return i
-		},
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetMessageRouter(
+			func(msg *ProducerMessage, topicMetadata TopicMetadata) int {
+				// The message key will contain the partition id where to route
+				i, err := strconv.Atoi(msg.Key)
+				assert.NoError(t, err)
+				return i
+			}),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -1310,10 +1311,10 @@ func TestProducerName(t *testing.T) {
 	producerName := "test-producer-name"
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-		Name:  producerName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetName(producerName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -1416,10 +1417,10 @@ func TestConsumerWithInterceptors(t *testing.T) {
 	defer consumer.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: false,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(false),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -134,7 +134,7 @@ func (r *dlqRouter) getProducer() Producer {
 		producer, err := r.client.CreateProducer(
 			SetTopic(r.policy.Topic),
 			SetCompressionType(LZ4),
-			SetBatchingMaxPublishDelay(100 * time.Millisecond),
+			SetBatchingMaxPublishDelay(100*time.Millisecond),
 		)
 
 		if err != nil {

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -131,11 +131,11 @@ func (r *dlqRouter) getProducer() Producer {
 	// Retry to create producer indefinitely
 	backoff := &internal.Backoff{}
 	for {
-		producer, err := r.client.CreateProducer(ProducerOptions{
-			Topic:                   r.policy.Topic,
-			CompressionType:         LZ4,
-			BatchingMaxPublishDelay: 100 * time.Millisecond,
-		})
+		producer, err := r.client.CreateProducer(
+			SetTopic(r.policy.Topic),
+			SetCompressionType(LZ4),
+			SetBatchingMaxPublishDelay(100 * time.Millisecond),
+		)
 
 		if err != nil {
 			r.log.WithError(err).Error("Failed to create DLQ producer")

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -140,6 +140,102 @@ type ProducerOptions struct {
 	Interceptors ProducerInterceptors
 }
 
+type ProducerOption func(*ProducerOptions)
+
+// SetTopic sets the topic this producer will be publishing on.
+func SetTopic(topic string) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.Topic = topic
+	}
+}
+
+// SetName sets name for this producer.
+func SetName(name string) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.Name = name
+	}
+}
+
+// SetProperties sets application defined properties that will be attached to the producer.
+func SetProperties(properties map[string]string) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.Properties = properties
+	}
+}
+
+// SetMaxPendingMessages sets the max size of the queue holding the messages pending to receive an
+// acknowledgment from the broker.
+func SetMaxPendingMessages(maxPendingMessages int) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.MaxPendingMessages = maxPendingMessages
+	}
+}
+
+// SetHashingScheme sets the hashingScheme used to chose the partition on where to publish a particular message.
+func SetHashingScheme(hashingScheme HashingScheme) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.HashingScheme = hashingScheme
+	}
+}
+
+// SetCompressionLevel sets the desired compression level.
+func SetCompressionLevel(compressionLevel CompressionLevel) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.CompressionLevel = compressionLevel
+	}
+}
+
+// SetCompressionType set the compression type for the producer.
+func SetCompressionType(compressionType CompressionType) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.CompressionType = compressionType
+	}
+}
+
+// SetMessageRouter set a custom message routing policy by passing an implementation of MessageRouter.
+func SetMessageRouter(messageRouter func(*ProducerMessage, TopicMetadata) int) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.MessageRouter = messageRouter
+	}
+}
+
+// SetDisableBatching sets whether automatic batching of messages is enabled for the producer.
+func SetDisableBatching(disableBatching bool) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.DisableBatching = disableBatching
+	}
+}
+
+// SetBatchingMaxPublishDelay sets the time period within which the messages sent will be batched (default: 10ms).
+func SetBatchingMaxPublishDelay(batchingMaxPublishDelay time.Duration) ProducerOption {
+	return func(o *ProducerOptions) {
+		if batchingMaxPublishDelay != 0 {
+			o.BatchingMaxPublishDelay = batchingMaxPublishDelay
+		}
+	}
+}
+
+// SetBatchingMaxMessages sets the maximum number of messages permitted in a batch. (default: 1000).
+func SetBatchingMaxMessages(batchingMaxMessages uint) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.BatchingMaxMessages = batchingMaxMessages
+	}
+}
+
+// SetBatchingMaxSize sets the maximum number of bytes permitted in a batch. (default 128 KB).
+func SetBatchingMaxSize(batchingMaxSize uint) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.BatchingMaxSize = batchingMaxSize
+	}
+}
+
+// SetInterceptors sets interceptors that will be called at some points defined in ProducerInterceptor interface.
+func SetInterceptors(interceptors ProducerInterceptors) ProducerOption {
+	return func(o *ProducerOptions) {
+		o.Interceptors = interceptors
+	}
+}
+
 // Producer is used to publish messages on a topic
 type Producer interface {
 	// Topic return the topic to which producer is publishing to

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -82,7 +82,7 @@ func getHashingFunction(s HashingScheme) func(string) uint32 {
 func newProducer(client *client, opts ...ProducerOption) (*producer, error) {
 	var options = &ProducerOptions{
 		BatchingMaxPublishDelay: defaultBatchingMaxPublishDelay,
-		Interceptors: defaultProducerInterceptors,
+		Interceptors:            defaultProducerInterceptors,
 	}
 	for _, o := range opts {
 		o(options)

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -115,7 +115,7 @@ func TestProducerAsyncSend(t *testing.T) {
 
 	producer, err := client.CreateProducer(
 		SetTopic(newTopicName()),
-		SetBatchingMaxPublishDelay(1 * time.Second),
+		SetBatchingMaxPublishDelay(1*time.Second),
 	)
 
 	assert.NoError(t, err)
@@ -273,7 +273,7 @@ func TestFlushInProducer(t *testing.T) {
 		SetTopic(topicName),
 		SetDisableBatching(false),
 		SetBatchingMaxMessages(uint(numOfMessages)),
-		SetBatchingMaxPublishDelay(time.Second * 10),
+		SetBatchingMaxPublishDelay(time.Second*10),
 		SetProperties(map[string]string{
 			"producer-name": "test-producer-name",
 			"producer-id":   "test-producer-id",
@@ -395,8 +395,8 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 	producer, err := client.CreateProducer(
 		SetTopic(topicName),
 		SetDisableBatching(false),
-		SetBatchingMaxMessages(uint(numOfMessages / numberOfPartitions)),
-		SetBatchingMaxPublishDelay(time.Second * 10),
+		SetBatchingMaxMessages(uint(numOfMessages/numberOfPartitions)),
+		SetBatchingMaxPublishDelay(time.Second*10),
 	)
 	assert.Nil(t, err)
 	defer producer.Close()

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -49,9 +49,9 @@ func TestProducerConnectError(t *testing.T) {
 
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	// Expect error in creating producer
 	assert.Nil(t, producer)
@@ -72,7 +72,7 @@ func TestProducerNoTopic(t *testing.T) {
 
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{})
+	producer, err := client.CreateProducer()
 
 	// Expect error in creating producer
 	assert.Nil(t, producer)
@@ -88,9 +88,9 @@ func TestSimpleProducer(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -113,10 +113,10 @@ func TestProducerAsyncSend(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   newTopicName(),
-		BatchingMaxPublishDelay: 1 * time.Second,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+		SetBatchingMaxPublishDelay(1 * time.Second),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -172,10 +172,10 @@ func TestProducerCompression(t *testing.T) {
 			assert.NoError(t, err)
 			defer client.Close()
 
-			producer, err := client.CreateProducer(ProducerOptions{
-				Topic:           newTopicName(),
-				CompressionType: p.compressionType,
-			})
+			producer, err := client.CreateProducer(
+				SetTopic(newTopicName()),
+				SetCompressionType(p.compressionType),
+			)
 
 			assert.NoError(t, err)
 			assert.NotNil(t, producer)
@@ -200,9 +200,9 @@ func TestProducerLastSequenceID(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
@@ -229,9 +229,9 @@ func TestEventTime(t *testing.T) {
 	defer client.Close()
 
 	topicName := "test-event-time"
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -269,16 +269,16 @@ func TestFlushInProducer(t *testing.T) {
 	ctx := context.Background()
 
 	// set batch message number numOfMessages, and max delay 10s
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   topicName,
-		DisableBatching:         false,
-		BatchingMaxMessages:     uint(numOfMessages),
-		BatchingMaxPublishDelay: time.Second * 10,
-		Properties: map[string]string{
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetDisableBatching(false),
+		SetBatchingMaxMessages(uint(numOfMessages)),
+		SetBatchingMaxPublishDelay(time.Second * 10),
+		SetProperties(map[string]string{
 			"producer-name": "test-producer-name",
 			"producer-id":   "test-producer-id",
-		},
-	})
+		}),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -392,12 +392,12 @@ func TestFlushInPartitionedProducer(t *testing.T) {
 	defer consumer.Close()
 
 	// create producer and set batch message number numOfMessages, and max delay 10s
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   topicName,
-		DisableBatching:         false,
-		BatchingMaxMessages:     uint(numOfMessages / numberOfPartitions),
-		BatchingMaxPublishDelay: time.Second * 10,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetDisableBatching(false),
+		SetBatchingMaxMessages(uint(numOfMessages / numberOfPartitions)),
+		SetBatchingMaxPublishDelay(time.Second * 10),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -469,10 +469,10 @@ func TestRoundRobinRouterPartitionedProducer(t *testing.T) {
 	defer consumer.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topicName,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -528,13 +528,13 @@ func TestMessageRouter(t *testing.T) {
 	assert.Nil(t, err)
 	defer consumer.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: "my-partitioned-topic",
-		MessageRouter: func(msg *ProducerMessage, tm TopicMetadata) int {
+	producer, err := client.CreateProducer(
+		SetTopic("my-partitioned-topic"),
+		SetMessageRouter(func(msg *ProducerMessage, tm TopicMetadata) int {
 			fmt.Println("Routing message ", msg, " -- Partitions: ", tm.NumPartitions())
 			return 2
-		},
-	})
+		}),
+	)
 
 	assert.Nil(t, err)
 	defer producer.Close()
@@ -564,9 +564,9 @@ func TestNonPersistentTopic(t *testing.T) {
 	assert.Nil(t, err)
 	defer client.Close()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 
 	assert.Nil(t, err)
 	defer producer.Close()
@@ -591,19 +591,19 @@ func TestProducerDuplicateNameOnSameTopic(t *testing.T) {
 	topicName := newTopicName()
 	producerName := "my-producer"
 
-	p1, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-		Name:  producerName,
-	})
+	p1, err := client.CreateProducer(
+		SetTopic(topicName),
+		SetName(producerName),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer p1.Close()
 
-	_, err = client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-		Name:  producerName,
-	})
+	_, err = client.CreateProducer(
+		SetTopic(topicName),
+		SetName(producerName),
+	)
 	assert.NotNil(t, err, "expected error when creating producer with same name")
 }
 
@@ -620,11 +620,11 @@ func TestProducerMetadata(t *testing.T) {
 	props := map[string]string{
 		"key1": "value1",
 	}
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:      topic,
-		Name:       "my-producer",
-		Properties: props,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetName("my-producer"),
+		SetProperties(props),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -653,9 +653,9 @@ func TestBatchMessageFlushing(t *testing.T) {
 	defer client.Close()
 
 	topic := newTopicName()
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,9 +713,9 @@ func TestDelayRelative(t *testing.T) {
 	defer client.Close()
 
 	topicName := newTopicName()
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -756,9 +756,9 @@ func TestDelayAbsolute(t *testing.T) {
 	defer client.Close()
 
 	topicName := newTopicName()
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -797,9 +797,9 @@ func TestMaxMessageSize(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	defer client.Close()
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: newTopicName(),
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(newTopicName()),
+	)
 	assert.NoError(t, err)
 	assert.NotNil(t, producer)
 	defer producer.Close()
@@ -861,14 +861,14 @@ func TestProducerWithInterceptors(t *testing.T) {
 
 	metric := &metricProduceInterceptor{}
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: false,
-		Interceptors: ProducerInterceptors{
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(false),
+		SetInterceptors(ProducerInterceptors{
 			noopProduceInterceptor{},
 			metric,
-		},
-	})
+		}),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -196,7 +196,7 @@ func TestReaderOnSpecificMessageWithBatching(t *testing.T) {
 		SetTopic(topic),
 		SetDisableBatching(false),
 		SetBatchingMaxMessages(3),
-		SetBatchingMaxPublishDelay(1 * time.Second),
+		SetBatchingMaxPublishDelay(1*time.Second),
 	)
 	assert.Nil(t, err)
 	defer producer.Close()
@@ -272,7 +272,7 @@ func TestReaderOnLatestWithBatching(t *testing.T) {
 		SetTopic(topic),
 		SetDisableBatching(false),
 		SetBatchingMaxMessages(4),
-		SetBatchingMaxPublishDelay(1 * time.Second),
+		SetBatchingMaxPublishDelay(1*time.Second),
 	)
 	assert.Nil(t, err)
 	defer producer.Close()

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -67,9 +67,9 @@ func TestReader(t *testing.T) {
 	defer reader.Close()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topic,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -124,10 +124,10 @@ func TestReaderOnSpecificMessage(t *testing.T) {
 	ctx := context.Background()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -192,12 +192,12 @@ func TestReaderOnSpecificMessageWithBatching(t *testing.T) {
 	ctx := context.Background()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   topic,
-		DisableBatching:         false,
-		BatchingMaxMessages:     3,
-		BatchingMaxPublishDelay: 1 * time.Second,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(false),
+		SetBatchingMaxMessages(3),
+		SetBatchingMaxPublishDelay(1 * time.Second),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -268,12 +268,12 @@ func TestReaderOnLatestWithBatching(t *testing.T) {
 	ctx := context.Background()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:                   topic,
-		DisableBatching:         false,
-		BatchingMaxMessages:     4,
-		BatchingMaxPublishDelay: 1 * time.Second,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(false),
+		SetBatchingMaxMessages(4),
+		SetBatchingMaxPublishDelay(1 * time.Second),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -324,10 +324,10 @@ func TestReaderHasNext(t *testing.T) {
 	ctx := context.Background()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -383,10 +383,10 @@ func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	ctx := context.Background()
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -457,9 +457,9 @@ func TestReaderSeek(t *testing.T) {
 	topicName := newTopicName()
 	ctx := context.Background()
 
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic: topicName,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topicName),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 
@@ -530,10 +530,10 @@ func TestReaderLatestInclusiveHasNext(t *testing.T) {
 	assert.False(t, reader0.HasNext())
 
 	// create producer
-	producer, err := client.CreateProducer(ProducerOptions{
-		Topic:           topic,
-		DisableBatching: true,
-	})
+	producer, err := client.CreateProducer(
+		SetTopic(topic),
+		SetDisableBatching(true),
+	)
 	assert.Nil(t, err)
 	defer producer.Close()
 


### PR DESCRIPTION
### Motivation

*Using the Functional Options Pattern to make producer constructor more elegant and explicit.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API: yes  (CreateProducer)
  - The schema:no
  - The default values of configurations:  no
  - The wire protocol:  no

### Documentation

  - Does this pull request introduce a new feature? no