### PR TITLE
fix send error logic

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -776,6 +776,7 @@ func (c *connection) handleSendError(sendError *pb.CommandSendError) {
 		}
 
 		c.log.Warnf("server error: %s: %s", sendError.GetError(), sendError.GetMessage())
+		break
 	case pb.ServerError_TopicTerminatedError:
 		_, ok := c.deletePendingProducers(producerID)
 		if !ok {
@@ -784,6 +785,7 @@ func (c *connection) handleSendError(sendError *pb.CommandSendError) {
 			return
 		}
 		c.log.Warnf("server error: %s: %s", sendError.GetError(), sendError.GetMessage())
+		break
 	default:
 		// By default, for transient error, let the reconnection logic
 		// to take place and re-establish the produce again


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

### Motivation


When the user receives `ServerError_NotAllowedError` and `ServerError_TopicTerminatedError` errors, we only need to remove the currently pending producer object, and there is no need to continue the logic of retrying.

Follow the java logic: https://github.com/apache/pulsar/blob/4147db88bc08eb3b2dab97a45af178fd9f4c7a6b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java#L668-L673

