### PR TITLE
fix nil pointer error with `GetPartitionedTopicMetadata` 

### DIFF
--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -203,7 +203,7 @@ func (ls *lookupService) GetPartitionedTopicMetadata(topic string) (*Partitioned
 
 		partitionedTopicMetadata.Partitions = int(res.Response.PartitionMetadataResponse.GetPartitions())
 	} else {
-		return nil, errors.New(fmt.Sprintf("Get topic{%s} partitioned metadata failed", topic))
+		return nil, fmt.Errorf("get topic{%s} partitioned metadata failed", topic)
 	}
 
 	return &partitionedTopicMetadata, nil

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -203,7 +203,7 @@ func (ls *lookupService) GetPartitionedTopicMetadata(topic string) (*Partitioned
 
 		partitionedTopicMetadata.Partitions = int(res.Response.PartitionMetadataResponse.GetPartitions())
 	} else {
-		return nil, fmt.Errorf("get topic{%s} partitioned metadata failed", topic)
+		return nil, fmt.Errorf("no partitioned metadata for topic{%s} in lookup response", topic)
 	}
 
 	return &partitionedTopicMetadata, nil

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -202,6 +202,8 @@ func (ls *lookupService) GetPartitionedTopicMetadata(topic string) (*Partitioned
 		}
 
 		partitionedTopicMetadata.Partitions = int(res.Response.PartitionMetadataResponse.GetPartitions())
+	} else {
+		return nil, errors.New(fmt.Sprintf("Get topic{%s} partitioned metadata failed", topic))
 	}
 
 	return &partitionedTopicMetadata, nil

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -190,11 +190,21 @@ func (ls *lookupService) GetPartitionedTopicMetadata(topic string) (*Partitioned
 	}
 	ls.log.Debugf("Got topic{%s} partitioned metadata response: %+v", topic, res)
 
-	if res.Response.PartitionMetadataResponse.Error != nil {
-		return nil, errors.New(res.Response.PartitionMetadataResponse.GetError().String())
+	var partitionedTopicMetadata PartitionedTopicMetadata
+
+	if res.Response.Error != nil {
+		return nil, errors.New(res.Response.GetError().String())
 	}
 
-	return &PartitionedTopicMetadata{Partitions: int(res.Response.PartitionMetadataResponse.GetPartitions())}, nil
+	if res.Response.PartitionMetadataResponse != nil {
+		if res.Response.PartitionMetadataResponse.Error != nil {
+			return nil, errors.New(res.Response.PartitionMetadataResponse.GetError().String())
+		}
+
+		partitionedTopicMetadata.Partitions = int(res.Response.PartitionMetadataResponse.GetPartitions())
+	}
+
+	return &partitionedTopicMetadata, nil
 }
 
 func (ls *lookupService) Close() {}


### PR DESCRIPTION
### Motivation

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xc7bd24]
goroutine 129 [running]:
github.com/apache/pulsar-client-go/pulsar/internal.(*lookupService).GetPartitionedTopicMetadata(0xc00017ac80, 0xc00040c1e0, 0x2c, 0x0, 0x0, 0x5)
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.4.1-0.20210504220432-203f2f60325b/pulsar/internal/lookup_service.go:193 +0x244
github.com/apache/pulsar-client-go/pulsar.(*client).TopicPartitions(0xc00010f860, 0xc00040c1e0, 0x2c, 0xc0005e6f80, 0x2, 0x2, 0xc0005e6f7c, 0x2)
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.4.1-0.20210504220432-203f2f60325b/pulsar/client_impl.go:184 +0xa2
github.com/apache/pulsar-client-go/pulsar.(*consumer).internalTopicSubscribeToPartitions(0xc0001d01a0, 0x0, 0x0)
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.4.1-0.20210504220432-203f2f60325b/pulsar/consumer_impl.go:250 +0x74
github.com/apache/pulsar-client-go/pulsar.(*consumer).runBackgroundPartitionDiscovery.func1(0xc0001280b0, 0xc00015c540, 0xc00017a190, 0xc0001d01a0)
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.4.1-0.20210504220432-203f2f60325b/pulsar/consumer_impl.go:237 +0xce
created by github.com/apache/pulsar-client-go/pulsar.(*consumer).runBackgroundPartitionDiscovery
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.4.1-0.20210504220432-203f2f60325b/pulsar/consumer_impl.go:229 +0xcd
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.
