### PR TITLE
Fixed buffer resize when writing request on connection

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -470,6 +470,7 @@ func (c *connection) writeCommand(cmd *pb.BaseCommand) {
 	c.writeBuffer.WriteUint32(frameSize)
 
 	c.writeBuffer.WriteUint32(cmdSize)
+	c.writeBuffer.ResizeIfNeeded(cmdSize)
 	_, err := cmd.MarshalToSizedBuffer(c.writeBuffer.WritableSlice()[:cmdSize])
 	if err != nil {
 		c.log.WithError(err).Fatal("Protobuf serialization error")


### PR DESCRIPTION
### Motivation

There is a problem when writing large commands on the connections (other than commands with payloads which are already handled correctly). 

If the connection buffer doesn't have enough space, we're getting a panic for buffer overflow. 

This can for example happen when triggering a lot of `Nack()` requests.

```
INFO[19:10:38.794] Stats - Consume rate:  770.4 msg/s -    6.0 Mbps
INFO[19:10:42.128] Connection closed                             local_addr="192.168.1.3:61179" remote_addr="pulsar://192.168.1.3:6651"
panic: runtime error: slice bounds out of range [:31678] with capacity 4088

goroutine 68 [running]:
github.com/apache/pulsar-client-go/pulsar/internal.(*connection).writeCommand(0xc00022e360, 0xc00055b6c0)
	/Users/mmerli/go/src/github.com/apache/pulsar-client-go/pulsar/internal/connection.go:461 +0x350
github.com/apache/pulsar-client-go/pulsar/internal.(*connection).internalSendRequest(...)
	/Users/mmerli/go/src/github.com/apache/pulsar-client-go/pulsar/internal/connection.go:562
github.com/apache/pulsar-client-go/pulsar/internal.(*connection).run(0xc00022e360)
	/Users/mmerli/go/src/github.com/apache/pulsar-client-go/pulsar/internal/connection.go:375 +0x20e
github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start.func1(0xc00022e360)
	/Users/mmerli/go/src/github.com/apache/pulsar-client-go/pulsar/internal/connection.go:231 +0x71
created by github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start
	/Users/mmerli/go/src/github.com/apache/pulsar-client-go/pulsar/internal/connection.go:227 +0x3f
exit status 2
```