### PR TITLE
Improve error log for frame size too big and maxMessageSize

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -302,7 +302,7 @@ func (c *connection) doHandshake() bool {
 			cmd.Error.GetMessage())
 		return false
 	}
-	if cmd.Connected.MaxMessageSize != nil {
+	if cmd.Connected.MaxMessageSize != nil && *cmd.Connected.MaxMessageSize > 0 {
 		c.log.Debug("Got MaxMessageSize from handshake response:", *cmd.Connected.MaxMessageSize)
 		c.maxMessageSize = *cmd.Connected.MaxMessageSize
 	} else {

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -74,8 +74,9 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 
 	// We have enough to read frame size
 	frameSize := r.buffer.ReadUint32()
-	if r.cnx.maxMessageSize != 0 && int32(frameSize) > (r.cnx.maxMessageSize+MessageFramePadding) {
-		frameSizeError := fmt.Errorf("Received too big frame size. size=%d maxFrameSize=%d", frameSize, r.cnx.maxMessageSize+MessageFramePadding)
+	maxFrameSize := r.cnx.maxMessageSize + MessageFramePadding
+	if r.cnx.maxMessageSize != 0 && int32(frameSize) > maxFrameSize {
+		frameSizeError := fmt.Errorf("received too big frame size=%d maxFrameSize=%d", frameSize, maxFrameSize)
 		r.cnx.log.Error(frameSizeError)
 		r.cnx.TriggerClose()
 		return nil, nil, frameSizeError

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -348,7 +348,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		p.log.WithError(errMessageTooLarge).
 			WithField("size", len(payload)).
 			WithField("properties", msg.Properties).
-			Error()
+			Errorf("MaxMessageSize %d", int(p.cnx.GetMaxMessageSize()))
 		p.metrics.PublishErrorsMsgTooLarge.Inc()
 		return
 	}


### PR DESCRIPTION
### Motivation
This PR is to improve error log for `frame size too big` on the consumer. We have seen a number of frame size too big error and I would like to trace what the exact maxMessageSize is set to that is not default. Debug log was not able to be enabled on the production system.


### Modifications

Log improvement mostly

### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
