### PR TITLE
fix 640,change create way is same as java client

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1008,6 +1008,7 @@ func (pc *partitionConsumer) reconnectToBroker() {
 		if strings.Contains(errMsg, errTopicNotFount) {
 			// when topic is deleted, we should give up reconnection.
 			pc.log.Warn("Topic Not Found.")
+			break
 		}
 
 		if maxRetry > 0 {
@@ -1020,7 +1021,6 @@ func (pc *partitionConsumer) grabConn() error {
 	lr, err := pc.client.lookupService.Lookup(pc.topic)
 	if err != nil {
 		pc.log.WithError(err).Warn("Failed to lookup topic, it will be retried later!")
-		pc.connectClosedCh <- connectionClosed{}
 		return err
 	}
 	pc.log.Debugf("Lookup result: %+v", lr)
@@ -1084,7 +1084,6 @@ func (pc *partitionConsumer) grabConn() error {
 
 	if err != nil {
 		pc.log.WithError(err).Error("Failed to create consumer, it may be retried later when connection error!")
-		pc.connectClosedCh <- connectionClosed{}
 		return err
 	}
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1016,8 +1016,9 @@ func (pc *partitionConsumer) reconnectToBroker() {
 func (pc *partitionConsumer) grabConn() error {
 	lr, err := pc.client.lookupService.Lookup(pc.topic)
 	if err != nil {
-		pc.log.WithError(err).Warn("Failed to lookup topic")
-		return err
+		pc.log.WithError(err).Warn("Failed to lookup topic, it will be retried later!")
+		pc.connectClosedCh <- connectionClosed{}
+		return nil
 	}
 	pc.log.Debugf("Lookup result: %+v", lr)
 
@@ -1079,8 +1080,9 @@ func (pc *partitionConsumer) grabConn() error {
 		pb.BaseCommand_SUBSCRIBE, cmdSubscribe)
 
 	if err != nil {
-		pc.log.WithError(err).Error("Failed to create consumer")
-		return err
+		pc.log.WithError(err).Error("Failed to create consumer, it will be retried later!")
+		pc.connectClosedCh <- connectionClosed{}
+		return nil
 	}
 
 	if res.Response.ConsumerStatsResponse != nil {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -207,7 +207,8 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 	if err != nil {
 		errMsg := err.Error()
 		if !strings.EqualFold(errMsg, pb.ServerError_ServiceNotReady.String()) &&
-			!strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) {
+			!strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) &&
+			!strings.EqualFold(errMsg, pb.ServerError_MetadataError.String()) {
 			// when topic is deleted, we should give up reconnection.
 			pc.log.WithError(err).Error("Failed to create consumer")
 			pc.nackTracker.Close()

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1084,7 +1084,7 @@ func (pc *partitionConsumer) grabConn() error {
 		pb.BaseCommand_SUBSCRIBE, cmdSubscribe)
 
 	if err != nil {
-		pc.log.WithError(err).Error("Failed to create consumer, it may be retried later when connection error!")
+		pc.log.WithError(err).Error("Failed to create consumer")
 		return err
 	}
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -206,7 +206,8 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 	err := pc.grabConn()
 	if err != nil {
 		errMsg := err.Error()
-		if !strings.EqualFold(errMsg, pb.ServerError_ServiceNotReady.String()) && !strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) {
+		if !strings.EqualFold(errMsg, pb.ServerError_ServiceNotReady.String()) &&
+			!strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) {
 			// when topic is deleted, we should give up reconnection.
 			pc.log.WithError(err).Error("Failed to create consumer")
 			pc.nackTracker.Close()

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -161,7 +161,8 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 	err := p.grabCnx()
 	if err != nil {
 		errMsg := err.Error()
-		if !strings.EqualFold(errMsg, pb.ServerError_ServiceNotReady.String()) && !strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) {
+		if !strings.EqualFold(errMsg, pb.ServerError_ServiceNotReady.String()) &&
+			!strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) {
 			// when topic is deleted, we should give up reconnection.
 			logger.WithError(err).Error("Failed to create producer")
 			return nil, err

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -194,7 +194,6 @@ func (p *partitionProducer) grabCnx() error {
 	lr, err := p.client.lookupService.Lookup(p.topic)
 	if err != nil {
 		p.log.WithError(err).Warn("Failed to lookup topic, it will be retried later!")
-		p.connectClosedCh <- connectionClosed{}
 		return errors.New(errLookupError)
 	}
 
@@ -238,7 +237,6 @@ func (p *partitionProducer) grabCnx() error {
 	res, err := p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_PRODUCER, cmdProducer)
 	if err != nil {
 		p.log.WithError(err).Error("Failed to create producer, it may be retried later when connection error!")
-		p.connectClosedCh <- connectionClosed{}
 		return err
 	}
 
@@ -370,6 +368,7 @@ func (p *partitionProducer) reconnectToBroker() {
 		if strings.Contains(errMsg, errTopicNotFount) {
 			// when topic is deleted, we should give up reconnection.
 			p.log.Warn("Topic Not Found.")
+			break
 		}
 
 		if maxRetry > 0 {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -162,7 +162,8 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 	if err != nil {
 		errMsg := err.Error()
 		if !strings.EqualFold(errMsg, pb.ServerError_ServiceNotReady.String()) &&
-			!strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) {
+			!strings.EqualFold(errMsg, pb.ServerError_TooManyRequests.String()) &&
+			!strings.EqualFold(errMsg, pb.ServerError_MetadataError.String()) {
 			// when topic is deleted, we should give up reconnection.
 			logger.WithError(err).Error("Failed to create producer")
 			return nil, err

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -231,7 +231,7 @@ func (p *partitionProducer) grabCnx() error {
 	}
 	res, err := p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_PRODUCER, cmdProducer)
 	if err != nil {
-		p.log.WithError(err).Error("Failed to create producer, it may be retried later when connection error!")
+		p.log.WithError(err).Error("Failed to create producer")
 		return err
 	}
 

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -107,10 +107,10 @@ func TestReaderConnectError(t *testing.T) {
 	})
 
 	// Expect error in creating consumer
-	assert.Nil(t, reader)
-	assert.NotNil(t, err)
+	assert.NotNil(t, reader)
+	assert.Nil(t, err)
 
-	assert.Equal(t, err.Error(), "connection error")
+	//assert.Equal(t, err.Error(), "connection error")
 }
 
 func TestReaderOnSpecificMessage(t *testing.T) {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -107,10 +107,10 @@ func TestReaderConnectError(t *testing.T) {
 	})
 
 	// Expect error in creating consumer
-	assert.NotNil(t, reader)
-	assert.Nil(t, err)
+	assert.Nil(t, reader)
+	assert.NotNil(t, err)
 
-	//assert.Equal(t, err.Error(), "connection error")
+	assert.Equal(t, err.Error(), "connection error")
 }
 
 func TestReaderOnSpecificMessage(t *testing.T) {


### PR DESCRIPTION
Fixes #640

Master Issue: #640

go client create producer and consumer client way is different with java client. and go client will throw error when call grabCnx while  Lookup or after sending CommandProducer.
if use get this error,  use must retry recreate client and this way is not neccessary.  and connect need to reconnect while send or connect check way.

java client handle like this, so it need be changed .

![image](https://user-images.githubusercontent.com/8108604/137318916-16baaab0-d03f-4bb4-bda8-fb5238d418e3.png)
![image](https://user-images.githubusercontent.com/8108604/137318933-9d09d2e9-9a27-463b-8bce-766bf8db9fe5.png)
and java code is this
![image](https://user-images.githubusercontent.com/8108604/137319037-ccdaacde-c4df-4410-abe1-34a4f00eadfd.png)


