### PR TITLE
Logging what really caused lookup failure

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -317,7 +317,7 @@ func (c *connection) waitUntilReady() error {
 	defer c.Unlock()
 
 	for c.state != connectionReady {
-		c.log.Debug("Wait until connection is ready. State: ", c.state)
+		c.log.Debugf("Wait until connection is ready. State: %s", connectionState(c.state))
 		if c.state == connectionClosed {
 			return errors.New("connection error")
 		}

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -19,7 +19,6 @@ package internal
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 
 	"github.com/gogo/protobuf/proto"
@@ -140,9 +139,12 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			}, nil
 
 		case pb.CommandLookupTopicResponse_Failed:
-			err := fmt.Errorf("failed to lookup topic: %s, error: %s, message: %s", topic, lr.GetError(), lr.GetMessage())
-			ls.log.Warn(err)
-			return nil, err
+			ls.log.WithFields(log.Fields{
+				"topic":   topic,
+				"error":   lr.GetError(),
+				"message": lr.GetMessage(),
+			}).Warn("Failed to lookup topic")
+			return nil, errors.New(lr.GetError().String())
 		}
 	}
 

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -140,12 +140,9 @@ func (ls *lookupService) Lookup(topic string) (*LookupResult, error) {
 			}, nil
 
 		case pb.CommandLookupTopicResponse_Failed:
-			errorMsg := ""
-			if lr.Error != nil {
-				errorMsg = lr.Error.String()
-			}
-			ls.log.Warnf("Failed to lookup topic: %s, error msg: %s", topic, errorMsg)
-			return nil, fmt.Errorf("failed to lookup topic: %s", errorMsg)
+			err := fmt.Errorf("failed to lookup topic: %s, error: %s, message: %s", topic, lr.GetError(), lr.GetMessage())
+			ls.log.Warn(err)
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
### Motivation

Clusters deployed over k8s, during broker pod restarting / terminating, it's service DNS `.cluster.local` will be removed, cause proxy can't resolve the restarting owner broker DNS name.
For now, client only logging `ServiceNotReady` error but without details which help troubleshoot.

### Modifications

Logging LookupResponse failure detail message, like this:

![image](https://user-images.githubusercontent.com/24536920/105743478-80b49f80-5f77-11eb-8613-9eb01e136227.png)


### Verifying this change

- [x] Make sure that the change passes the CI checks.