### PR TITLE
Support sendTimeout

### DIFF
--- a/integration-tests/standalone.conf
+++ b/integration-tests/standalone.conf
@@ -54,7 +54,7 @@ brokerShutdownTimeoutMs=3000
 backlogQuotaCheckEnabled=true
 
 # How often to check for topics that have reached the quota
-backlogQuotaCheckIntervalInSeconds=60
+backlogQuotaCheckIntervalInSeconds=5
 
 # Default per-topic backlog quota limit
 backlogQuotaDefaultLimitGB=10

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -78,7 +78,7 @@ type ProducerOptions struct {
 
 	// SendTimeout set the timeout for a message that not be acknowledged by server since sent.
 	// Send and SendAsync returns an error after timeout.
-	// Default is 30 seconds, -1 to disable.
+	// Default is 30 seconds, negative such as -1 to disable.
 	SendTimeout time.Duration
 
 	// DisableBlockIfQueueFull control whether Send and SendAsync block if producer's message queue is full.

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -81,9 +81,9 @@ type ProducerOptions struct {
 	// Default is 30 seconds, -1 to disable.
 	SendTimeout time.Duration
 
-	// BlockIfQueueFull control whether Send and SendAsync return error if producer's message queue is full.
-	// Default is false.
-	BlockIfQueueFull bool
+	// NonBlockIfQueueFull control whether Send and SendAsync block if producer's message queue is full.
+	// Default is false, if set to true then Send and SendAsync return error when queue is full.
+	NonBlockIfQueueFull bool
 
 	// MaxPendingMessages set the max size of the queue holding the messages pending to receive an
 	// acknowledgment from the broker.

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -76,6 +76,15 @@ type ProducerOptions struct {
 	// This properties will be visible in the topic stats
 	Properties map[string]string
 
+	// SendTimeout set the timeout for a message that not be acknowledged by server since sent.
+	// Send and SendAsync returns an error after timeout.
+	// Default is 30 seconds, -1 to disable.
+	SendTimeout time.Duration
+
+	// BlockIfQueueFull control whether Send and SendAsync return error if producer's message queue is full.
+	// Default is false.
+	BlockIfQueueFull bool
+
 	// MaxPendingMessages set the max size of the queue holding the messages pending to receive an
 	// acknowledgment from the broker.
 	MaxPendingMessages int

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -81,9 +81,9 @@ type ProducerOptions struct {
 	// Default is 30 seconds, -1 to disable.
 	SendTimeout time.Duration
 
-	// NonBlockIfQueueFull control whether Send and SendAsync block if producer's message queue is full.
+	// DisableBlockIfQueueFull control whether Send and SendAsync block if producer's message queue is full.
 	// Default is false, if set to true then Send and SendAsync return error when queue is full.
-	NonBlockIfQueueFull bool
+	DisableBlockIfQueueFull bool
 
 	// MaxPendingMessages set the max size of the queue holding the messages pending to receive an
 	// acknowledgment from the broker.

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -96,8 +96,6 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 
 	if options.SendTimeout == 0 {
 		options.SendTimeout = defaultSendTimeout
-	} else if options.SendTimeout == -1 {
-		options.SendTimeout = 0
 	}
 	if options.BatchingMaxMessages == 0 {
 		options.BatchingMaxMessages = defaultMaxMessagesPerBatch

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -32,6 +32,9 @@ import (
 )
 
 const (
+	// defaultSendTimeout init default timeout for ack since sent.
+	defaultSendTimeout = 30 * time.Second
+
 	// defaultBatchingMaxPublishDelay init default for maximum delay to batch messages
 	defaultBatchingMaxPublishDelay = 10 * time.Millisecond
 
@@ -91,13 +94,18 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 		return nil, newError(ResultInvalidTopicName, "Topic name is required for producer")
 	}
 
+	if options.SendTimeout == 0 {
+		options.SendTimeout = defaultSendTimeout
+	} else if options.SendTimeout == -1 {
+		options.SendTimeout = 0
+	}
 	if options.BatchingMaxMessages == 0 {
 		options.BatchingMaxMessages = defaultMaxMessagesPerBatch
 	}
 	if options.BatchingMaxSize == 0 {
 		options.BatchingMaxSize = defaultMaxBatchSize
 	}
-	if options.BatchingMaxPublishDelay == 0 {
+	if options.BatchingMaxPublishDelay <= 0 {
 		options.BatchingMaxPublishDelay = defaultBatchingMaxPublishDelay
 	}
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -470,8 +470,7 @@ func (p *partitionProducer) failTimeoutMessages() {
 	}
 
 	pi := item.(*pendingItem)
-	diff := p.options.SendTimeout - time.Since(pi.sentAt)
-	if diff > 0 {
+	if time.Since(pi.sentAt) < p.options.SendTimeout {
 		// pending messages not timeout yet
 		return
 	}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -589,7 +589,7 @@ func (p *partitionProducer) internalSendAsync(ctx context.Context, msg *Producer
 	}
 	p.options.Interceptors.BeforeSend(p, msg)
 
-	if p.options.NonBlockIfQueueFull {
+	if p.options.DisableBlockIfQueueFull {
 		if !p.publishSemaphore.TryAcquire() {
 			if callback != nil {
 				callback(nil, msg, errSendQueueIsFull)


### PR DESCRIPTION
### Motivation

Support `SendTimeout` and `DisableBlockIfQueueFull ` for producer.

### Modifications

- Add 2 configurations into `ProducerOptions`
- Check and fail timeout messages before flushing batch.
- Check `DisableBlockIfQueueFull` before acquiring publish semaphore while sending messages.
- Add `TestSendTimeout` to verify sendTimeout effective whille backlog exceeded on topic.

### Others
client-go and client-java have different ways to disable `sendTimeout`
- client-java: set `sendTimeout` to 0 explicitly, to override default 30s configuration.
- client-go: set `sendTimeout` to -1, to bypass unset detection.

### Documentation
[configure-producer](https://pulsar.apache.org/docs/en/client-libraries-java/#configure-producer)

### Verifying this change

- [x] Make sure that the change passes the CI checks.