### PR TITLE
Improve support for Azure AD OAuth 2.0

### DIFF
--- a/pulsar/internal/auth/oauth2.go
+++ b/pulsar/internal/auth/oauth2.go
@@ -36,7 +36,7 @@ const (
 	ConfigParamTypeClientCredentials = "client_credentials"
 	ConfigParamIssuerURL             = "issuerUrl"
 	ConfigParamAudience              = "audience"
-	ConfigParamScopes                = "scopes"
+	ConfigParamScope                 = "scope"
 	ConfigParamKeyFile               = "privateKey"
 	ConfigParamClientID              = "clientId"
 )
@@ -64,7 +64,7 @@ func NewAuthenticationOAuth2WithParams(params map[string]string) (Provider, erro
 	case ConfigParamTypeClientCredentials:
 		flow, err := oauth2.NewDefaultClientCredentialsFlow(oauth2.ClientCredentialsFlowOptions{
 			KeyFile:          params[ConfigParamKeyFile],
-			AdditionalScopes: strings.Split(params[ConfigParamScopes], " "),
+			AdditionalScopes: strings.Split(params[ConfigParamScope], " "),
 		})
 		if err != nil {
 			return nil, err

--- a/pulsar/internal/auth/oauth2_test.go
+++ b/pulsar/internal/auth/oauth2_test.go
@@ -98,7 +98,7 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
 			ConfigParamClientID:  "client-id",
 			ConfigParamAudience:  "audience",
 			ConfigParamKeyFile:   kf,
-			ConfigParamScopes:    "profile",
+			ConfigParamScope:     "profile",
 		},
 		{
 			ConfigParamType:      ConfigParamTypeClientCredentials,
@@ -106,7 +106,7 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
 			ConfigParamClientID:  "client-id",
 			ConfigParamAudience:  "audience",
 			ConfigParamKeyFile:   fmt.Sprintf("file://%s", kf),
-			ConfigParamScopes:    "profile",
+			ConfigParamScope:     "profile",
 		},
 		{
 			ConfigParamType:      ConfigParamTypeClientCredentials,
@@ -120,7 +120,7 @@ func TestNewAuthenticationOAuth2WithParams(t *testing.T) {
   "client_email":"oauth@test.org",
   "issuer_url":"%s"
 }`, server.URL),
-			ConfigParamScopes: "profile",
+			ConfigParamScope: "profile",
 		},
 	}
 


### PR DESCRIPTION

### Motivation

Reverts a change to the authparams made in PR: https://github.com/apache/pulsar-client-go/pull/633

### Modifications

For consistency with the Java client, the auth params should contain `scope` not `scopes`.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
