### PR TITLE
Fix bot action ci yaml file

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -9,9 +9,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Bot actions
-        uses: zymap/bot@v1.0.0
+        uses: zymap/bot@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GO_CLIENT_BOT_TOKEN }}
         with:


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>


### Motivation

Currently, when run the bot ci, the error as follows:

```
Run zymap/bot@v1.0.0
  with:
    repo_owner: apache
    repo_name: pulsar-client-go
    rerun_cmd: rerun failure checks
    comment: rerun failure checks
  env:
    GITHUB_TOKEN: ***
Error: HttpError: No commit found for SHA: xiaolong/test-bot
```

### Modifications

Fix bot action ci yaml file
