### PR TITLE
[PR366] Make sure reconnectToBroker invoked before tearing down connection

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -753,7 +753,7 @@ func (c *connection) TriggerClose() {
 		close(c.closeCh)
 		cnx := c.cnx
 		if cnx != nil {
-			c.log.Infof("%v close conneciton", c.logicalAddr)
+			c.log.Infof("%v close connection", c.logicalAddr)
 			cnx.Close()
 		}
 


### PR DESCRIPTION
<--
### Contribution Checklist
Master Issue: https://github.com/apache/pulsar-client-go/pull/366

### Motivation
We have seen consumer hanging issues reported similar to https://github.com/apache/pulsar-client-go/pull/366 
Consumer was unable to reconnect to broker under these conditions
- multiple consumers with shared subscriptions
- topic is unloaded and reloaded to another broker due to load balancing

As @jiazhai pointed that partition consumer's reconnectToBroker() may have never been invoked due to deadlock of closed Connection. This is described at the end of PR 366 comments.

### Modifications
Reorganize the code to ensure consumer and producer handlers are closed before the connection is torn down, so that broker reconnect mechanism can run independently to retry until successful or reach the retry limit.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
This is not a feature but a bug fix.
