### PR TITLE
Fix ConsumersOpened counter not incremented when use multitopic or regexp consumer

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -151,7 +151,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 			return nil, err
 		}
 		topic = tns[0].Name
-		return topicSubscribe(client, options, topic, messageCh, dlq, rlq)
+		return newInternalConsumer(client, options, topic, messageCh, dlq, rlq, false)
 	}
 
 	if len(options.Topics) > 1 {
@@ -212,6 +212,7 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 	}
 	consumer.stopDiscovery = consumer.runBackgroundPartitionDiscovery(duration)
 
+	consumer.metrics.ConsumersOpened.Inc()
 	return consumer, nil
 }
 
@@ -374,15 +375,6 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 		c.metrics.ConsumersPartitions.Add(float64(partitionsToAdd))
 	}
 	return nil
-}
-
-func topicSubscribe(client *client, options ConsumerOptions, topic string,
-	messageCh chan ConsumerMessage, dlqRouter *dlqRouter, retryRouter *retryRouter) (Consumer, error) {
-	c, err := newInternalConsumer(client, options, topic, messageCh, dlqRouter, retryRouter, false)
-	if err == nil {
-		c.metrics.ConsumersOpened.Inc()
-	}
-	return c, err
 }
 
 func (c *consumer) Subscription() string {


### PR DESCRIPTION


<--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

There was a kind of weird behavior when internal consumers created by multitopic- or regexp consumer are not counted as opened, but do as closed, so we can see in Prometheus that there were more consumers closed than opened.

### Modifications

Drop `topicSubscribe` function, increment `ConsumersOpened` counter on each success `newInternalConsumer` call similary to 

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
