### PR TITLE
Expose GetHashingFunction() method on producer

### DIFF
--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -20,6 +20,8 @@ package pulsar
 import (
 	"context"
 	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar/internal"
 )
 
 type HashingScheme int
@@ -198,4 +200,16 @@ type Producer interface {
 	// No more writes will be accepted from this producer. Waits until all pending write request are persisted. In case
 	// of errors, pending writes will not be retried.
 	Close()
+}
+
+// GetHashingFunction return the corresponding hashing function for the hashing scheme
+func GetHashingFunction(s HashingScheme) func(string) uint32 {
+	switch s {
+	case JavaStringHash:
+		return internal.JavaStringHash
+	case Murmur3_32Hash:
+		return internal.Murmur3_32Hash
+	default:
+		return internal.JavaStringHash
+	}
 }

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -59,17 +59,6 @@ type producer struct {
 
 var partitionsAutoDiscoveryInterval = 1 * time.Minute
 
-func getHashingFunction(s HashingScheme) func(string) uint32 {
-	switch s {
-	case JavaStringHash:
-		return internal.JavaStringHash
-	case Murmur3_32Hash:
-		return internal.Murmur3_32Hash
-	default:
-		return internal.JavaStringHash
-	}
-}
-
 func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 	if options.Topic == "" {
 		return nil, newError(InvalidTopicName, "Topic name is required for producer")
@@ -102,7 +91,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 
 	if options.MessageRouter == nil {
 		internalRouter := NewDefaultRouter(
-			getHashingFunction(options.HashingScheme),
+			GetHashingFunction(options.HashingScheme),
 			options.BatchingMaxMessages,
 			options.BatchingMaxSize,
 			options.BatchingMaxPublishDelay,

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -39,6 +41,12 @@ func TestInvalidURL(t *testing.T) {
 	if client != nil || err == nil {
 		t.Fatal("Should have failed to create client")
 	}
+}
+
+func TestGetHashingFunction(t *testing.T) {
+	assertHashingFunctionEqual(t, internal.JavaStringHash, GetHashingFunction(-1))
+	assertHashingFunctionEqual(t, internal.JavaStringHash, GetHashingFunction(JavaStringHash))
+	assertHashingFunctionEqual(t, internal.Murmur3_32Hash, GetHashingFunction(Murmur3_32Hash))
 }
 
 func TestProducerConnectError(t *testing.T) {
@@ -1030,4 +1038,10 @@ func TestProducerWithInterceptors(t *testing.T) {
 
 	assert.Equal(t, 10, metric.sendn)
 	assert.Equal(t, 10, metric.ackn)
+}
+
+func assertHashingFunctionEqual(t *testing.T, func1, func2 func(string) uint32) {
+	funcName1 := runtime.FuncForPC(reflect.ValueOf(func1).Pointer()).Name()
+	funcName2 := runtime.FuncForPC(reflect.ValueOf(func2).Pointer()).Name()
+	assert.Equal(t, funcName1, funcName2)
 }


### PR DESCRIPTION
### Motivation

Expose GetHashingFunction() so that the user could construct the hashFunc to call `NewDefaultRouter`.

### Modifications

Expose `GetHashingFunction()` and added unit tests.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
- Added unit tests in producer_test.go

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
