### PR TITLE
[Issue 515][pulsar-producer]Fix for Producer Send and SendAsyn is blocked forever when pulsar is down.

### DIFF
--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -930,6 +930,53 @@ func TestSendTimeout(t *testing.T) {
 	makeHTTPCall(t, http.MethodDelete, quotaURL, "")
 }
 
+func TestSendTimeoutWithUnlimitedRetry(t *testing.T) {
+	quotaURL := adminURL + "/admin/v2/namespaces/public/default/backlogQuota"
+	quotaFmt := `{"limit": "%d", "policy": "producer_request_hold"}`
+	makeHTTPCall(t, http.MethodPost, quotaURL, fmt.Sprintf(quotaFmt, 10*1024))
+
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	topicName := newTopicName()
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            topicName,
+		SubscriptionName: "send_timeout_sub",
+	})
+	assert.Nil(t, err)
+	defer consumer.Close() // subscribe but do nothing
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:       topicName,
+		SendTimeout: 2 * time.Second,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	for i := 0; i < 10; i++ {
+		id, err := producer.Send(context.Background(), &ProducerMessage{
+			Payload: make([]byte, 1024),
+		})
+		assert.Nil(t, err)
+		assert.NotNil(t, id)
+	}
+
+	// waiting for the backlog check
+	time.Sleep((5 + 1) * time.Second)
+
+	id, err := producer.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	log.Printf("Error in send : %v", err)
+	assert.NotNil(t, err)
+	assert.Nil(t, id)
+
+	makeHTTPCall(t, http.MethodDelete, quotaURL, "")
+}
+
 type noopProduceInterceptor struct{}
 
 func (noopProduceInterceptor) BeforeSend(producer Producer, message *ProducerMessage) {}


### PR DESCRIPTION
 Issue link - https://github.com/apache/pulsar-client-go/issues/515

Signed-off-by: Megaraj Mahadikar <megarajtm@gmail.com>

Fixes #515

### Motivation
Producer `Send` and `SendAsyn` is blocked forever when pulsar is down if the MaxReconnectToBroker is set to unlimited retry. In case of pulsar down scenarios, within runEventsLoop in producer_partition.go, the call enters reconnectToBroker and remains in a forever loop until the pulsar broker connection is established. Due to this, no more events are consumed from eventsChan channel causing both `Send` and `SendAsyn` to be blocked. Due to this, the SendTimeout would also be not honoured.

### Modifications

In runEventsLoop, have a separate go-routine working on connectClosedCh channel. This way eventsChan is never blocked.

### Verifying this change
This change added tests and can be verified as follows:
1. A new test is added in producer_test.go. `TestSendTimeoutWithUnlimitedRetry` 

