### PR TITLE
Go 1.11 & 1.12 Docker images are not working anymore

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.11, 1.12, 1.13, 1.14]
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17]
     steps:
       - name: clean docker cache
         run: |

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.11, 1.12, 1.13, 1.14]
+        go-version: [1.13, 1.14, 1.15, 1.16, 1.17]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG GO_VERSION=golang:1.12
 FROM apachepulsar/pulsar:latest as pulsar
 FROM $GO_VERSION as go
 
-RUN apt-get update && apt-get install -y openjdk-11-jre-headless
+RUN apt-get update && apt-get install -y openjdk-11-jre-headless ca-certificates
 
 COPY --from=pulsar /pulsar /pulsar
 


### PR DESCRIPTION
### Motivation

CI is currently broken because the `go mod download` is failing in the docker images for Go 1.11 and 1.12.

```
go: gopkg.in/check.v1@v1.0.0-20190902080502-41f04d3bba15: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /pkg/mod/cache/vcs/7e5fa1eab4705eb80c9746632736cea906708d060702d529df6241d1c8c2c9f9: exit status 128:
	fatal: unable to access 'https://gopkg.in/check.v1/': server certificate verification failed. CAfile: none CRLfile: none
go: gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127: unknown revision 788fd7840127
```

The issue is related with Let's Encrypt root CA getting changed. Apparently the `go` tool is not even using the updated certs from the image.


Removing 1.11 and 1.12 from CI and adding newer versions 1.15, 1.16 and 1.17.

