### PR TITLE
Retry assertion several times in consumer regex test

### DIFF
--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -177,10 +177,11 @@ func runRegexConsumerDiscoverPatternAll(t *testing.T, c Client, namespace string
 		t.Fatal(err)
 	}
 	rc.discover()
-	time.Sleep(2000 * time.Millisecond)
-
-	consumers = cloneConsumers(rc)
-	assert.Equal(t, 1, len(consumers))
+	retryAssert(t, 5, 2000, func() {
+		consumers = cloneConsumers(rc)
+	}, func(x assert.TestingT) bool {
+		return assert.Equal(x, 1, len(consumers))
+	})
 }
 
 func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string) {
@@ -216,10 +217,11 @@ func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string
 	defer deleteTopic(myTopic)
 
 	rc.discover()
-	time.Sleep(2000 * time.Millisecond)
-
-	consumers = cloneConsumers(rc)
-	assert.Equal(t, 0, len(consumers))
+	retryAssert(t, 5, 2000, func() {
+		consumers = cloneConsumers(rc)
+	}, func(x assert.TestingT) bool {
+		return assert.Equal(x, 0, len(consumers))
+	})
 
 	// create a topic not in the regex
 	fooTopic := namespace + "/foo-topic"
@@ -229,10 +231,11 @@ func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string
 	}
 
 	rc.discover()
-	time.Sleep(2000 * time.Millisecond)
-
-	consumers = cloneConsumers(rc)
-	assert.Equal(t, 1, len(consumers))
+	retryAssert(t, 5, 2000, func() {
+		consumers = cloneConsumers(rc)
+	}, func(x assert.TestingT) bool {
+		return assert.Equal(x, 1, len(consumers))
+	})
 }
 
 func TestRegexConsumer(t *testing.T) {

--- a/pulsar/test_helper.go
+++ b/pulsar/test_helper.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/stretchr/testify/assert"
 
 	pkgerrors "github.com/pkg/errors"
 )
@@ -164,4 +165,15 @@ func topicPath(topic string) string {
 		return tn.Namespace + "/" + tn.Name[idx:]
 	}
 	return tn.Name
+}
+
+func retryAssert(t assert.TestingT, times int, milliseconds int, update func(), assert func(assert.TestingT) bool) {
+	for i := 0; i < times; i++ {
+		time.Sleep(time.Duration(milliseconds) * time.Millisecond)
+		update()
+		if assert(nil) {
+			break
+		}
+	}
+	assert(t)
 }


### PR DESCRIPTION
### Motivation

in `consumer_regex_test.go`, sometimes consumers take more than 2 seconds (waiting time) subscribing, and assertions fail.

### Modifications

instead of waiting and asserting just once, repeat it a specified number of times so that consumers have enough time to subscribe.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- Does this pull request introduce a new feature? no
