### PR TITLE
support jwt and trusted cert for pulsar perf client

### DIFF
--- a/perf/perf-consumer.go
+++ b/perf/perf-consumer.go
@@ -65,9 +65,7 @@ func consume(consumeArgs *ConsumeArgs, stop <-chan struct{}) {
 	b, _ = json.MarshalIndent(consumeArgs, "", "  ")
 	log.Info("Consumer config: ", string(b))
 
-	client, err := pulsar.NewClient(pulsar.ClientOptions{
-		URL: clientArgs.ServiceURL,
-	})
+	client, err := NewClient()
 
 	if err != nil {
 		log.Fatal(err)
@@ -92,6 +90,7 @@ func consume(consumeArgs *ConsumeArgs, stop <-chan struct{}) {
 
 	// Print stats of the consume rate
 	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
 
 	for {
 		select {

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -136,6 +136,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 	// Print stats of the publish rate and latencies
 	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
 	q := quantile.NewTargeted(0.50, 0.95, 0.99, 0.999, 1.0)
 	messagesPublished := 0
 

--- a/perf/pulsar-perf-go.go
+++ b/perf/pulsar-perf-go.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -64,10 +63,7 @@ func NewClient() (pulsar.Client, error) {
 		clientOpts.Authentication = pulsar.NewAuthenticationToken(string(tokenBytes))
 	}
 
-	if strings.HasPrefix(clientArgs.ServiceURL, "pulsar+ssl://") {
-		if clientArgs.TLSTrustCertFile == "" {
-			return nil, fmt.Errorf("fatal error: missing trustStore while pulsar+ssl tls is enabled")
-		}
+	if clientArgs.TLSTrustCertFile != "" {
 		clientOpts.TLSTrustCertsFilePath = clientArgs.TLSTrustCertFile
 	}
 	return pulsar.NewClient(clientOpts)

--- a/perf/pulsar-perf-go.go
+++ b/perf/pulsar-perf-go.go
@@ -20,11 +20,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,7 +42,9 @@ var flagDebug bool
 var PrometheusPort int
 
 type ClientArgs struct {
-	ServiceURL string
+	ServiceURL       string
+	TokenFile        string
+	TLSTrustCertFile string
 }
 
 var clientArgs ClientArgs
@@ -48,6 +52,23 @@ var clientArgs ClientArgs
 func NewClient() (pulsar.Client, error) {
 	clientOpts := pulsar.ClientOptions{
 		URL: clientArgs.ServiceURL,
+	}
+
+	if clientArgs.TokenFile != "" {
+		// read JWT from the file
+		tokenBytes, err := ioutil.ReadFile(clientArgs.TokenFile)
+		if err != nil {
+			log.WithError(err).Errorf("failed to read Pulsar JWT from a file %s", clientArgs.TokenFile)
+			os.Exit(1)
+		}
+		clientOpts.Authentication = pulsar.NewAuthenticationToken(string(tokenBytes))
+	}
+
+	if strings.HasPrefix(clientArgs.ServiceURL, "pulsar+ssl://") {
+		if clientArgs.TLSTrustCertFile == "" {
+			return nil, fmt.Errorf("fatal error: missing trustStore while pulsar+ssl tls is enabled")
+		}
+		clientOpts.TLSTrustCertsFilePath = clientArgs.TLSTrustCertFile
 	}
 	return pulsar.NewClient(clientOpts)
 }
@@ -78,6 +99,8 @@ func main() {
 	flags.BoolVar(&flagDebug, "debug", false, "enable debug output")
 	flags.StringVarP(&clientArgs.ServiceURL, "service-url", "u",
 		"pulsar://localhost:6650", "The Pulsar service URL")
+	flags.StringVar(&clientArgs.TokenFile, "token-file", "", "file path to the Pulsar JWT file")
+	flags.StringVar(&clientArgs.TLSTrustCertFile, "trust-cert-file", "", "file path to the trusted certificate file")
 
 	rootCmd.AddCommand(newProducerCommand())
 	rootCmd.AddCommand(newConsumerCommand())


### PR DESCRIPTION
### Motivation

Add token/JWT and trusted certificate support in Pulsar perf go client. So that it can be used in production environment.

### Modifications

Implement pulsar-perf-go command line arguments for token-file and trusted-cert-file. These two arguments are optional. There is no change to the default non-TLS and no auth configuration.

### Verifying this change

This is a change to Pulsar perf go client. It should pass build and existing test cases.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
