### PR TITLE
[bug] Fix reader latest position

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -575,6 +575,10 @@ func (pc *partitionConsumer) messageShouldBeDiscarded(msgID trackingMessageID) b
 	if pc.startMessageID.Undefined() {
 		return false
 	}
+	// if we start at latest message, we should never discard
+	if pc.options.startMessageID.equal(latestMessageId) {
+		return false
+	}
 
 	if pc.options.startMessageIDInclusive {
 		return pc.startMessageID.greater(msgID.messageID)

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -576,7 +576,7 @@ func (pc *partitionConsumer) messageShouldBeDiscarded(msgID trackingMessageID) b
 		return false
 	}
 	// if we start at latest message, we should never discard
-	if pc.options.startMessageID.equal(latestMessageId) {
+	if pc.options.startMessageID.equal(latestMessageID) {
 		return false
 	}
 

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -34,6 +35,20 @@ type messageID struct {
 	entryID      int64
 	batchIdx     int32
 	partitionIdx int32
+}
+
+var latestMessageId messageID = messageID{
+	ledgerID:     math.MaxInt64,
+	entryID:      math.MaxInt64,
+	batchIdx:     -1,
+	partitionIdx: -1,
+}
+
+var earliestMessageId messageID = messageID{
+	ledgerID:     -1,
+	entryID:      -1,
+	batchIdx:     -1,
+	partitionIdx: -1,
 }
 
 type trackingMessageID struct {

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -37,14 +37,14 @@ type messageID struct {
 	partitionIdx int32
 }
 
-var latestMessageId messageID = messageID{
+var latestMessageID messageID = messageID{
 	ledgerID:     math.MaxInt64,
 	entryID:      math.MaxInt64,
 	batchIdx:     -1,
 	partitionIdx: -1,
 }
 
-var earliestMessageId messageID = messageID{
+var earliestMessageID messageID = messageID{
 	ledgerID:     -1,
 	entryID:      -1,
 	batchIdx:     -1,

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -37,14 +37,14 @@ type messageID struct {
 	partitionIdx int32
 }
 
-var latestMessageID messageID = messageID{
+var latestMessageID = messageID{
 	ledgerID:     math.MaxInt64,
 	entryID:      math.MaxInt64,
 	batchIdx:     -1,
 	partitionIdx: -1,
 }
 
-var earliestMessageID messageID = messageID{
+var earliestMessageID = messageID{
 	ledgerID:     -1,
 	entryID:      -1,
 	batchIdx:     -1,

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -18,7 +18,6 @@
 package pulsar
 
 import (
-	"math"
 	"time"
 )
 
@@ -129,10 +128,10 @@ func DeserializeMessageID(data []byte) (MessageID, error) {
 
 // EarliestMessageID returns a messageID that points to the earliest message available in a topic
 func EarliestMessageID() MessageID {
-	return newMessageID(-1, -1, -1, -1)
+	return earliestMessageId
 }
 
 // LatestMessage returns a messageID that points to the latest message
 func LatestMessageID() MessageID {
-	return newMessageID(math.MaxInt64, math.MaxInt64, -1, -1)
+	return latestMessageId
 }

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -128,10 +128,10 @@ func DeserializeMessageID(data []byte) (MessageID, error) {
 
 // EarliestMessageID returns a messageID that points to the earliest message available in a topic
 func EarliestMessageID() MessageID {
-	return earliestMessageId
+	return earliestMessageID
 }
 
 // LatestMessage returns a messageID that points to the latest message
 func LatestMessageID() MessageID {
-	return latestMessageId
+	return latestMessageID
 }


### PR DESCRIPTION
Currently, using reader.latest fails because we discard
all messages less than the startPositionID, this causes an issue with
the reader as we filter all messages as all messages are less than
latest message id

