### PR TITLE
Fix unexpected nil pointer when reading item from keyring

### DIFF
--- a/oauth2/store/keyring.go
+++ b/oauth2/store/keyring.go
@@ -117,7 +117,7 @@ func (f *KeyringStore) WhoAmI(audience string) (string, error) {
 	defer f.lock.Unlock()
 
 	key := hashKeyringKey(audience)
-	authItem, err := f.kr.GetMetadata(key)
+	authItem, err := f.kr.Get(key)
 	if err != nil {
 		if err == keyring.ErrKeyNotFound {
 			return "", ErrNoAuthenticationData


### PR DESCRIPTION
**Motivation**

When compiling the code across different platform, sometimes
 will encounter the nil pointer when getting the label from the
`authIterm`.

error logs:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x13105e1]

goroutine 1 [running]:
github.com/apache/pulsar-client-go/oauth2/store.(*KeyringStore).WhoAmI(0xc0001ae660, 0x7ffeefbff459, 0x1b, 0x0, 0x0, 0x0, 0x0)
	/Users/zhangyong/github.com/apache/pulsar-client-go/oauth2/store/keyring.go:127 +0x221
github.com/streamnative/pulsarctl/pkg/oauth2.doActivate(0xc0003446e0, 0x7ffeefbff3ae, 0x3a, 0x7ffeefbff459, 0x1b, 0x7ffeefbff421, 0x2c, 0xc000357cf8, 0x157a745)
	/Users/zhangyong/github.com/streamnative/pulsarctl/pkg/oauth2/active.go:93 +0x21a
github.com/streamnative/pulsarctl/pkg/oauth2.activateCmd.func1(0x1492580, 0xc000357d08)
	/Users/zhangyong/github.com/streamnative/pulsarctl/pkg/oauth2/active.go:52 +0x69
github.com/streamnative/pulsarctl/pkg/cmdutils.run(0xc000329d10)
	/Users/zhangyong/github.com/streamnative/pulsarctl/pkg/cmdutils/verb.go:100 +0x27
github.com/streamnative/pulsarctl/pkg/cmdutils.(*VerbCmd).SetRunFunc.func1(0xc000361180, 0xc0002bcd80, 0x0, 0x8)
	/Users/zhangyong/github.com/streamnative/pulsarctl/pkg/cmdutils/verb.go:67 +0x2a
github.com/spf13/cobra.(*Command).execute(0xc000361180, 0xc0002bcc00, 0x8, 0x8, 0xc000361180, 0xc0002bcc00)
	/Users/zhangyong/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc00016c280, 0xc000339260, 0xc00001e0c0, 0xa)
	/Users/zhangyong/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x30b
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/zhangyong/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/Users/zhangyong/github.com/streamnative/pulsarctl/main.go:41 +0x1c5
```

