### PR TITLE
add LedgerId,EntryId,BatchIdx,PartitionIdx func for MessageId interface

### DIFF
--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -123,11 +123,11 @@ func (id messageID) Serialize() []byte {
 	return data
 }
 
-func (id messageID) LedgerId() int64 {
+func (id messageID) LedgerID() int64 {
 	return id.ledgerID
 }
 
-func (id messageID) EntryId() int64 {
+func (id messageID) EntryID() int64 {
 	return id.entryID
 }
 

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -123,6 +123,22 @@ func (id messageID) Serialize() []byte {
 	return data
 }
 
+func (id messageID) LedgerId() int64 {
+	return id.ledgerID
+}
+
+func (id messageID) EntryId() int64 {
+	return id.entryID
+}
+
+func (id messageID) BatchIdx() int32 {
+	return id.batchIdx
+}
+
+func (id messageID) PartitionIdx() int32 {
+	return id.partitionIdx
+}
+
 func (id messageID) String() string {
 	return fmt.Sprintf("%d:%d:%d", id.ledgerID, id.entryID, id.partitionIdx)
 }

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -18,9 +18,8 @@
 package pulsar
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestMessageId(t *testing.T) {
@@ -35,6 +34,11 @@ func TestMessageId(t *testing.T) {
 	assert.Equal(t, int64(2), id2.(messageID).entryID)
 	assert.Equal(t, int32(3), id2.(messageID).batchIdx)
 	assert.Equal(t, int32(4), id2.(messageID).partitionIdx)
+
+	assert.Equal(t, int64(1), id2.LedgerId())
+	assert.Equal(t, int64(2), id2.EntryId())
+	assert.Equal(t, int32(3), id2.BatchIdx())
+	assert.Equal(t, int32(4), id2.PartitionIdx())
 
 	id, err = DeserializeMessageID(nil)
 	assert.Error(t, err)

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -35,11 +35,6 @@ func TestMessageId(t *testing.T) {
 	assert.Equal(t, int32(3), id2.(messageID).batchIdx)
 	assert.Equal(t, int32(4), id2.(messageID).partitionIdx)
 
-	assert.Equal(t, int64(1), id2.LedgerId())
-	assert.Equal(t, int64(2), id2.EntryId())
-	assert.Equal(t, int32(3), id2.BatchIdx())
-	assert.Equal(t, int32(4), id2.PartitionIdx())
-
 	id, err = DeserializeMessageID(nil)
 	assert.Error(t, err)
 	assert.Nil(t, id)
@@ -47,6 +42,15 @@ func TestMessageId(t *testing.T) {
 	id, err = DeserializeMessageID(make([]byte, 0))
 	assert.Error(t, err)
 	assert.Nil(t, id)
+}
+
+func TestMessageIdGetFuncs(t *testing.T) {
+	// test LedgerId,EntryId,BatchIdx,PartitionIdx
+	id := newMessageID(1, 2, 3, 4)
+	assert.Equal(t, int64(1), id.LedgerId())
+	assert.Equal(t, int64(2), id.EntryId())
+	assert.Equal(t, int32(3), id.BatchIdx())
+	assert.Equal(t, int32(4), id.PartitionIdx())
 }
 
 func TestAckTracker(t *testing.T) {

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -18,8 +18,9 @@
 package pulsar
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMessageId(t *testing.T) {
@@ -47,8 +48,8 @@ func TestMessageId(t *testing.T) {
 func TestMessageIdGetFuncs(t *testing.T) {
 	// test LedgerId,EntryId,BatchIdx,PartitionIdx
 	id := newMessageID(1, 2, 3, 4)
-	assert.Equal(t, int64(1), id.LedgerId())
-	assert.Equal(t, int64(2), id.EntryId())
+	assert.Equal(t, int64(1), id.LedgerID())
+	assert.Equal(t, int64(2), id.EntryID())
 	assert.Equal(t, int32(3), id.BatchIdx())
 	assert.Equal(t, int32(4), id.PartitionIdx())
 }

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -120,11 +120,11 @@ type MessageID interface {
 	// Serialize the message id into a sequence of bytes that can be stored somewhere else
 	Serialize() []byte
 
-	// Get the message ledgerId
-	LedgerId() int64
+	// Get the message ledgerID
+	LedgerID() int64
 
-	// Get the message entryId
-	EntryId() int64
+	// Get the message entryID
+	EntryID() int64
 
 	// Get the message batchIdx
 	BatchIdx() int32

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -119,6 +119,18 @@ type Message interface {
 type MessageID interface {
 	// Serialize the message id into a sequence of bytes that can be stored somewhere else
 	Serialize() []byte
+
+	// Get the message ledgerId
+	LedgerId() int64
+
+	// Get the message entryId
+	EntryId() int64
+
+	// Get the message batchIdx
+	BatchIdx() int32
+
+	// Get the message partitionIdx
+	PartitionIdx() int32
 }
 
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -391,12 +391,12 @@ func (id *myMessageID) Serialize() []byte {
 	return id.data
 }
 
-func (id *myMessageID) LedgerId() int64 {
-	return id.LedgerId()
+func (id *myMessageID) LedgerID() int64 {
+	return id.LedgerID()
 }
 
-func (id *myMessageID) EntryId() int64 {
-	return id.EntryId()
+func (id *myMessageID) EntryID() int64 {
+	return id.EntryID()
 }
 
 func (id *myMessageID) BatchIdx() int32 {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -391,6 +391,22 @@ func (id *myMessageID) Serialize() []byte {
 	return id.data
 }
 
+func (id *myMessageID) LedgerId() int64 {
+	return id.LedgerId()
+}
+
+func (id *myMessageID) EntryId() int64 {
+	return id.EntryId()
+}
+
+func (id *myMessageID) BatchIdx() int32 {
+	return id.BatchIdx()
+}
+
+func (id *myMessageID) PartitionIdx() int32 {
+	return id.PartitionIdx()
+}
+
 func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION
In some cases, consumers need to obtain the ledgerId, entryId, batchId, partitionidx of the messageId.

This expose LedgerId EntryId BatchId PartitionIdx func for MessageId interface.
