### PR TITLE
Fix unsubscribe blocked when consumer is closing or has closed

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -373,7 +373,7 @@ func (pc *partitionConsumer) internalSeek(seek *seekRequest) {
 func (pc *partitionConsumer) requestSeek(msgID messageID) error {
 	state := pc.getConsumerState()
 	if state == consumerClosing || state == consumerClosed {
-		pc.log.Error("Consumer was already closed")
+		pc.log.WithField("state", state).Error("Consumer is closing or has closed")
 		return nil
 	}
 
@@ -417,7 +417,7 @@ func (pc *partitionConsumer) internalSeekByTime(seek *seekByTimeRequest) {
 
 	state := pc.getConsumerState()
 	if state == consumerClosing || state == consumerClosed {
-		pc.log.Error("Consumer was already closed")
+		pc.log.WithField("state", pc.state).Error("Consumer is closing or has closed")
 		return
 	}
 
@@ -817,7 +817,7 @@ func (pc *partitionConsumer) internalClose(req *closeRequest) {
 	}
 
 	if state == consumerClosed || state == consumerClosing {
-		pc.log.Error("The consumer is closing or has been closed")
+		pc.log.WithField("state", state).Error("Consumer is closing or has closed")
 		if pc.nackTracker != nil {
 			pc.nackTracker.Close()
 		}


### PR DESCRIPTION
### Motivation

For the present consumer, `Close()` and `Unsubscribe()` handled by the same eventloop goroutine.
The eventloop exited after `Close()`, then unsubscribe event wouldn't be selected and handled anymore, lead to block.

example:
```go
func main() {
	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: "pulsar://localhost:6650"})
	if err != nil {
		log.Fatal(err)
	}
	defer client.Close()

	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
		Topic:            "topic-1",
		SubscriptionName: "my-sub",
	})
	if err != nil {
		log.Fatal(err)
	}
	
	defer consumer.Unsubscribe() // unintentional
	defer consumer.Close()
}
```

`Unsubscribe()` blocked:

![image](https://user-images.githubusercontent.com/24536920/106294060-ab5d6b80-6289-11eb-913c-85e1d18467a0.png)




### Modifications

Check consumer state before send unsubscribe event, if consumer is closing or has closed, just logging it

### Verifying this change

- [x] Make sure that the change passes the CI checks.