### PR TITLE
[Issue 398][consumer] only update the permits when we try to receive messages

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -52,7 +52,8 @@ func newClient(options ClientOptions) (Client, error) {
 	if options.Logger != nil {
 		logger = options.Logger
 	} else {
-		logger = log.NewLoggerWithLogrus(logrus.StandardLogger())
+		l := logrus.StandardLogger()
+		logger = log.NewLoggerWithLogrus(l)
 	}
 
 	if options.URL == "" {

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -91,7 +91,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		return nil, newError(SubscriptionNotFound, "subscription name is required for consumer")
 	}
 
-	if options.ReceiverQueueSize <= 0 {
+	if options.ReceiverQueueSize < 0 {
 		options.ReceiverQueueSize = defaultReceiverQueueSize
 	}
 
@@ -391,6 +391,10 @@ func (c *consumer) Unsubscribe() error {
 }
 
 func (c *consumer) Receive(ctx context.Context) (message Message, err error) {
+	for _, consumer := range c.consumers {
+		consumer.nudgePermits()
+	}
+
 	for {
 		select {
 		case <-c.closeCh:


### PR DESCRIPTION
Fixes #398 

### Motivation

The client didn't handle a receiverqueuesize of 0 correctly. See the attached issue for the in-depth explanation of the issue. 

### Modifications

The problem lies in the fact that, while the message is popped from the internal messageChannel towards the client code, we should hold back on receiving the next message. 

I was able to "solve" this for my case by moving the logic to ask for new/more permits away from the passing of the message, and into the logic that fetched the next message, eventually delaying the update of the permits.

I'm pretty sure this isn't the best fix possible, but it highlights the problem area...

### Verifying this change

Sorry, no tests added, i'm just not good enough at golang :D

### Does this pull request potentially affect one of the following parts:

No

### Documentation

No