### PR TITLE
Add messageID from string and from parts

### DIFF
--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -112,6 +112,14 @@ func (id messageID) String() string {
 	return fmt.Sprintf("%d:%d:%d", id.ledgerID, id.entryID, id.partitionIdx)
 }
 
+func (id messageID) Equals(other MessageID) bool {
+	rmsgid, ok := other.(messageID)
+	if !ok {
+		return false
+	}
+	return id.equal(rmsgid)
+}
+
 func deserializeMessageID(data []byte) (MessageID, error) {
 	msgID := &pb.MessageIdData{}
 	err := proto.Unmarshal(data, msgID)

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -18,11 +18,12 @@
 package pulsar
 
 import (
-	"github.com/pkg/errors"
 	"math"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // ProducerMessage abstraction used in Pulsar producer
@@ -134,8 +135,8 @@ func DeserializeMessageID(data []byte) (MessageID, error) {
 	return deserializeMessageID(data)
 }
 
-func MessageIDFromParts(ledgerId, entryId int64, batchIdx, partitionIdx int32) MessageID {
-	return newMessageID(ledgerId, entryId, batchIdx, partitionIdx)
+func MessageIDFromParts(ledgerID, entryID int64, batchIdx, partitionIdx int32) MessageID {
+	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx)
 }
 
 func MessageIDFromString(str string) (MessageID, error) {
@@ -146,12 +147,12 @@ func MessageIDFromString(str string) (MessageID, error) {
 		return nil, errors.Errorf("invalid message id string. %s", str)
 	}
 
-	ledgerId, err := strconv.ParseInt(s[0], 10, 64)
+	ledgerID, err := strconv.ParseInt(s[0], 10, 64)
 	if err != nil {
 		return nil, errors.Errorf("invalid ledger id. %s", str)
 	}
 
-	entryId, err := strconv.ParseInt(s[1], 10, 64)
+	entryID, err := strconv.ParseInt(s[1], 10, 64)
 	if err != nil {
 		return nil, errors.Errorf("invalid entry id. %s", str)
 	}
@@ -173,7 +174,7 @@ func MessageIDFromString(str string) (MessageID, error) {
 		}
 		batchIdx = int32(bi)
 	}
-	return newMessageID(ledgerId, entryId, batchIdx, partitionIdx), nil
+	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx), nil
 }
 
 // EarliestMessageID returns a messageID that points to the earliest message available in a topic

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -125,6 +125,8 @@ type MessageID interface {
 	Serialize() []byte
 	// String the message id represented as a string
 	String() string
+	// Equals indicates to message IDs are equal
+	Equals(other MessageID) bool
 }
 
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation
@@ -179,7 +181,7 @@ func EarliestMessageID() MessageID {
 	return newMessageID(-1, -1, -1, -1)
 }
 
-// LatestMessage returns a messageID that points to the latest message
+// LatestMessageID returns a messageID that points to the latest message
 func LatestMessageID() MessageID {
 	return newMessageID(math.MaxInt64, math.MaxInt64, -1, -1)
 }

--- a/pulsar/message_test.go
+++ b/pulsar/message_test.go
@@ -1,0 +1,47 @@
+package pulsar
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMessageIDFromString(t *testing.T) {
+	id, err := MessageIDFromString("1:2")
+	assert.Nil(t, err)
+	assert.True(t, id.Equals(MessageIDFromParts(1, 2, -1,  -1)))
+
+	id, err = MessageIDFromString("1:2:3")
+	assert.Nil(t, err)
+	assert.True(t, id.Equals(MessageIDFromParts(1, 2, -1,  3)))
+
+	id, err = MessageIDFromString("1:2:3:4")
+	assert.Nil(t, err)
+	assert.True(t, id.Equals(MessageIDFromParts(1, 2, 4,  3)))
+}
+
+func TestMessageIDFromStringErrors(t *testing.T) {
+	id, err := MessageIDFromString("1;1")
+	assert.Nil(t, id)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid message id string. 1;1", err.Error())
+
+	id, err = MessageIDFromString("a:1")
+	assert.Nil(t, id)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid ledger id. a:1", err.Error())
+
+	id, err = MessageIDFromString("1:a")
+	assert.Nil(t, id)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid entry id. 1:a", err.Error())
+
+	id, err = MessageIDFromString("1:2:a")
+	assert.Nil(t, id)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid partition index. 1:2:a", err.Error())
+
+	id, err = MessageIDFromString("1:2:3:a")
+	assert.Nil(t, id)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid batch index. 1:2:3:a", err.Error())
+}

--- a/pulsar/message_test.go
+++ b/pulsar/message_test.go
@@ -2,21 +2,22 @@ package pulsar
 
 import (
 	"github.com/stretchr/testify/assert"
+
 	"testing"
 )
 
 func TestMessageIDFromString(t *testing.T) {
 	id, err := MessageIDFromString("1:2")
 	assert.Nil(t, err)
-	assert.True(t, id.Equals(MessageIDFromParts(1, 2, -1,  -1)))
+	assert.True(t, id.Equals(MessageIDFromParts(1, 2, -1, -1)))
 
 	id, err = MessageIDFromString("1:2:3")
 	assert.Nil(t, err)
-	assert.True(t, id.Equals(MessageIDFromParts(1, 2, -1,  3)))
+	assert.True(t, id.Equals(MessageIDFromParts(1, 2, -1, 3)))
 
 	id, err = MessageIDFromString("1:2:3:4")
 	assert.Nil(t, err)
-	assert.True(t, id.Equals(MessageIDFromParts(1, 2, 4,  3)))
+	assert.True(t, id.Equals(MessageIDFromParts(1, 2, 4, 3)))
 }
 
 func TestMessageIDFromStringErrors(t *testing.T) {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -391,6 +391,14 @@ func (id *myMessageID) Serialize() []byte {
 	return id.data
 }
 
+func (id *myMessageID) String() string {
+	return ""
+}
+
+func (id *myMessageID) Equals(other MessageID) bool {
+	return true
+}
+
 func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION
If we want to deal with string message ids, we need methods for being
able to create them from either a string or a using the individual parts
of the message id.

This exposes some constructors for this as well as an equals method to make testing more straight forward (but I am not sure if we want to expose equals...)

This is primarily to match the java implementation, but if we don't want to add the string version, we should at least expose the method to make up a message id from the individual parts.

This commit adds tests for the needed new methods