### PR TITLE
Fix multitopic- and regexp consumers not removed from client handlers on Close

### DIFF
--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -30,6 +30,8 @@ import (
 )
 
 type multiTopicConsumer struct {
+	client *client
+
 	options ConsumerOptions
 
 	consumerName string
@@ -48,6 +50,7 @@ type multiTopicConsumer struct {
 func newMultiTopicConsumer(client *client, options ConsumerOptions, topics []string,
 	messageCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter) (Consumer, error) {
 	mtc := &multiTopicConsumer{
+		client:       client,
 		options:      options,
 		messageCh:    messageCh,
 		consumers:    make(map[string]Consumer, len(topics)),
@@ -186,6 +189,7 @@ func (c *multiTopicConsumer) Close() {
 		}
 		wg.Wait()
 		close(c.closeCh)
+		c.client.handlers.Del(c)
 		c.dlq.close()
 		c.rlq.close()
 	})

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -217,6 +217,7 @@ func (c *regexConsumer) Close() {
 			}(con)
 		}
 		wg.Wait()
+		c.client.handlers.Del(c)
 		c.dlq.close()
 		c.rlq.close()
 	})

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -33,6 +33,7 @@ const (
 
 type reader struct {
 	sync.Mutex
+	client              *client
 	pc                  *partitionConsumer
 	messageCh           chan ConsumerMessage
 	lastMessageInBroker trackingMessageID
@@ -91,6 +92,7 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 	}
 
 	reader := &reader{
+		client:    client,
 		messageCh: make(chan ConsumerMessage),
 		log:       client.log.SubLogger(log.Fields{"topic": options.Topic}),
 		metrics:   client.metrics.GetTopicMetrics(options.Topic),
@@ -174,6 +176,7 @@ func (r *reader) hasMoreMessages() bool {
 
 func (r *reader) Close() {
 	r.pc.Close()
+	r.client.handlers.Del(r)
 	r.metrics.ReadersClosed.Inc()
 }
 


### PR DESCRIPTION
Currently, every consumer created by `client.Subscribe()` call is registered into `client.handlers` map so that it can be disposed on `client.Closed` if it is still active. According to `(*consumer).Close()` implementation, entity is supposed to remove itself from `client.handlers` when gets disposed, but it's not implemented for multitopic consumer, regexp consumer and reader, so even after user closes them, their memory remains reachable, causing hard-to-debug memory leak.

This PR fixes such leakage by forcing multitopic consumer, regexp consumer and reader to remove themself from `client.handlers` map on `Close`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
