### PR TITLE
[issue 513] fix batch size limit validation

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -153,7 +153,7 @@ func (bc *batchContainer) IsFull() bool {
 
 func (bc *batchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages > 0 && (bc.buffer.ReadableBytes()+msgSize) > uint32(bc.maxBatchSize)
+	return bc.numMessages+1 > bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) > uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to batch.
@@ -170,7 +170,7 @@ func (bc *batchContainer) Add(
 		// There's already a message with cluster replication list. need to flush before next
 		// message can be sent
 		return false
-	} else if bc.hasSpace(payload) {
+	} else if !bc.hasSpace(payload) {
 		// The current batch is full. Producer has to call Flush() to
 		return false
 	}

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -116,7 +116,7 @@ func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
 
 func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages > 0 && (bc.buffer.ReadableBytes()+msgSize) > uint32(bc.maxBatchSize)
+	return bc.numMessages+1 > bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) > uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to key-based batch with message key.
@@ -133,7 +133,7 @@ func (bc *keyBasedBatchContainer) Add(
 		// There's already a message with cluster replication list. need to flush before next
 		// message can be sent
 		return false
-	} else if bc.hasSpace(payload) {
+	} else if !bc.hasSpace(payload) {
 		// The current batch is full. Producer has to call Flush() to
 		return false
 	}


### PR DESCRIPTION
Fixes #513

fix batch size limit validation

### Motivation

The current batch size validation is incorrect. 

### Modifications

The batch max size should be used to compare against the current size. The message should be flushed when the max size is reached.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: ( no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
