### PR TITLE
Ignore partitions shrink in client side

### DIFF
--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -177,7 +177,14 @@ func (p *producer) internalCreatePartitionsProducers() error {
 
 	if oldProducers != nil {
 		oldNumPartitions = len(oldProducers)
-		if oldNumPartitions == newNumPartitions {
+		if newNumPartitions < oldNumPartitions {
+			p.log.WithFields(log.Fields{
+				"old_partitions": oldNumPartitions,
+				"new_partitions": newNumPartitions,
+			}).Error("Number of partitions shrank, ignored.")
+			// since it's not client's fault, we just ignore it temporarily
+			return nil
+		} else if newNumPartitions == oldNumPartitions {
 			p.log.Debug("Number of partitions in topic has not changed")
 			return nil
 		}


### PR DESCRIPTION
### Issue
This happened in out production env suddenly without any admin operation.

![image](https://user-images.githubusercontent.com/24536920/127653251-88bff5e1-1e9d-4c4f-906e-e12789793ccb.png)


### Modifications

Since partitions shrink is not client's fault, we just ignore it temporarily, I'll try to find cause in server side.



### Verifying this change

- [ ] Make sure that the change passes the CI checks.