### PR TITLE
Reduce the default TCP connection timeout from 30 to 5 seconds

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -80,7 +80,7 @@ type ClientOptions struct {
 	// This parameter is required
 	URL string
 
-	// Timeout for the establishment of a TCP connection (default: 30 seconds)
+	// Timeout for the establishment of a TCP connection (default: 5 seconds)
 	ConnectionTimeout time.Duration
 
 	// Set the operation timeout (default: 30 seconds)

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	defaultConnectionTimeout = 30 * time.Second
+	defaultConnectionTimeout = 5 * time.Second
 	defaultOperationTimeout  = 30 * time.Second
 )
 


### PR DESCRIPTION
### Motivation

The default TCP connection timeout of 30 seconds is too high. The connection timeout should be low enough such that we can recover a producer session with brokers before the operation or the publish timeouts expired (default is 30sec for both).

5 seconds is a better default value for this scope.