### PR TITLE
Support ack timeout

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -132,6 +132,9 @@ type ConsumerOptions struct {
 	// Set the consumer name.
 	Name string
 
+	// Timeout of unacked messages.
+	AckTimeout time.Duration
+
 	// If enabled, the consumer will read messages from the compacted topic rather than reading the full message backlog
 	// of the topic. This means that, if the topic has been compacted, the consumer will only see the latest value for
 	// each key in the topic, up until the point in the topic message backlog that has been compacted. Beyond that

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -114,8 +114,8 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 
 	if options.AckTimeout != 0 && options.AckTimeout < minAckTimeout {
 		msg := fmt.Sprintf("ackTimeout %dms should be greater than %dms",
-			options.AckTimeout.Milliseconds(),
-			minAckTimeout.Milliseconds(),
+			options.AckTimeout.Nanoseconds()/1e6,
+			minAckTimeout.Nanoseconds()/1e6,
 		)
 		return nil, newError(ResultInvalidConfiguration, msg)
 	}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -227,7 +227,7 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 	}
 
 	if options.AckTimeout > 0 {
-		consumer.unackTracker = NewUnackedMessageTracker(options.AckTimeout, minAckTimeoutTickTime)
+		consumer.unackTracker = newUnackedMessageTracker(options.AckTimeout)
 	}
 	err := consumer.internalTopicSubscribeToPartitions()
 	if err != nil {

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -113,10 +113,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 	}
 
 	if options.AckTimeout != 0 && options.AckTimeout < minAckTimeout {
-		msg := fmt.Sprintf("ackTimeout %dms should be greater than %dms",
-			options.AckTimeout.Nanoseconds()/1e6,
-			minAckTimeout.Nanoseconds()/1e6,
-		)
+		msg := fmt.Sprintf("ackTimeout %s should be greater than %s", options.AckTimeout, minAckTimeout)
 		return nil, newError(ResultInvalidConfiguration, msg)
 	}
 

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -61,7 +61,7 @@ func newMultiTopicConsumer(client *client, options ConsumerOptions, topics []str
 	}
 
 	if options.AckTimeout > 0 {
-		mtc.unackTracker = NewUnackedMessageTracker(options.AckTimeout, minAckTimeoutTickTime)
+		mtc.unackTracker = newUnackedMessageTracker(options.AckTimeout)
 		// avoid consumers instantiate unack tracker separately
 		options.AckTimeout = 0
 	}

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -92,7 +92,7 @@ func newRegexConsumer(c *client, opts ConsumerOptions, tn *internal.TopicName, p
 		return nil, err
 	}
 	if opts.AckTimeout > 0 {
-		rc.unackTracker = NewUnackedMessageTracker(opts.AckTimeout, minAckTimeoutTickTime)
+		rc.unackTracker = newUnackedMessageTracker(opts.AckTimeout)
 		opts.AckTimeout = 0
 	}
 

--- a/pulsar/unacked_message_tracker.go
+++ b/pulsar/unacked_message_tracker.go
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type timeSector map[messageID]interface{}
+
+type unackedMessageTracker struct {
+	sync.Mutex
+
+	tick       *time.Ticker
+	ackTimeout time.Duration
+
+	// Consumer delegate trackingMessageID's acker to do Redelivery
+	sectors      []timeSector
+	msgID2Acker  map[messageID]acker
+	msgID2Sector map[messageID]timeSector
+
+	doneCh chan interface{}
+}
+
+func NewUnackedMessageTracker(ackTimeout time.Duration, tickTime time.Duration) *unackedMessageTracker {
+	t := &unackedMessageTracker{
+		tick:         time.NewTicker(tickTime),
+		msgID2Sector: make(map[messageID]timeSector),
+		msgID2Acker:  make(map[messageID]acker),
+		doneCh:       make(chan interface{}),
+	}
+	n := int(math.Ceil(float64(ackTimeout) / float64(tickTime)))
+	for i := 0; i <= n; i++ {
+		t.sectors = append(t.sectors, make(timeSector))
+	}
+
+	go t.track()
+	return t
+}
+
+func (t *unackedMessageTracker) add(msgID trackingMessageID) {
+	// do not add each item in batch message into tracker
+	mid := msgID.messageID
+	mid.batchIdx = 0
+	t.Lock()
+	defer t.Unlock()
+
+	tailSector := t.sectors[len(t.sectors)-1]
+	if _, ok := t.msgID2Sector[mid]; !ok {
+		tailSector[mid] = nil
+		t.msgID2Acker[mid] = msgID.consumer
+		t.msgID2Sector[mid] = tailSector
+	}
+}
+
+func (t *unackedMessageTracker) remove(msgID messageID) {
+	msgID.batchIdx = 0
+	t.Lock()
+	defer t.Unlock()
+	if sector, ok := t.msgID2Sector[msgID]; ok {
+		delete(sector, msgID)
+		delete(t.msgID2Acker, msgID)
+		delete(t.msgID2Sector, msgID)
+	}
+}
+
+func (t *unackedMessageTracker) track() {
+	for {
+		select {
+		case <-t.doneCh:
+			log.Debug("Closing unacked tracker")
+			return
+		case <-t.tick.C:
+			t.Lock()
+
+			headSector := t.sectors[0]
+			t.sectors = t.sectors[1:] // dequeue
+			n := len(headSector)
+			msgIDs := make([]messageID, 0, n)
+			if n > 0 {
+				log.Warnf("%d messages have timed-out", n)
+				for msgID := range headSector {
+					msgIDs = append(msgIDs, msgID)
+					delete(t.msgID2Sector, msgID)
+				}
+			}
+			headSector = nil
+			headSector = make(map[messageID]interface{})
+			t.sectors = append(t.sectors, headSector) // enqueue
+
+			t.Unlock()
+
+			if len(msgIDs) > 0 {
+				acker2ids := make(map[acker][]messageID)
+				t.Lock()
+				for _, id := range msgIDs {
+					if acker, ok := t.msgID2Acker[id]; ok {
+						acker2ids[acker] = append(acker2ids[acker], id)
+						delete(t.msgID2Acker, id)
+					}
+				}
+				t.Unlock()
+
+				for acker, ids := range acker2ids {
+					acker.Redeliver(ids)
+				}
+			}
+		}
+	}
+}
+
+func (t *unackedMessageTracker) Close() {
+	t.doneCh <- nil
+}

--- a/pulsar/unacked_message_tracker.go
+++ b/pulsar/unacked_message_tracker.go
@@ -128,3 +128,9 @@ func (t *unackedMessageTracker) track() {
 func (t *unackedMessageTracker) Close() {
 	t.doneCh <- nil
 }
+
+func (t *unackedMessageTracker) size() int {
+	t.Lock()
+	defer t.Unlock()
+	return len(t.msgID2Sector)
+}

--- a/pulsar/unacked_message_tracker_test.go
+++ b/pulsar/unacked_message_tracker_test.go
@@ -420,11 +420,11 @@ func receiveAll(c Consumer, ack bool) int {
 func unackTrackersSize(ic Consumer) (tracked int) {
 	switch c := ic.(type) {
 	case *consumer:
-		return len(c.unackTracker.msgID2Sector)
+		return c.unackTracker.size()
 	case *multiTopicConsumer:
-		return len(c.unackTracker.msgID2Sector)
+		return c.unackTracker.size()
 	case *regexConsumer:
-		return len(c.unackTracker.msgID2Sector)
+		return c.unackTracker.size()
 	default:
 		log.Errorf("unexpected Consumer type: %T", ic)
 		return -1

--- a/pulsar/unacked_message_tracker_test.go
+++ b/pulsar/unacked_message_tracker_test.go
@@ -1,0 +1,430 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ackTimeout  = 2000 * time.Millisecond
+	recvTimeout = 1000 * time.Millisecond
+)
+
+type ackTimeoutMockedConsumer struct {
+	msgCh chan messageID
+}
+
+func newAckTimeoutMockedConsumer() *ackTimeoutMockedConsumer {
+	c := &ackTimeoutMockedConsumer{
+		msgCh: make(chan messageID, 10),
+	}
+	go func() {
+		// ensure we have enough time to verify msgs after timeout
+		time.Sleep(ackTimeout + minAckTimeoutTickTime*2)
+		close(c.msgCh)
+	}()
+	return c
+}
+
+func (c *ackTimeoutMockedConsumer) Redeliver(msgIds []messageID) {
+	for _, msgId := range msgIds {
+		c.msgCh <- msgId
+	}
+}
+
+func (c *ackTimeoutMockedConsumer) AckID(trackingMessageID) {}
+
+func (c *ackTimeoutMockedConsumer) NackID(trackingMessageID) {}
+
+func TestAckTimeoutWithBatchesTracker(t *testing.T) {
+	c := newAckTimeoutMockedConsumer()
+	tracker := NewUnackedMessageTracker(ackTimeout, minAckTimeoutTickTime)
+	defer tracker.Close()
+
+	f := func(ledgerID, entryID int64, batchIdx int32) trackingMessageID {
+		return trackingMessageID{
+			messageID: messageID{
+				ledgerID: ledgerID,
+				entryID:  entryID,
+				batchIdx: batchIdx,
+			},
+			consumer: c,
+		}
+	}
+	tracker.add(f(1, 1, 1))
+	tracker.add(f(1, 1, 2))
+	tracker.add(f(1, 1, 3))
+	tracker.add(f(2, 2, 1))
+
+	var msgIds []messageID
+	for msgId := range c.msgCh {
+		msgIds = append(msgIds, msgId)
+	}
+	msgIds = sortMessageIds(msgIds)
+
+	assert.Equal(t, 2, len(msgIds))
+	assert.Equal(t, int64(1), msgIds[0].ledgerID)
+	assert.Equal(t, int64(1), msgIds[0].entryID)
+	assert.Equal(t, int64(2), msgIds[1].ledgerID)
+	assert.Equal(t, int64(2), msgIds[1].entryID)
+}
+
+func TestMinAckTimeout(t *testing.T) {
+	client, err := newClient(ClientOptions{URL: lookupURL})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            newTopicName(),
+		SubscriptionName: "sub-1",
+		Type:             Exclusive,
+		AckTimeout:       minAckTimeout - 1*time.Millisecond,
+	})
+	assert.NotNil(t, err)
+	log.Error(err)
+	assert.Nil(t, consumer)
+}
+
+func TestAckTimeoutExclusive(t *testing.T) {
+	client, err := newClient(ClientOptions{URL: lookupURL})
+	assert.Nil(t, err)
+	defer client.Close()
+	totalMsgs := 10
+
+	topic := newTopicName()
+	ctx := context.Background()
+
+	// 1. create producer
+	producer, err := client.CreateProducer(ProducerOptions{Topic: topic})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// 2. create consumer
+	c, err := client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		SubscriptionName: "sub-1",
+		Type:             Exclusive,
+		AckTimeout:       ackTimeout,
+	})
+	assert.Nil(t, err)
+	defer c.Close()
+
+	// 3. publish 5 messages
+	for i := 0; i < totalMsgs/2; i++ {
+		_, err = producer.Send(ctx, &ProducerMessage{Payload: []byte(fmt.Sprintf("MSG_%d", i))})
+		assert.Nil(t, err)
+	}
+
+	// 4. received 5 messages, but not ack
+	recv := receiveAll(c, recvTimeout, false)
+	assert.Equal(t, totalMsgs/2, recv)
+
+	// validate consumer's unack tracker size
+	assert.Equal(t, totalMsgs/2, unackTrackersSize(c))
+	// wait ack timeout triggered
+	time.Sleep(ackTimeout)
+
+	// 5. publish more 5 messages
+	for i := totalMsgs / 2; i < totalMsgs; i++ {
+		_, err = producer.Send(ctx, &ProducerMessage{Payload: []byte(fmt.Sprintf("MSG_%d", i))})
+		assert.Nil(t, err)
+	}
+
+	// 6. receive 10 messages, and ack
+	recv = receiveAll(c, recvTimeout, true)
+	assert.Equal(t, totalMsgs, recv)
+	assert.Equal(t, 0, unackTrackersSize(c))
+}
+
+func TestAckTimeoutFailover(t *testing.T) {
+	topic := newTopicName()
+	uri := adminURL + "/" + "admin/v2/persistent/public/default/" + topic + "/partitions"
+	makeHTTPCall(t, http.MethodPut, uri, "3")
+
+	client, err := newClient(ClientOptions{URL: lookupURL})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	totalMsgs := 10
+	ctx := context.Background()
+
+	// 1. create producer
+	producer, err := client.CreateProducer(ProducerOptions{Topic: topic})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// 2. create 2 consumers
+	c1, err := client.Subscribe(ConsumerOptions{
+		Name:             "C1",
+		Topic:            topic,
+		SubscriptionName: "sub-1",
+		Type:             Failover,
+		AckTimeout:       ackTimeout,
+	})
+	assert.Nil(t, err)
+	defer c1.Close()
+
+	c2, err := client.Subscribe(ConsumerOptions{
+		Name:             "C2",
+		Topic:            topic,
+		SubscriptionName: "sub-1",
+		Type:             Failover,
+		AckTimeout:       ackTimeout,
+	})
+	assert.Nil(t, err)
+	defer c2.Close()
+
+	// 3. publish 10 messages
+	for i := 0; i < totalMsgs; i++ {
+		_, err = producer.Send(ctx, &ProducerMessage{Payload: []byte(fmt.Sprintf("MSG_%d", i))})
+		assert.Nil(t, err)
+	}
+
+	// 4. received 10 messages totally
+	recv1 := receiveAll(c1, recvTimeout, false)
+	acked1 := 0
+	recv2 := receiveAll(c2, recvTimeout, true)
+	assert.Equal(t, totalMsgs, recv1+recv2)
+
+	// wait ack timeout triggered
+	time.Sleep(ackTimeout)
+
+	// 5. check if messages redelivery
+	recv1 = receiveAll(c1, recvTimeout, true)
+	acked1 = recv1
+	recv2 += receiveAll(c2, recvTimeout, false)
+	assert.Equal(t, totalMsgs, acked1+recv2)
+	assert.Equal(t, 0, unackTrackersSize(c1))
+	assert.Equal(t, 0, unackTrackersSize(c2))
+}
+
+func TestAckTimeoutShared(t *testing.T) {
+	topic := newTopicName()
+	uri := adminURL + "/" + "admin/v2/persistent/public/default/" + topic + "/partitions"
+	makeHTTPCall(t, http.MethodPut, uri, "3")
+
+	client, err := newClient(ClientOptions{URL: lookupURL})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	totalMsgs := 10
+	ctx := context.Background()
+
+	// 1. create producer
+	producer, err := client.CreateProducer(ProducerOptions{Topic: topic})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// 2. create 2 consumers
+	c1, err := client.Subscribe(ConsumerOptions{
+		Name:             "C1",
+		Topic:            topic,
+		SubscriptionName: "sub-1",
+		Type:             Shared,
+		AckTimeout:       ackTimeout,
+	})
+	assert.Nil(t, err)
+	defer c1.Close()
+
+	c2, err := client.Subscribe(ConsumerOptions{
+		Name:             "C2",
+		Topic:            topic,
+		SubscriptionName: "sub-1",
+		Type:             Shared,
+		AckTimeout:       ackTimeout,
+	})
+	assert.Nil(t, err)
+	defer c2.Close()
+
+	// 3. publish 10 messages
+	for i := 0; i < totalMsgs; i++ {
+		_, err = producer.Send(ctx, &ProducerMessage{Payload: []byte(fmt.Sprintf("MSG_%d", i))})
+		assert.Nil(t, err)
+	}
+
+	// 4. receive 10 messages totally
+	recv1 := receiveAll(c1, recvTimeout, false) // not-ack
+	acked1 := 0
+	recv2 := receiveAll(c2, recvTimeout, true) // ack
+	acked2 := recv2
+	assert.Equal(t, totalMsgs, recv1+recv2)
+
+	time.Sleep(ackTimeout)
+
+	// 5. check if messages redelivery again
+	recv1 = receiveAll(c1, recvTimeout, true) // not-ack --> ack
+	acked1 = recv1
+	recv2 += receiveAll(c2, recvTimeout, false) // ack --> not-ack
+	assert.Equal(t, totalMsgs, recv1+recv2)
+	assert.Equal(t, totalMsgs, acked1+recv2)
+
+	time.Sleep(ackTimeout)
+
+	// 6. now check remaining messages redelivery
+	acked1 += receiveAll(c1, recvTimeout, true)
+	acked2 += receiveAll(c2, recvTimeout, true)
+	assert.Equal(t, totalMsgs, acked1+acked2)
+	assert.Equal(t, 0, unackTrackersSize(c1))
+	assert.Equal(t, 0, unackTrackersSize(c2))
+}
+
+func TestAckTimeoutSharedMultiAndRegexTopics(t *testing.T) {
+	t.Run("AckTimeoutMultiTopics", func(t *testing.T) {
+		topic := newTopicName()
+		topics := []string{topic + "1", topic + "2"}
+		option := ConsumerOptions{
+			Topics:           topics,
+			SubscriptionName: "sub-1",
+			Type:             Shared,
+			AckTimeout:       ackTimeout,
+		}
+		runAckTimeoutMultiTopics(t, topics, option)
+	})
+
+	t.Run("AckTimeoutRegexTopics", func(t *testing.T) {
+		topic := newTopicName()
+		topics := []string{topic + "1", topic + "2"}
+		option := ConsumerOptions{
+			TopicsPattern:    topic + ".*",
+			SubscriptionName: "sub-1",
+			Type:             Shared,
+			AckTimeout:       ackTimeout,
+		}
+		runAckTimeoutMultiTopics(t, topics, option)
+	})
+}
+
+func runAckTimeoutMultiTopics(t *testing.T, topics []string, options ConsumerOptions) {
+	topic1, topic2 := topics[0], topics[1]
+	assert.Nil(t, createPartitionTopic(t, topic1, 3))
+	assert.Nil(t, createPartitionTopic(t, topic2, 3))
+
+	client, err := newClient(ClientOptions{URL: lookupURL})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	totalMsgs := 10
+	ctx := context.Background()
+
+	// 1. create 2 producers
+	p1, err := client.CreateProducer(ProducerOptions{Topic: topic1})
+	assert.Nil(t, err)
+	defer p1.Close()
+	p2, err := client.CreateProducer(ProducerOptions{Topic: topic2})
+	assert.Nil(t, err)
+	defer p2.Close()
+
+	// 2. create 2 consumers
+	options.Name = "C1"
+	c1, err := client.Subscribe(options)
+	assert.Nil(t, err)
+	defer c1.Close()
+
+	options.Name = "C2"
+	c2, err := client.Subscribe(options)
+	assert.Nil(t, err)
+	defer c2.Close()
+
+	// 3. publish 10 messages
+	for i := 0; i < totalMsgs/2; i++ {
+		_, err = p1.Send(ctx, &ProducerMessage{Payload: []byte(fmt.Sprintf("MSG_T1_%d", i))})
+		assert.Nil(t, err)
+		_, err = p2.Send(ctx, &ProducerMessage{Payload: []byte(fmt.Sprintf("MSG_T2_%d", i))})
+		assert.Nil(t, err)
+	}
+
+	// 4. receive 10 messages totally
+	recv1 := receiveAll(c1, recvTimeout, false) // not-ack
+	acked1 := 0
+	recv2 := receiveAll(c2, recvTimeout, true) // ack
+	acked2 := recv2
+	assert.Equal(t, totalMsgs, recv1+recv2)
+
+	time.Sleep(ackTimeout)
+
+	// 5. check if messages redelivery again
+	recv1 = receiveAll(c1, recvTimeout, true) // reset
+	acked1 = recv1
+	recv2 += receiveAll(c2, recvTimeout, false)
+	assert.Equal(t, totalMsgs, recv1+recv2)
+	assert.Equal(t, totalMsgs, acked1+recv2)
+
+	time.Sleep(ackTimeout)
+
+	// 6. now check remaining messages redelivery
+	acked1 += receiveAll(c1, recvTimeout, true)
+	acked2 += receiveAll(c2, recvTimeout, true)
+	assert.Equal(t, totalMsgs, acked1+acked2)
+	assert.Equal(t, 0, unackTrackersSize(c1))
+	assert.Equal(t, 0, unackTrackersSize(c2))
+}
+
+func receiveAll(c Consumer, timeout time.Duration, ack bool) int {
+	received := 0
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		msg, err := c.Receive(ctx)
+		if err != nil {
+			if err == context.DeadlineExceeded || msg == nil {
+				return received
+			}
+			log.Errorf("unexpected receiveAll error: %v", err)
+			return 0
+		}
+		if !ack {
+			log.Warnf("%s consumed but not ack: <%s>: %s", c.Name(), msg.ID(), string(msg.Payload()))
+		} else {
+			log.Infof("%s consumed and ack: <%s>: %s", c.Name(), msg.ID(), string(msg.Payload()))
+			c.Ack(msg)
+		}
+		received++
+		cancel()
+	}
+}
+
+func unackTrackersSize(c Consumer) (tracked int) {
+	switch c.(type) {
+	case *consumer:
+		return len(c.(*consumer).unackTracker.msgID2Sector)
+	case *multiTopicConsumer:
+		return len(c.(*multiTopicConsumer).unackTracker.msgID2Sector)
+	case *regexConsumer:
+		return len(c.(*regexConsumer).unackTracker.msgID2Sector)
+	default:
+		log.Errorf("unexpected Consumer type: %T", c)
+		return -1
+	}
+}
+
+func createPartitionTopic(t *testing.T, topic string, partition int) error {
+	if partition <= 1 {
+		return createTopic(topic)
+	}
+	uri := adminURL + "/" + "admin/v2/persistent/public/default/" + topic + "/partitions"
+	makeHTTPCall(t, http.MethodPut, uri, strconv.Itoa(partition))
+	return nil
+}


### PR DESCRIPTION
### Motivation
Follow doc [acknowledgement-timeout](https://pulsar.apache.org/docs/en/concepts-messaging/#acknowledgement-timeout) to support ack timeout feature.

### Modifications

- Add `AckTimeout` to ConsumerOptions.
- Add `unackedMessageTracker` to track messages which received by user.
- Add 5 `TestAckTimeout*` test cases.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- `TestAckTimeout*`
    Track ack timeout in single topic consumers, with `Exclusive, Failover, Shared` subscription.
- `TestAckTimeoutSharedMultiAndRegexTopics` 
    Track ack timeout in multi topics consumers, with `Shared` subscription.

### Different default behavior
- Java Client: if consumer enabled DLQPolicy, added 30s `ackTimeout` by default, see [apache/pulsar #3104](https://github.com/apache/pulsar/pull/3014)
- Go Client: I think it's no longer necessary to do this, so ignored.