### PR TITLE
Fix producer panic by oldProducers

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -259,7 +259,6 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 	c.Lock()
 	defer c.Unlock()
 	oldConsumers := c.consumers
-	c.consumers = make([]*partitionConsumer, newNumPartitions)
 
 	if oldConsumers != nil {
 		oldNumPartitions = len(oldConsumers)
@@ -278,7 +277,11 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 		c.log.WithField("old_partitions", oldNumPartitions).
 			WithField("new_partitions", newNumPartitions).
 			Info("Changed number of partitions in topic")
+	}
 
+	c.consumers = make([]*partitionConsumer, newNumPartitions)
+
+	if oldConsumers != nil {
 		// Copy over the existing consumer instances
 		for i := 0; i < oldNumPartitions; i++ {
 			c.consumers[i] = oldConsumers[i]

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/pkg/errors"
 )
 
 const defaultNackRedeliveryDelay = 1 * time.Minute
@@ -265,6 +266,13 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 		if oldNumPartitions == newNumPartitions {
 			c.log.Debug("Number of partitions in topic has not changed")
 			return nil
+		}
+
+		if oldNumPartitions > newNumPartitions {
+			c.log.WithField("old_partitions", oldNumPartitions).
+				WithField("new_partitions", newNumPartitions).
+				Error("Does not support scaling down operations on topic partitions")
+			return errors.New("Does not support scaling down operations on topic partitions")
 		}
 
 		c.log.WithField("old_partitions", oldNumPartitions).

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -258,6 +258,7 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 	c.Lock()
 	defer c.Unlock()
 	oldConsumers := c.consumers
+	c.consumers = make([]*partitionConsumer, newNumPartitions)
 
 	if oldConsumers != nil {
 		oldNumPartitions = len(oldConsumers)
@@ -269,13 +270,11 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 		c.log.WithField("old_partitions", oldNumPartitions).
 			WithField("new_partitions", newNumPartitions).
 			Info("Changed number of partitions in topic")
-	}
 
-	c.consumers = make([]*partitionConsumer, newNumPartitions)
-
-	// Copy over the existing consumer instances
-	for i := 0; i < oldNumPartitions; i++ {
-		c.consumers[i] = oldConsumers[i]
+		// Copy over the existing consumer instances
+		for i := 0; i < oldNumPartitions; i++ {
+			c.consumers[i] = oldConsumers[i]
+		}
 	}
 
 	type ConsumerError struct {

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -181,6 +182,13 @@ func (p *producer) internalCreatePartitionsProducers() error {
 		if oldNumPartitions == newNumPartitions {
 			p.log.Debug("Number of partitions in topic has not changed")
 			return nil
+		}
+
+		if oldNumPartitions > newNumPartitions {
+			p.log.WithField("old_partitions", oldNumPartitions).
+				WithField("new_partitions", newNumPartitions).
+				Error("Does not support scaling down operations on topic partitions")
+			return errors.New("Does not support scaling down operations on topic partitions")
 		}
 
 		p.log.WithField("old_partitions", oldNumPartitions).

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -175,6 +175,7 @@ func (p *producer) internalCreatePartitionsProducers() error {
 
 	oldProducers := p.producers
 
+	p.producers = make([]Producer, newNumPartitions)
 	if oldProducers != nil {
 		oldNumPartitions = len(oldProducers)
 		if oldNumPartitions == newNumPartitions {
@@ -185,12 +186,8 @@ func (p *producer) internalCreatePartitionsProducers() error {
 		p.log.WithField("old_partitions", oldNumPartitions).
 			WithField("new_partitions", newNumPartitions).
 			Info("Changed number of partitions in topic")
-	}
 
-	p.producers = make([]Producer, newNumPartitions)
-
-	// Copy over the existing consumer instances
-	if oldProducers != nil {
+		// Copy over the existing consumer instances
 		for i := 0; i < oldNumPartitions; i++ {
 			p.producers[i] = oldProducers[i]
 		}

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -190,8 +190,10 @@ func (p *producer) internalCreatePartitionsProducers() error {
 	p.producers = make([]Producer, newNumPartitions)
 
 	// Copy over the existing consumer instances
-	for i := 0; i < oldNumPartitions; i++ {
-		p.producers[i] = oldProducers[i]
+	if oldProducers != nil {
+		for i := 0; i < oldNumPartitions; i++ {
+			p.producers[i] = oldProducers[i]
+		}
 	}
 
 	type ProducerError struct {

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -176,7 +176,6 @@ func (p *producer) internalCreatePartitionsProducers() error {
 
 	oldProducers := p.producers
 
-	p.producers = make([]Producer, newNumPartitions)
 	if oldProducers != nil {
 		oldNumPartitions = len(oldProducers)
 		if oldNumPartitions == newNumPartitions {
@@ -195,6 +194,11 @@ func (p *producer) internalCreatePartitionsProducers() error {
 			WithField("new_partitions", newNumPartitions).
 			Info("Changed number of partitions in topic")
 
+	}
+
+	p.producers = make([]Producer, newNumPartitions)
+
+	if oldProducers != nil {
 		// Copy over the existing consumer instances
 		for i := 0; i < oldNumPartitions; i++ {
 			p.producers[i] = oldProducers[i]


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>



### Motivation

```
panic: runtime error: index out of range [1] with length 1

goroutine 166288 [running]:
github.com/apache/pulsar-client-go/pulsar.(*producer).internalCreatePartitionsProducers(0xc0070aa6e0, 0x0, 0x0)
        /Users/lzhuang/scfproj/scf_trigger_v2/vendor/github.com/apache/pulsar-client-go/pulsar/producer_impl.go:194 +0x785
github.com/apache/pulsar-client-go/pulsar.(*producer).runBackgroundPartitionDiscovery.func1(0xc004167cd0, 0xc00559f5c0, 0xc006af6dc0, 0xc0070aa6e0)
        /Users/lzhuang/scfproj/scf_trigger_v2/vendor/github.com/apache/pulsar-client-go/pulsar/producer_impl.go:152 +0xce
created by github.com/apache/pulsar-client-go/pulsar.(*producer).runBackgroundPartitionDiscovery
        /Users/lzhuang/scfproj/scf_trigger_v2/vendor/github.com/apache/pulsar-client-go/pulsar/producer_impl.go:144 +0xcd
```

### Modifications

indexing may panic because of 'nil' slice(oldProducers)

