### PR TITLE
Add metric for internal publish latency

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -82,6 +82,12 @@ var (
 		Help:    "Publish latency experienced by the client",
 		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
+
+	publishInternalLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "pulsar_client_producer_internal_latency_seconds",
+		Help:    "Publish latency experienced internally by the client when sending data to receiving an ack",
+		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+	})
 )
 
 type partitionProducer struct {
@@ -424,6 +430,7 @@ type pendingItem struct {
 	sync.Mutex
 	batchData    internal.Buffer
 	sequenceID   uint64
+	sentAt       int64
 	sendRequests []interface{}
 	completed    bool
 }
@@ -437,6 +444,7 @@ func (p *partitionProducer) internalFlushCurrentBatch() {
 	p.pendingQueue.Put(&pendingItem{
 		batchData:    batchData,
 		sequenceID:   sequenceID,
+		sentAt:       time.Now().UnixNano(),
 		sendRequests: callbacks,
 	})
 	p.cnx.WriteData(batchData)
@@ -545,6 +553,9 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 	// lock the pending item while sending the requests
 	pi.Lock()
 	defer pi.Unlock()
+	if pi.sentAt > 0 {
+		publishInternalLatency.Observe(float64(now-pi.sentAt) / 1.0e9)
+	}
 	for idx, i := range pi.sendRequests {
 		sr := i.(*sendRequest)
 		if sr.msg != nil {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -83,9 +83,9 @@ var (
 		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
 
-	publishInternalLatency = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pulsar_client_producer_internal_latency_seconds",
-		Help:    "Publish latency experienced internally by the client when sending data to receiving an ack",
+	publishRPCLatency = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "pulsar_client_producer_rpc_latency_seconds",
+		Help:    "Publish RPC latency experienced internally by the client when sending data to receiving an ack",
 		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
 )
@@ -554,7 +554,7 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 	pi.Lock()
 	defer pi.Unlock()
 	if pi.sentAt > 0 {
-		publishInternalLatency.Observe(float64(now-pi.sentAt) / 1.0e9)
+		publishRPCLatency.Observe(float64(now-pi.sentAt) / 1.0e9)
 	}
 	for idx, i := range pi.sendRequests {
 		sr := i.(*sendRequest)


### PR DESCRIPTION
The current publish latency metric measures the time when send is called until the message is acked. The metric can be skewed if batching is enabled. 

For example, if we call send the client will hold that message until x number of messages are collected or an interval has passed. This new metric measures the time when we send the data to the connection until we get an ack from the broker. This cuts out any batch skewing and provides a more accurate latency of what the client sees at the connection level.