### PR TITLE
Fix reconnection logic when topic is deleted

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -893,13 +893,12 @@ func (pc *partitionConsumer) reconnectToBroker() {
 			// Successfully reconnected
 			pc.log.Info("Reconnected consumer to broker")
 			return
-		} else {
-			errMsg := err.Error()
-			if strings.Contains(errMsg, errTopicNotFount) {
-				// when topic is deleted, we should give up reconnection.
-				pc.log.Warn("Topic Not Found.")
-				break
-			}
+		}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, errTopicNotFount) {
+			// when topic is deleted, we should give up reconnection.
+			pc.log.Warn("Topic Not Found.")
+			break
 		}
 
 		if maxRetry > 0 {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -892,6 +893,13 @@ func (pc *partitionConsumer) reconnectToBroker() {
 			// Successfully reconnected
 			pc.log.Info("Reconnected consumer to broker")
 			return
+		} else {
+			errMsg := err.Error()
+			if strings.Contains(errMsg, errTopicNotFount) {
+				// when topic is deleted, we should give up reconnection.
+				pc.log.Warn("Topic Not Found.")
+				break
+			}
 		}
 
 		if maxRetry > 0 {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -352,13 +352,12 @@ func (p *partitionProducer) reconnectToBroker() {
 			// Successfully reconnected
 			p.log.WithField("cnx", p.cnx.ID()).Info("Reconnected producer to broker")
 			return
-		} else {
-			errMsg := err.Error()
-			if strings.Contains(errMsg, errTopicNotFount) {
-				// when topic is deleted, we should give up reconnection.
-				p.log.Warn("Topic Not Found.")
-				break
-			}
+		}
+		errMsg := err.Error()
+		if strings.Contains(errMsg, errTopicNotFount) {
+			// when topic is deleted, we should give up reconnection.
+			p.log.Warn("Topic Not Found.")
+			break
 		}
 
 		if maxRetry > 0 {


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


Fixes #623


### Motivation

As #623 said, when the topic is deleted forced, we don't should trying to reconnect, instead of giving up reconnection.


### Modifications

- Fix prodcuer reconnetion logic
- Fix consumer reconnection logic


