### PR TITLE
Fix discard unacked messages

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -980,6 +980,10 @@ func (pc *partitionConsumer) clearQueueAndGetNextMessage() trackingMessageID {
 func (pc *partitionConsumer) clearReceiverQueue() trackingMessageID {
 	nextMessageInQueue := pc.clearQueueAndGetNextMessage()
 
+	if pc.startMessageID.Undefined() {
+		return pc.startMessageID
+	}
+
 	if !nextMessageInQueue.Undefined() {
 		return getPreviousMessage(nextMessageInQueue)
 	} else if !pc.lastDequeuedMsg.Undefined() {


### PR DESCRIPTION
https://github.com/apache/pulsar-client-go/issues/389#issuecomment-741560624


### Motivation
When a consumer whose receive queue is not empty reconnects to a broker, unacked messages don't be redelivered to a client application and these are removed from backlog.
This is because StartMessageID is updated and the consumer implicitly acks redelivered unacked messages.
https://github.com/apache/pulsar-client-go/blob/v0.3.0/pulsar/consumer_partition.go#L972-L976
https://github.com/apache/pulsar-client-go/blob/v0.3.0/pulsar/consumer_partition.go#L507-L510



### Modifications
* If startMessageID is undefined, it will not be updated in order to prevent  unacked messages from being discarded by following logic.
.https://github.com/apache/pulsar-client-go/blob/v0.3.0/pulsar/consumer_partition.go#L507-L510

