### PR TITLE
[fix #479] use pulsar-test-infra/pulsarbot as github action bot

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,21 +2,23 @@ name: Bot tests
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [closed]
 
 jobs:
   bot:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v2
         with:
+          fetch-depth: 100
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Bot actions
-        uses: zymap/bot@v1.0.1
+      - name: Execute pulsarbot command
+        id:   pulsarbot
+        if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/pulsarbot')
         env:
           GITHUB_TOKEN: ${{ secrets.GO_CLIENT_BOT_TOKEN }}
-        with:
-          repo_owner: apache
-          repo_name: pulsar-client-go
-          rerun_cmd: rerun failure checks
-          comment: ${{ github.event.comment.body }}
+        uses: apache/pulsar-test-infra/pulsarbot@master


### PR DESCRIPTION
Fixes #479

### Motivation

ci bot for pulsar-client-go is not working due to below error:

`zymap/bot@v1.0.1 is not allowed to be used in apache/pulsar-client-go. Actions in this workflow must be: within a repository owned by apache, created by GitHub, verified in the GitHub Marketplace or match the following: */*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+, AdoptOpenJDK/install-jdk@*, apache/*, burrunan/gradle-cache-action@*, codecov/codecov-action@*, conda-incubator/setup-miniconda@*, container-tools/kind-action@*, dawidd6/action-download-artifact@*, gradle/wrapper-validation-action@*, julia-actions/julia-runtest@*, julia-actions/setup-julia@*, msys2/setup-msys2@*, peaceiris/actions-gh-pages@*, peaceiris/actions-hugo@*, peter-evans/create-pull-request@*, potiuk/cancel-workflow-runs@*, r-lib/actions/*, scacap/action-surefire-report@*, shivammathur/setup-php@*, shogo82148/actions-setup-perl@*, shufo/auto-assign-reviewer-by-files@*, ruby/setup-ruby@*.`

Since https://github.com/apache/pulsar-test-infra/issues/17 allows `pulsar-test-infra/pulsarbot` able to used in different repos, this pr changed the bot from `zymap/bot` to `pulsar-test-infra/pulsarbot` to get bot back to pulsar-client-go.

One should noticed that the rerun command is changed from `rerun failure checks` to `/pulsarbot run-failure-checks`
