### PR TITLE
Fix default connection timeout

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	defaultConnectionTimeout = 5 * time.Second
+	defaultConnectionTimeout = 10 * time.Second
 	defaultOperationTimeout  = 30 * time.Second
 )
 


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


### Motivation

In Java SDK, the default connection timeout is **10** sec

```
private int connectionTimeoutMs = 10000;
```

The problem here is that when the load of the broker is high, there is no way to complete the processing and creation of the connection within 5s, which will cause the client to constantly create new connections and try to establish a connection with the broker, and the broker Continuously disconnecting from the client, forming a vicious circle

### Modifications

Replace 5 sec of connection timeout with `10` sec
