### PR TITLE
Make PartitionsAutoDiscoveryInterval configurable

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1430,7 +1430,6 @@ func TestConsumerAddTopicPartitions(t *testing.T) {
 	makeHTTPCall(t, http.MethodPut, testURL, "3")
 
 	// create producer
-	partitionsAutoDiscoveryInterval = 100 * time.Millisecond
 	producer, err := client.CreateProducer(ProducerOptions{
 		Topic: topic,
 		MessageRouter: func(msg *ProducerMessage, topicMetadata TopicMetadata) int {
@@ -1439,6 +1438,7 @@ func TestConsumerAddTopicPartitions(t *testing.T) {
 			assert.NoError(t, err)
 			return i
 		},
+		PartitionsAutoDiscoveryInterval: 100 * time.Millisecond,
 	})
 	assert.Nil(t, err)
 	defer producer.Close()

--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -159,6 +159,10 @@ type ProducerOptions struct {
 	// - DefaultBatchBuilder
 	// - KeyBasedBatchBuilder
 	BatcherBuilderType
+
+	// PartitionsAutoDiscoveryInterval is the time interval for the background process to discover new partitions
+	// Default is 1 minute
+	PartitionsAutoDiscoveryInterval time.Duration
 }
 
 // Producer is used to publish messages on a topic

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -40,6 +40,9 @@ const (
 
 	// defaultMaxMessagesPerBatch init default num of entries in per batch.
 	defaultMaxMessagesPerBatch = 1000
+
+	// defaultPartitionsAutoDiscoveryInterval init default time interval for partitions auto discovery
+	defaultPartitionsAutoDiscoveryInterval = 1 * time.Minute
 )
 
 type producer struct {
@@ -56,8 +59,6 @@ type producer struct {
 	log           log.Logger
 	metrics       *internal.TopicMetrics
 }
-
-var partitionsAutoDiscoveryInterval = 1 * time.Minute
 
 func getHashingFunction(s HashingScheme) func(string) uint32 {
 	switch s {
@@ -86,6 +87,9 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 	}
 	if options.BatchingMaxPublishDelay <= 0 {
 		options.BatchingMaxPublishDelay = defaultBatchingMaxPublishDelay
+	}
+	if options.PartitionsAutoDiscoveryInterval <= 0 {
+		options.PartitionsAutoDiscoveryInterval = defaultPartitionsAutoDiscoveryInterval
 	}
 
 	p := &producer{
@@ -125,7 +129,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 		return nil, err
 	}
 
-	p.stopDiscovery = p.runBackgroundPartitionDiscovery(partitionsAutoDiscoveryInterval)
+	p.stopDiscovery = p.runBackgroundPartitionDiscovery(options.PartitionsAutoDiscoveryInterval)
 
 	p.metrics.ProducersOpened.Inc()
 	return p, nil


### PR DESCRIPTION
### Motivation
`partitionsAutoDiscoveryInterval` is currently hardcoded to 1 minute: https://github.com/apache/pulsar-client-go/blob/6ab17dcca28db389ab91a4a2ea6e5ae990d613da/pulsar/producer_impl.go#L60

I could think of two reasons for making it a configurable value:
* A faster or slower partitions discovery is desired. A faster one is more likely when users would like a partition increment to be effective more quickly.
* Allow a test to be able to set it to a much smaller time duration so that the test could exercise the logic within a reasonable short time

### Modifications

Added `PartitionsAutoDiscoveryInterval` into `ProducerOptions` with a default value of 1 minute.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / **not documented**)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
