### PR TITLE
fix: batch flush method

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -397,7 +397,11 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		msg.ReplicationClusters, deliverAt)
 	if !added {
 		// The current batch is full.. flush it and retry
-		p.internalFlushCurrentBatch()
+		if p.batchBuilder.IsMultiBatches() {
+			p.internalFlushCurrentBatches()
+		} else {
+			p.internalFlushCurrentBatch()
+		}
 
 		// after flushing try again to add the current payload
 		if ok := p.batchBuilder.Add(smm, p.sequenceIDGenerator, payload, request,


### PR DESCRIPTION
Fixes #475

### Motivation

Fix wrong batch flush method bug.

### Modifications

Check if batchBuilder is multi batches before flush.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API:  no
  - The schema:  no
  - The default values of configurations:  no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? GoDocs 
