### PR TITLE
Fix race condition/goroutine leak in partition discovery goroutine

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -49,12 +49,12 @@ type consumer struct {
 	// channel used to deliver message to clients
 	messageCh chan ConsumerMessage
 
-	dlq       *dlqRouter
-	rlq       *retryRouter
-	closeOnce sync.Once
-	closeCh   chan struct{}
-	errorCh   chan error
-	ticker    *time.Ticker
+	dlq           *dlqRouter
+	rlq           *retryRouter
+	closeOnce     sync.Once
+	closeCh       chan struct{}
+	errorCh       chan error
+	stopDiscovery func()
 
 	log     log.Logger
 	metrics *internal.TopicMetrics
@@ -210,19 +210,7 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 	if duration <= 0 {
 		duration = defaultAutoDiscoveryDuration
 	}
-	consumer.ticker = time.NewTicker(duration)
-
-	go func() {
-		for {
-			select {
-			case <-consumer.closeCh:
-				return
-			case <-consumer.ticker.C:
-				consumer.log.Debug("Auto discovering new partitions")
-				consumer.internalTopicSubscribeToPartitions()
-			}
-		}
-	}()
+	consumer.stopDiscovery = consumer.runBackgroundPartitionDiscovery(duration)
 
 	return consumer, nil
 }
@@ -230,6 +218,32 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 // Name returns the name of consumer.
 func (c *consumer) Name() string {
 	return c.consumerName
+}
+
+func (c *consumer) runBackgroundPartitionDiscovery(period time.Duration) (cancel func()) {
+	var wg sync.WaitGroup
+	stopDiscoveryCh := make(chan struct{})
+	ticker := time.NewTicker(period)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopDiscoveryCh:
+				return
+			case <-ticker.C:
+				c.log.Debug("Auto discovering new partitions")
+				c.internalTopicSubscribeToPartitions()
+			}
+		}
+	}()
+
+	return func() {
+		ticker.Stop()
+		close(stopDiscoveryCh)
+		wg.Wait()
+	}
 }
 
 func (c *consumer) internalTopicSubscribeToPartitions() error {
@@ -485,6 +499,8 @@ func (c *consumer) NackID(msgID MessageID) {
 
 func (c *consumer) Close() {
 	c.closeOnce.Do(func() {
+		c.stopDiscovery()
+
 		c.Lock()
 		defer c.Unlock()
 
@@ -498,7 +514,6 @@ func (c *consumer) Close() {
 		}
 		wg.Wait()
 		close(c.closeCh)
-		c.ticker.Stop()
 		c.client.handlers.Del(c)
 		c.dlq.close()
 		c.rlq.close()


### PR DESCRIPTION
Master issue: #462

### Motivation

In some cases consumer `Close` method might be called in nearly the same moment with background partiotion discovery routine tick. When `Close` acquires mutex first, it will release all underlying consumers, but that not guarantees backgound routine's not wait for the same mutex in `internalTopicSubscribeToPartitions`, so when `Close` completes, mutex gets acquired by not-finished-yet goroutine leading to new partition consumers gets created without any chance to close them.
The same logic is valid for producer partition discovery goroutine which is closed the same manner.

This PR modifies background discrovery goroutine the way it will be closed before acquiring mutex in `Close` method.

### Modifications

Described above.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
