### PR TITLE
Add const client label to metrics

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -36,18 +36,21 @@ import (
 
 var (
 	consumersOpened = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_consumers_opened",
-		Help: "Counter of consumers created by the client",
+		Name:        "pulsar_client_consumers_opened",
+		Help:        "Counter of consumers created by the client",
+		ConstLabels: constLabels(),
 	})
 
 	consumersClosed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_consumers_closed",
-		Help: "Counter of consumers closed by the client",
+		Name:        "pulsar_client_consumers_closed",
+		Help:        "Counter of consumers closed by the client",
+		ConstLabels: constLabels(),
 	})
 
 	consumersPartitions = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pulsar_client_consumers_partitions_active",
-		Help: "Counter of individual partitions the consumers are currently active",
+		Name:        "pulsar_client_consumers_partitions_active",
+		Help:        "Counter of individual partitions the consumers are currently active",
+		ConstLabels: constLabels(),
 	})
 )
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -36,44 +36,52 @@ import (
 
 var (
 	messagesReceived = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_messages_received",
-		Help: "Counter of messages received by the client",
+		Name:        "pulsar_client_messages_received",
+		Help:        "Counter of messages received by the client",
+		ConstLabels: constLabels(),
 	})
 
 	bytesReceived = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_bytes_received",
-		Help: "Counter of bytes received by the client",
+		Name:        "pulsar_client_bytes_received",
+		Help:        "Counter of bytes received by the client",
+		ConstLabels: constLabels(),
 	})
 
 	prefetchedMessages = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pulsar_client_consumer_prefetched_messages",
-		Help: "Number of messages currently sitting in the consumer pre-fetch queue",
+		Name:        "pulsar_client_consumer_prefetched_messages",
+		Help:        "Number of messages currently sitting in the consumer pre-fetch queue",
+		ConstLabels: constLabels(),
 	})
 
 	prefetchedBytes = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pulsar_client_consumer_prefetched_bytes",
-		Help: "Total number of bytes currently sitting in the consumer pre-fetch queue",
+		Name:        "pulsar_client_consumer_prefetched_bytes",
+		Help:        "Total number of bytes currently sitting in the consumer pre-fetch queue",
+		ConstLabels: constLabels(),
 	})
 
 	acksCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_consumer_acks",
-		Help: "Counter of messages acked by client",
+		Name:        "pulsar_client_consumer_acks",
+		Help:        "Counter of messages acked by client",
+		ConstLabels: constLabels(),
 	})
 
 	nacksCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_consumer_nacks",
-		Help: "Counter of messages nacked by client",
+		Name:        "pulsar_client_consumer_nacks",
+		Help:        "Counter of messages nacked by client",
+		ConstLabels: constLabels(),
 	})
 
 	dlqCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_consumer_dlq_messages",
-		Help: "Counter of messages sent to Dead letter queue",
+		Name:        "pulsar_client_consumer_dlq_messages",
+		Help:        "Counter of messages sent to Dead letter queue",
+		ConstLabels: constLabels(),
 	})
 
 	processingTime = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pulsar_client_consumer_processing_time_seconds",
-		Help:    "Time it takes for application to process messages",
-		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		Name:        "pulsar_client_consumer_processing_time_seconds",
+		Help:        "Time it takes for application to process messages",
+		Buckets:     []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		ConstLabels: constLabels(),
 	})
 
 	lastestMessageID = LatestMessageID()

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -51,21 +51,25 @@ var (
 	connectionsOpened = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pulsar_client_connections_opened",
 		Help: "Counter of connections created by the client",
+		ConstLabels: constLabels(),
 	})
 
 	connectionsClosed = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pulsar_client_connections_closed",
 		Help: "Counter of connections closed by the client",
+		ConstLabels: constLabels(),
 	})
 
 	connectionsEstablishmentErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pulsar_client_connections_establishment_errors",
 		Help: "Counter of errors in connections establishment",
+		ConstLabels: constLabels(),
 	})
 
 	connectionsHandshakeErrors = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pulsar_client_connections_handshake_errors",
 		Help: "Counter of errors in connections handshake (eg: authz)",
+		ConstLabels: constLabels(),
 	})
 )
 

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -49,26 +49,26 @@ const (
 
 var (
 	connectionsOpened = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_connections_opened",
-		Help: "Counter of connections created by the client",
+		Name:        "pulsar_client_connections_opened",
+		Help:        "Counter of connections created by the client",
 		ConstLabels: constLabels(),
 	})
 
 	connectionsClosed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_connections_closed",
-		Help: "Counter of connections closed by the client",
+		Name:        "pulsar_client_connections_closed",
+		Help:        "Counter of connections closed by the client",
 		ConstLabels: constLabels(),
 	})
 
 	connectionsEstablishmentErrors = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_connections_establishment_errors",
-		Help: "Counter of errors in connections establishment",
+		Name:        "pulsar_client_connections_establishment_errors",
+		Help:        "Counter of errors in connections establishment",
 		ConstLabels: constLabels(),
 	})
 
 	connectionsHandshakeErrors = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_connections_handshake_errors",
-		Help: "Counter of errors in connections handshake (eg: authz)",
+		Name:        "pulsar_client_connections_handshake_errors",
+		Help:        "Counter of errors in connections handshake (eg: authz)",
 		ConstLabels: constLabels(),
 	})
 )

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -32,8 +32,8 @@ import (
 
 var (
 	lookupRequestsCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_lookup_count",
-		Help: "Counter of lookup requests made by the client",
+		Name:        "pulsar_client_lookup_count",
+		Help:        "Counter of lookup requests made by the client",
 		ConstLabels: constLabels(),
 	})
 )

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -34,6 +34,7 @@ var (
 	lookupRequestsCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pulsar_client_lookup_count",
 		Help: "Counter of lookup requests made by the client",
+		ConstLabels: constLabels(),
 	})
 )
 

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -17,12 +17,8 @@
 
 package internal
 
-import (
-	"fmt"
-)
-
 func constLabels() map[string]string {
 	return map[string]string{
-		"client": fmt.Sprintf("go"),
+		"client": "go",
 	}
 }

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"fmt"
+)
+
+func constLabels() map[string]string {
+	return map[string]string{
+		"client": fmt.Sprintf("go"),
+	}
+}

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -35,8 +35,8 @@ import (
 
 var (
 	rpcRequestCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_rpc_count",
-		Help: "Counter of RPC requests made by the client",
+		Name:        "pulsar_client_rpc_count",
+		Help:        "Counter of RPC requests made by the client",
 		ConstLabels: constLabels(),
 	})
 )

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -37,6 +37,7 @@ var (
 	rpcRequestCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "pulsar_client_rpc_count",
 		Help: "Counter of RPC requests made by the client",
+		ConstLabels: constLabels(),
 	})
 )
 

--- a/pulsar/metrics.go
+++ b/pulsar/metrics.go
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"fmt"
+)
+
+func constLabels() map[string]string {
+	return map[string]string{
+		"client": fmt.Sprintf("go"),
+	}
+}

--- a/pulsar/metrics.go
+++ b/pulsar/metrics.go
@@ -17,12 +17,8 @@
 
 package pulsar
 
-import (
-	"fmt"
-)
-
 func constLabels() map[string]string {
 	return map[string]string{
-		"client": fmt.Sprintf("go"),
+		"client": "go",
 	}
 }

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -47,18 +47,21 @@ const (
 
 var (
 	producersOpened = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_producers_opened",
-		Help: "Counter of producers created by the client",
+		Name:        "pulsar_client_producers_opened",
+		Help:        "Counter of producers created by the client",
+		ConstLabels: constLabels(),
 	})
 
 	producersClosed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_producers_closed",
-		Help: "Counter of producers closed by the client",
+		Name:        "pulsar_client_producers_closed",
+		Help:        "Counter of producers closed by the client",
+		ConstLabels: constLabels(),
 	})
 
 	producersPartitions = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pulsar_client_producers_partitions_active",
-		Help: "Counter of individual partitions the producers are currently active",
+		Name:        "pulsar_client_producers_partitions_active",
+		Help:        "Counter of individual partitions the producers are currently active",
+		ConstLabels: constLabels(),
 	})
 )
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -61,40 +61,47 @@ const (
 
 var (
 	messagesPublished = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_messages_published",
-		Help: "Counter of messages published by the client",
+		Name:        "pulsar_client_messages_published",
+		Help:        "Counter of messages published by the client",
+		ConstLabels: constLabels(),
 	})
 
 	bytesPublished = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "pulsar_client_bytes_published",
-		Help: "Counter of messages published by the client",
+		Name:        "pulsar_client_bytes_published",
+		Help:        "Counter of messages published by the client",
+		ConstLabels: constLabels(),
 	})
 
 	messagesPending = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pulsar_client_producer_pending_messages",
-		Help: "Counter of messages pending to be published by the client",
+		Name:        "pulsar_client_producer_pending_messages",
+		Help:        "Counter of messages pending to be published by the client",
+		ConstLabels: constLabels(),
 	})
 
 	bytesPending = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "pulsar_client_producer_pending_bytes",
-		Help: "Counter of bytes pending to be published by the client",
+		Name:        "pulsar_client_producer_pending_bytes",
+		Help:        "Counter of bytes pending to be published by the client",
+		ConstLabels: constLabels(),
 	})
 
 	publishErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "pulsar_client_producer_errors",
-		Help: "Counter of publish errors",
+		Name:        "pulsar_client_producer_errors",
+		Help:        "Counter of publish errors",
+		ConstLabels: constLabels(),
 	}, []string{"error"})
 
 	publishLatency = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pulsar_client_producer_latency_seconds",
-		Help:    "Publish latency experienced by the client",
-		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		Name:        "pulsar_client_producer_latency_seconds",
+		Help:        "Publish latency experienced by the client",
+		ConstLabels: constLabels(),
+		Buckets:     []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
 
 	publishRPCLatency = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pulsar_client_producer_rpc_latency_seconds",
-		Help:    "Publish RPC latency experienced internally by the client when sending data to receiving an ack",
-		Buckets: []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		Name:        "pulsar_client_producer_rpc_latency_seconds",
+		Help:        "Publish RPC latency experienced internally by the client when sending data to receiving an ack",
+		ConstLabels: constLabels(),
+		Buckets:     []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 	})
 )
 


### PR DESCRIPTION
Add const client label to metrics so when metrics are added to other clients we can filter the metrics by client language. 
