### PR TITLE
Add reconsumer level later logic

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -117,6 +117,9 @@ type ConsumerOptions struct {
 	// Default is false
 	RetryEnable bool
 
+	// Configuration for Retry delay level policy
+	DelayLevelUtil DelayLevelUtil
+
 	// Sets a `MessageChannel` for the consumer
 	// When a message is received, it will be pushed to the channel for consumption
 	MessageChannel chan ConsumerMessage
@@ -180,6 +183,14 @@ type Consumer interface {
 
 	// ReconsumeLater mark a message for redelivery after custom delay
 	ReconsumeLater(msg Message, delay time.Duration)
+
+	// Reconsume a message
+	ReconsumeLaterLevel(message Message, options ReconsumeOptions) error
+
+	// Reconsume a message Async
+	ReconsumeLaterLevelAsync(message Message,
+		options ReconsumeOptions,
+		callback func(MessageID, *ProducerMessage, error))
 
 	// Acknowledge the failure to process a single message.
 	//

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -150,6 +151,14 @@ func (c *regexConsumer) Receive(ctx context.Context) (message Message, err error
 			return nil, ctx.Err()
 		}
 	}
+}
+
+func (c *regexConsumer) ReconsumeLaterLevel(message Message, options ReconsumeOptions) error {
+	return errors.New("Regex topic consumer not support reconsume! ")
+}
+
+func (c *regexConsumer) ReconsumeLaterLevelAsync(message Message, options ReconsumeOptions, callback func(MessageID, *ProducerMessage, error)) {
+	c.log.Error("Regex topic consumer not support reconsume! ")
 }
 
 // Chan

--- a/pulsar/negative_acks_tracker.go
+++ b/pulsar/negative_acks_tracker.go
@@ -76,6 +76,22 @@ func (t *negativeAcksTracker) Add(msgID messageID) {
 	t.negativeAcks[batchMsgID] = targetTime
 }
 
+func (t *negativeAcksTracker) Del(msgID trackingMessageID) {
+	batchMsgID := messageID{
+		ledgerID: msgID.ledgerID,
+		entryID:  msgID.entryID,
+		batchIdx: 0,
+	}
+	t.Lock()
+	defer t.Unlock()
+
+	_, present := t.negativeAcks[batchMsgID]
+	if !present {
+		return
+	}
+	delete(t.negativeAcks, batchMsgID)
+}
+
 func (t *negativeAcksTracker) track() {
 	for {
 		select {

--- a/pulsar/reconsume_later_util.go
+++ b/pulsar/reconsume_later_util.go
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	log "github.com/sirupsen/logrus"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const DefaultMessageDelayLevel = "1s 5s 10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h"
+
+type DelayLevelUtil interface {
+	GetMaxDelayLevel() int
+	GetDelayTime(level int) int64
+	ParseDelayLevel() bool
+}
+
+type delayLevelUtil struct {
+	maxDelayLevel   int
+	levelString     string
+	delayLevelTable map[int]int64
+}
+
+func NewDelayLevelUtil(levelStr string) DelayLevelUtil {
+	delayLevelUtil := &delayLevelUtil{
+		levelString:     levelStr,
+		delayLevelTable: make(map[int]int64),
+	}
+	delayLevelUtil.ParseDelayLevel()
+	return delayLevelUtil
+}
+
+func (d *delayLevelUtil) GetMaxDelayLevel() int {
+	return d.maxDelayLevel
+}
+
+func (d *delayLevelUtil) GetDelayTime(level int) int64 {
+	if d.delayLevelTable == nil {
+		return 0
+	} else if level < 1 {
+		return 0
+	} else if level > d.maxDelayLevel {
+		return d.delayLevelTable[d.maxDelayLevel]
+	} else {
+		return d.delayLevelTable[level]
+	}
+}
+
+func (d *delayLevelUtil) ParseDelayLevel() bool {
+	d.delayLevelTable = make(map[int]int64)
+	timeUnitTable := make(map[string]int64)
+	timeUnitTable["s"] = 1000
+	timeUnitTable["m"] = 1000 * 60
+	timeUnitTable["h"] = 1000 * 60 * 60
+	timeUnitTable["d"] = 1000 * 60 * 60 * 24
+
+	levelArray := strings.Split(d.levelString, " ")
+	for i := 0; i < len(levelArray); i++ {
+		length := len(levelArray[i])
+		if length == 0 {
+			continue
+		}
+		timeunit := timeUnitTable[levelArray[i][length-1:]]
+
+		level := i + 1
+		if level > d.maxDelayLevel {
+			d.maxDelayLevel = level
+		}
+		num, err := strconv.ParseInt(levelArray[i][:length-1], 10, 64)
+		if err != nil {
+			log.Error("parseDelayLevel exception" + err.Error())
+			log.Info("levelString str = {}", d.levelString)
+			return false
+		}
+		delayTimeMills := timeunit * num
+		d.delayLevelTable[level] = delayTimeMills
+	}
+	return true
+}
+
+type reconsumeOptions struct {
+	delayTime     int64
+	delayTimeUnit time.Duration
+	delayLevel    int
+}
+
+type ReconsumeOptions interface {
+	DelayTime() int64
+	DelayTimeUnit() time.Duration
+	DelayLevel() int
+}
+
+func NewReconsumeOptions() ReconsumeOptions {
+	return &reconsumeOptions{
+		delayTime:     0,
+		delayTimeUnit: time.Millisecond,
+		delayLevel:    -2,
+	}
+}
+
+func NewReconsumeOptionsWithTime(delayTime int64, delayTimeUnit time.Duration) ReconsumeOptions {
+	return &reconsumeOptions{
+		delayTime:     delayTime,
+		delayTimeUnit: delayTimeUnit,
+		delayLevel:    -1,
+	}
+}
+
+func NewReconsumeOptionsWithLevel(delayLevel int) ReconsumeOptions {
+	return &reconsumeOptions{
+		delayTime:     0,
+		delayTimeUnit: time.Millisecond,
+		delayLevel:    delayLevel,
+	}
+}
+
+func (ro *reconsumeOptions) DelayTime() int64 {
+	return ro.delayTime
+}
+
+func (ro *reconsumeOptions) DelayTimeUnit() time.Duration {
+	return ro.delayTimeUnit
+}
+
+func (ro *reconsumeOptions) DelayLevel() int {
+	return ro.delayLevel
+}

--- a/pulsar/reconsume_later_util_test.go
+++ b/pulsar/reconsume_later_util_test.go
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDelayLevelUtil_GetDelayTime(t *testing.T) {
+	a := "1s 5s   10s 30s 1m 2m 3m 4m 5m 6m 7m 8m 9m 10m 20m 30m 1h 2h"
+	d := NewDelayLevelUtil(a)
+	assert.Equal(t, int64(0), d.GetDelayTime(0))
+	assert.Equal(t, int64(7200000), d.GetDelayTime(d.GetMaxDelayLevel()))
+	assert.Equal(t, int64(7200000), d.GetDelayTime(100))
+}


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


### Motivation


As https://github.com/apache/pulsar/issues/11892 show, add reconsumer level later logic

### Modifications

- Add `ReconsumerLaterLevel()` logic
- Add `ReconsumerLaterLevelAsync()` logic

