### PR TITLE
Fix infinite loop in connection.failLeftRequestsWhenClose

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -331,10 +331,10 @@ func (c *connection) waitUntilReady() error {
 }
 
 func (c *connection) failLeftRequestsWhenClose() {
+	close(c.incomingRequestsCh)
 	for req := range c.incomingRequestsCh {
 		c.internalSendRequest(req)
 	}
-	close(c.incomingRequestsCh)
 }
 
 func (c *connection) run() {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -547,12 +547,18 @@ func (c *connection) SendRequest(requestID uint64, req *pb.BaseCommand,
 	callback func(command *pb.BaseCommand, err error)) {
 	if c.getState() == connectionClosed {
 		callback(req, ErrConnectionClosed)
-	} else {
-		c.incomingRequestsCh <- &request{
-			id:       &requestID,
-			cmd:      req,
-			callback: callback,
-		}
+		return
+	}
+
+	select {
+	case <-c.closeCh:
+		callback(req, ErrConnectionClosed)
+	case c.incomingRequestsCh <- &request{
+		id:       &requestID,
+		cmd:      req,
+		callback: callback,
+	}:
+		// ok
 	}
 }
 
@@ -561,12 +567,16 @@ func (c *connection) SendRequestNoWait(req *pb.BaseCommand) error {
 		return ErrConnectionClosed
 	}
 
-	c.incomingRequestsCh <- &request{
+	select {
+	case <-c.closeCh:
+		return ErrConnectionClosed
+	case c.incomingRequestsCh <- &request{
 		id:       nil,
 		cmd:      req,
 		callback: nil,
+	}:
+		return nil
 	}
-	return nil
 }
 
 func (c *connection) internalSendRequest(req *request) {


### PR DESCRIPTION
Master Issue: #462

### Motivation

As mentioned in [this comment](https://github.com/apache/pulsar-client-go/issues/462#issuecomment-780357151), when connection closed, one of its goroutine stucks within `failLeftRequestsWhenClose` method as `incomingRequestsCh` gets never closed. This simple PR swaps order of operation done in this method so that it first closes the channel (as buffered chan used, it's perfectly valid and no data ever lost) and then handles any message left in `incomingRequestsCh` channel.

### Modifications

Mentioned above.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
