### PR TITLE
add epoch to handle create producer timeout

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -306,7 +306,8 @@ func (p *partitionProducer) reconnectToBroker() {
 		p.log.Info("Reconnecting to broker in ", d)
 		time.Sleep(d)
 		atomic.AddUint64(&p.epoch, 1)
-		p.log.WithField("epoch", atomic.LoadUint64(&p.epoch)).Debug("Reconnecting to broker with epoch ", atomic.LoadUint64(&p.epoch))
+		p.log.WithField("epoch", atomic.LoadUint64(&p.epoch)).Debug(
+			"Reconnecting to broker with epoch ", atomic.LoadUint64(&p.epoch))
 		err := p.grabCnx()
 		if err == nil {
 			// Successfully reconnected

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -139,7 +139,6 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 	p.log = p.log.SubLogger(log.Fields{
 		"producer_name": p.producerName,
 		"producerID":    p.producerID,
-		"epoch":         atomic.LoadUint64(&p.epoch),
 	})
 
 	p.log.WithField("cnx", p.cnx.ID()).Info("Created producer")
@@ -307,7 +306,7 @@ func (p *partitionProducer) reconnectToBroker() {
 		p.log.Info("Reconnecting to broker in ", d)
 		time.Sleep(d)
 		atomic.AddUint64(&p.epoch, 1)
-		p.log.WithField("epoch", atomic.LoadUint64(&p.epoch))
+		p.log.WithField("epoch", atomic.LoadUint64(&p.epoch)).Debug("Reconnecting to broker with epoch ", atomic.LoadUint64(&p.epoch))
 		err := p.grabCnx()
 		if err == nil {
 			// Successfully reconnected

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1127,3 +1127,40 @@ func TestProducerSendAfterClose(t *testing.T) {
 	assert.Nil(t, ID)
 	assert.Error(t, err)
 }
+
+func TestExactlyOnceWithProducerNameSpecified(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	topicName := newTopicName()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: topicName,
+		Name:  "p-name-1",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, producer)
+	defer producer.Close()
+
+	producer2, err := client.CreateProducer(ProducerOptions{
+		Topic: topicName,
+		Name:  "p-name-2",
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, producer2)
+	defer producer2.Close()
+
+	producer3, err := client.CreateProducer(ProducerOptions{
+		Topic: topicName,
+		Name:  "p-name-2",
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, producer3)
+	defer producer3.Close()
+}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1162,5 +1162,4 @@ func TestExactlyOnceWithProducerNameSpecified(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Nil(t, producer3)
-	defer producer3.Close()
 }


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/5606

### Motivation

Handle create producer timeout on pulsar-client-go. To prevent duplicate producer when broker is not available.

### Modifications

- add `epoch` to `partitionProducer`
- add `userProvidedProducerName` to `partitionProducer`
- add tests

### Verifying this change

- [x] Make sure that the change passes the CI checks.