### PR TITLE
modify producer reconnect bug ,fix 638

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -68,13 +68,13 @@ type partitionProducer struct {
 	log    log.Logger
 	cnx    internal.Connection
 
-	options             *ProducerOptions
-	producerName        string
+	options                  *ProducerOptions
+	producerName             string
 	userProvidedProducerName bool
-	producerID          uint64
-	batchBuilder        internal.BatchBuilder
-	sequenceIDGenerator *uint64
-	batchFlushTicker    *time.Ticker
+	producerID               uint64
+	batchBuilder             internal.BatchBuilder
+	sequenceIDGenerator      *uint64
+	batchFlushTicker         *time.Ticker
 
 	// Channel where app is posting messages to be published
 	eventsChan      chan interface{}


### PR DESCRIPTION
Fixes #638

Master Issue: #638
 
userProvidedProducerName is used to mark is or not user config producerName. it must not to be reset when auto reconnect.