### PR TITLE
Improve support for Azure AD OAuth 2.0

### DIFF
--- a/pulsar/internal/auth/oauth2.go
+++ b/pulsar/internal/auth/oauth2.go
@@ -36,7 +36,7 @@ const (
 	ConfigParamTypeClientCredentials = "client_credentials"
 	ConfigParamIssuerURL             = "issuerUrl"
 	ConfigParamAudience              = "audience"
-	ConfigParamScope                 = "scope"
+	ConfigParamScopes                = "scopes"
 	ConfigParamKeyFile               = "privateKey"
 	ConfigParamClientID              = "clientId"
 )
@@ -64,7 +64,7 @@ func NewAuthenticationOAuth2WithParams(params map[string]string) (Provider, erro
 	case ConfigParamTypeClientCredentials:
 		flow, err := oauth2.NewDefaultClientCredentialsFlow(oauth2.ClientCredentialsFlowOptions{
 			KeyFile:          params[ConfigParamKeyFile],
-			AdditionalScopes: strings.Split(params[ConfigParamScope], ""),
+			AdditionalScopes: strings.Split(params[ConfigParamScopes], " "),
 		})
 		if err != nil {
 			return nil, err

--- a/pulsar/internal/auth/oauth2_test.go
+++ b/pulsar/internal/auth/oauth2_test.go
@@ -98,6 +98,7 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
 			ConfigParamClientID:  "client-id",
 			ConfigParamAudience:  "audience",
 			ConfigParamKeyFile:   kf,
+			ConfigParamScopes:    "profile",
 		},
 		{
 			ConfigParamType:      ConfigParamTypeClientCredentials,
@@ -105,6 +106,7 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
 			ConfigParamClientID:  "client-id",
 			ConfigParamAudience:  "audience",
 			ConfigParamKeyFile:   fmt.Sprintf("file://%s", kf),
+			ConfigParamScopes:    "profile",
 		},
 		{
 			ConfigParamType:      ConfigParamTypeClientCredentials,
@@ -118,6 +120,7 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
   "client_email":"oauth@test.org",
   "issuer_url":"%s"
 }`, server.URL),
+			ConfigParamScopes: "profile",
 		},
 	}
 


### PR DESCRIPTION

### Motivation

This is a bugfix for a flaw in an earlier PR, https://github.com/apache/pulsar-client-go/pull/630.

### Modifications

- rename the newly-added `scope` auth param to `scopes` for consistency
- parsing fix for scopes auth param

### Verifying this change

This change added tests and can be verified as follows:

- oauth2_test.go
