### PR TITLE
Renamed Metrics.RpcRequestCount to RPCRequestCount to conform to style check

### DIFF
--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -56,7 +56,7 @@ type Metrics struct {
 	ConnectionsEstablishmentErrors prometheus.Counter
 	ConnectionsHandshakeErrors     prometheus.Counter
 	LookupRequestsCount            prometheus.Counter
-	RpcRequestCount                prometheus.Counter
+	RPCRequestCount                prometheus.Counter
 }
 
 type TopicMetrics struct {
@@ -268,7 +268,7 @@ func NewMetricsProvider(userDefinedLabels map[string]string) *Metrics {
 			ConstLabels: constLabels,
 		}),
 
-		RpcRequestCount: prometheus.NewCounter(prometheus.CounterOpts{
+		RPCRequestCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Name:        "pulsar_client_rpc_count",
 			Help:        "Counter of RPC requests made by the client",
 			ConstLabels: constLabels,
@@ -306,7 +306,7 @@ func NewMetricsProvider(userDefinedLabels map[string]string) *Metrics {
 	prometheus.DefaultRegisterer.Register(metrics.ConnectionsEstablishmentErrors)
 	prometheus.DefaultRegisterer.Register(metrics.ConnectionsHandshakeErrors)
 	prometheus.DefaultRegisterer.Register(metrics.LookupRequestsCount)
-	prometheus.DefaultRegisterer.Register(metrics.RpcRequestCount)
+	prometheus.DefaultRegisterer.Register(metrics.RPCRequestCount)
 	return metrics
 }
 

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -108,7 +108,7 @@ func (c *rpcClient) RequestToAnyBroker(requestID uint64, cmdType pb.BaseCommand_
 
 func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
 	cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
-	c.metrics.RpcRequestCount.Inc()
+	c.metrics.RPCRequestCount.Inc()
 	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 
 func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
 	message proto.Message) (*RPCResult, error) {
-	c.metrics.RpcRequestCount.Inc()
+	c.metrics.RPCRequestCount.Inc()
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
@@ -158,7 +158,7 @@ func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.Ba
 }
 
 func (c *rpcClient) RequestOnCnxNoWait(cnx Connection, cmdType pb.BaseCommand_Type, message proto.Message) error {
-	c.metrics.RpcRequestCount.Inc()
+	c.metrics.RPCRequestCount.Inc()
 	return cnx.SendRequestNoWait(baseCommand(cmdType, message))
 }
 


### PR DESCRIPTION
### Motivation

After some tooling change, the variable name `RpcRequestCount` is now triggering an error in the checkstyle job. Changing to `RPCRequestCount`