### PR TITLE
[Issue 367][producer] Send delay message individually even batching is enabled

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -152,7 +152,7 @@ func (bb *BatchBuilder) reset() {
 	bb.numMessages = 0
 	bb.buffer.Clear()
 	bb.callbacks = []interface{}{}
-	bb.msgMetadata.ReplicateTo = nil
+	bb.msgMetadata.Reset()
 }
 
 // Flush all the messages buffered in the client and wait until all messages have been successfully persisted.

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -152,7 +152,8 @@ func (bb *BatchBuilder) reset() {
 	bb.numMessages = 0
 	bb.buffer.Clear()
 	bb.callbacks = []interface{}{}
-	bb.msgMetadata.Reset()
+	bb.msgMetadata.ReplicateTo = nil
+	bb.msgMetadata.DeliverAtTime = nil
 }
 
 // Flush all the messages buffered in the client and wait until all messages have been successfully persisted.

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -334,6 +334,9 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		sequenceID = internal.GetAndAdd(p.sequenceIDGenerator, 1)
 	}
 
+	if !sendAsBatch {
+		p.internalFlushCurrentBatch()
+	}
 	added := p.batchBuilder.Add(smm, sequenceID, msg.Payload, request,
 		msg.ReplicationClusters, deliverAt)
 	if !added {
@@ -437,7 +440,6 @@ func (p *partitionProducer) SendAsync(ctx context.Context, msg *ProducerMessage,
 
 func (p *partitionProducer) internalSendAsync(ctx context.Context, msg *ProducerMessage,
 	callback func(MessageID, *ProducerMessage, error), flushImmediately bool) {
-
 	sr := &sendRequest{
 		ctx:              ctx,
 		msg:              msg,

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -733,10 +733,10 @@ func TestBatchDelayMessage(t *testing.T) {
 		Payload:      []byte("delay: 3s"),
 		DeliverAfter: 3 * time.Second,
 	}
-	var delayMsgId int64
+	var delayMsgID int64
 	ch := make(chan struct{}, 2)
 	producer.SendAsync(ctx, delayMsg, func(id MessageID, producerMessage *ProducerMessage, err error) {
-		atomic.StoreInt64(&delayMsgId, id.(messageID).entryID)
+		atomic.StoreInt64(&delayMsgID, id.(messageID).entryID)
 		ch <- struct{}{}
 	})
 	delayMsgPublished := false
@@ -750,18 +750,18 @@ func TestBatchDelayMessage(t *testing.T) {
 	noDelayMsg := &ProducerMessage{
 		Payload: []byte("no delay"),
 	}
-	var noDelayMsgId int64
+	var noDelayMsgID int64
 	producer.SendAsync(ctx, noDelayMsg, func(id MessageID, producerMessage *ProducerMessage, err error) {
-		atomic.StoreInt64(&noDelayMsgId, id.(messageID).entryID)
+		atomic.StoreInt64(&noDelayMsgID, id.(messageID).entryID)
 	})
 	for i := 0; i < 2; i++ {
 		msg, err := consumer.Receive(context.Background())
 		assert.Nil(t, err, "unexpected error occurred when recving message from topic")
 
 		switch msg.ID().(trackingMessageID).entryID {
-		case atomic.LoadInt64(&noDelayMsgId):
+		case atomic.LoadInt64(&noDelayMsgID):
 			assert.LessOrEqual(t, time.Since(msg.PublishTime()).Nanoseconds(), int64(batchingDelay*2))
-		case atomic.LoadInt64(&delayMsgId):
+		case atomic.LoadInt64(&delayMsgID):
 			assert.GreaterOrEqual(t, time.Since(msg.PublishTime()).Nanoseconds(), int64(time.Second*3))
 		default:
 			t.Fatalf("got an unexpected message from topic, id:%v", msg.ID().Serialize())


### PR DESCRIPTION
Fixes #367 


### Motivation

Send delay message individually even batching is enabled.


### Modifications

1. flush batching messages immediately when a new delay message is received
2. reset deliverAtTime metadata of `BatchBuilder`

### Verifying this change

Ref #367 


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
