### PR TITLE
fix: KeyFileTypeServiceAccount not found compile error

### DIFF
--- a/oauth2/client_credentials_flow_test.go
+++ b/oauth2/client_credentials_flow_test.go
@@ -42,7 +42,7 @@ func (m *MockClientCredentialsProvider) GetClientCredentials() (*KeyFile, error)
 var _ ClientCredentialsProvider = &MockClientCredentialsProvider{}
 
 var clientCredentials = KeyFile{
-	Type:         KeyFileTypeServiceAccount,
+	Type:         "resource",
 	ClientID:     "test_clientID",
 	ClientSecret: "test_clientSecret",
 	ClientEmail:  "test_clientEmail",


### PR DESCRIPTION
### Motivation

[KeyFileTypeServiceAccount](https://github.com/apache/pulsar-client-go/blob/v0.3.0/oauth2/client_credentials_flow_test.go#L45) is not defiend in the latest version of oauth2/client_credentials_provider.go file,so there will be a compile error in oauth2/client_credentials_flow_test.go

### Modifications

change KeyFileTypeServiceAccount to "resource" in test file.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API:  no
  - The schema:  no 

### Documentation

  - Does this pull request introduce a new feature?  no
