### PR TITLE
Support nack backoff policy for SDK

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -158,6 +158,13 @@ type ConsumerOptions struct {
 
 	// Decryption decryption related fields to decrypt the encrypted message
 	Decryption *MessageDecryptionInfo
+
+	// NackBackoffPolicy is a redelivery backoff mechanism which we can achieve redelivery with different
+	// delays according to the number of times the message is retried.
+	//
+	// > Notice: the NackBackoffPolicy will not work with `consumer.NackID(MessageID)`
+	// > because we are not able to get the redeliveryCount from the message ID.
+	NackBackoffPolicy NackBackoffPolicy
 }
 
 // Consumer is an interface that abstracts behavior of Pulsar's consumer

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -159,6 +159,10 @@ type ConsumerOptions struct {
 	// Decryption decryption related fields to decrypt the encrypted message
 	Decryption *MessageDecryptionInfo
 
+	// If enabled, the default implementation of NackBackoffPolicy will be used to calculate the delay time of
+	// nack backoff, Default: false.
+	EnableDefaultNackBackoffPolicy bool
+
 	// NackBackoffPolicy is a redelivery backoff mechanism which we can achieve redelivery with different
 	// delays according to the number of times the message is retried.
 	//

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -88,7 +88,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		}
 	}
 
-	if options.NackBackoffPolicy == nil && options.EnableDefaultNackBackoffPolicy == true {
+	if options.NackBackoffPolicy == nil && options.EnableDefaultNackBackoffPolicy {
 		options.NackBackoffPolicy = new(defaultNackBackoffPolicy)
 	}
 

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -88,7 +88,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		}
 	}
 
-	if options.NackBackoffPolicy == nil {
+	if options.NackBackoffPolicy == nil && options.EnableDefaultNackBackoffPolicy == true {
 		options.NackBackoffPolicy = new(defaultNackBackoffPolicy)
 	}
 

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -164,7 +164,18 @@ func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 }
 
 func (c *multiTopicConsumer) Nack(msg Message) {
-	c.NackID(msg.ID())
+	msgID := msg.ID()
+	mid, ok := toTrackingMessageID(msgID)
+	if !ok {
+		c.log.Warnf("invalid message id type %T", msgID)
+		return
+	}
+
+	if mid.consumer == nil {
+		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
+		return
+	}
+	mid.NackByMsg(msg)
 }
 
 func (c *multiTopicConsumer) NackID(msgID MessageID) {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -164,18 +164,23 @@ func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 }
 
 func (c *multiTopicConsumer) Nack(msg Message) {
-	msgID := msg.ID()
-	mid, ok := toTrackingMessageID(msgID)
-	if !ok {
-		c.log.Warnf("invalid message id type %T", msgID)
+	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
+		msgID := msg.ID()
+		mid, ok := toTrackingMessageID(msgID)
+		if !ok {
+			c.log.Warnf("invalid message id type %T", msgID)
+			return
+		}
+
+		if mid.consumer == nil {
+			c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
+			return
+		}
+		mid.NackByMsg(msg)
 		return
 	}
 
-	if mid.consumer == nil {
-		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
-		return
-	}
-	mid.NackByMsg(msg)
+	c.NackID(msg.ID())
 }
 
 func (c *multiTopicConsumer) NackID(msgID MessageID) {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -89,6 +89,7 @@ type partitionConsumerOpts struct {
 	partitionIdx               int
 	receiverQueueSize          int
 	nackRedeliveryDelay        time.Duration
+	nackBackoffPolicy          NackBackoffPolicy
 	metadata                   map[string]string
 	replicateSubscriptionState bool
 	startMessageID             trackingMessageID
@@ -201,7 +202,7 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 
 	pc.decryptor = decryptor
 
-	pc.nackTracker = newNegativeAcksTracker(pc, options.nackRedeliveryDelay, pc.log)
+	pc.nackTracker = newNegativeAcksTracker(pc, options.nackRedeliveryDelay, options.nackBackoffPolicy, pc.log)
 
 	err := pc.grabConn()
 	if err != nil {
@@ -328,6 +329,11 @@ func (pc *partitionConsumer) AckID(msgID trackingMessageID) {
 
 func (pc *partitionConsumer) NackID(msgID trackingMessageID) {
 	pc.nackTracker.Add(msgID.messageID)
+	pc.metrics.NacksCounter.Inc()
+}
+
+func (pc *partitionConsumer) NackMsg(msg Message) {
+	pc.nackTracker.AddMessage(msg)
 	pc.metrics.NacksCounter.Inc()
 }
 

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -183,7 +183,18 @@ func (c *regexConsumer) AckID(msgID MessageID) {
 }
 
 func (c *regexConsumer) Nack(msg Message) {
-	c.NackID(msg.ID())
+	msgID := msg.ID()
+	mid, ok := toTrackingMessageID(msgID)
+	if !ok {
+		c.log.Warnf("invalid message id type %T", msgID)
+		return
+	}
+
+	if mid.consumer == nil {
+		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
+		return
+	}
+	mid.NackByMsg(msg)
 }
 
 func (c *regexConsumer) NackID(msgID MessageID) {

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -183,18 +183,23 @@ func (c *regexConsumer) AckID(msgID MessageID) {
 }
 
 func (c *regexConsumer) Nack(msg Message) {
-	msgID := msg.ID()
-	mid, ok := toTrackingMessageID(msgID)
-	if !ok {
-		c.log.Warnf("invalid message id type %T", msgID)
+	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
+		msgID := msg.ID()
+		mid, ok := toTrackingMessageID(msgID)
+		if !ok {
+			c.log.Warnf("invalid message id type %T", msgID)
+			return
+		}
+
+		if mid.consumer == nil {
+			c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
+			return
+		}
+		mid.NackByMsg(msg)
 		return
 	}
 
-	if mid.consumer == nil {
-		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
-		return
-	}
-	mid.NackByMsg(msg)
+	c.NackID(msg.ID())
 }
 
 func (c *regexConsumer) NackID(msgID MessageID) {

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -79,6 +79,13 @@ func (id trackingMessageID) Nack() {
 	id.consumer.NackID(id)
 }
 
+func (id trackingMessageID) NackByMsg(msg Message) {
+	if id.consumer == nil {
+		return
+	}
+	id.consumer.NackMsg(msg)
+}
+
 func (id trackingMessageID) ack() bool {
 	if id.tracker != nil && id.batchIdx > -1 {
 		return id.tracker.ack(int(id.batchIdx))

--- a/pulsar/negative_acks_tracker.go
+++ b/pulsar/negative_acks_tracker.go
@@ -66,7 +66,6 @@ func newNegativeAcksTracker(rc redeliveryConsumer, delay time.Duration,
 			negativeAcks:       make(map[messageID]time.Time),
 			rc:                 rc,
 			tick:               time.NewTicker(delay / 3),
-			tickForNackBackoff: nil,
 			nackBackoff:        nil,
 			delay:              delay,
 			log:                logger,
@@ -102,7 +101,6 @@ func (t *negativeAcksTracker) Add(msgID messageID) {
 func (t *negativeAcksTracker) AddMessage(msg Message) {
 	nackBackoffDelay := t.nackBackoff.Next(msg.RedeliveryCount())
 	t.delay = time.Duration(nackBackoffDelay)
-	t.tick = nil
 	t.tickForNackBackoff = time.NewTicker(t.delay / 3)
 
 	// Use trackFlag to avoid opening a new gorutine to execute `t.track()` every AddMessage.

--- a/pulsar/negative_acks_tracker.go
+++ b/pulsar/negative_acks_tracker.go
@@ -62,13 +62,13 @@ func newNegativeAcksTracker(rc redeliveryConsumer, delay time.Duration,
 		}
 	} else {
 		t = &negativeAcksTracker{
-			doneCh:             make(chan interface{}),
-			negativeAcks:       make(map[messageID]time.Time),
-			rc:                 rc,
-			tick:               time.NewTicker(delay / 3),
-			nackBackoff:        nil,
-			delay:              delay,
-			log:                logger,
+			doneCh:       make(chan interface{}),
+			negativeAcks: make(map[messageID]time.Time),
+			rc:           rc,
+			tick:         time.NewTicker(delay / 3),
+			nackBackoff:  nil,
+			delay:        delay,
+			log:          logger,
 		}
 
 		go t.track()

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -148,3 +148,155 @@ func TestNacksWithBatchesTracker(t *testing.T) {
 
 	nacks.Close()
 }
+
+func TestNackBackoffTracker(t *testing.T) {
+	nmc := newNackMockedConsumer()
+	nacks := newNegativeAcksTracker(nmc, testNackDelay, new(defaultNackBackoffPolicy), log.DefaultNopLogger())
+
+	nacks.AddMessage(new(mockMessage1))
+	nacks.AddMessage(new(mockMessage2))
+
+	msgIds := make([]messageID, 0)
+	for id := range nmc.Wait() {
+		msgIds = append(msgIds, id)
+	}
+	msgIds = sortMessageIds(msgIds)
+
+	assert.Equal(t, 2, len(msgIds))
+	assert.Equal(t, int64(1), msgIds[0].ledgerID)
+	assert.Equal(t, int64(1), msgIds[0].entryID)
+	assert.Equal(t, int64(2), msgIds[1].ledgerID)
+	assert.Equal(t, int64(2), msgIds[1].entryID)
+
+	nacks.Close()
+	// allow multiple Close without panicing
+	nacks.Close()
+}
+
+type mockMessage1 struct {
+	properties map[string]string
+}
+
+func (msg *mockMessage1) Topic() string {
+	return ""
+}
+
+func (msg *mockMessage1) Properties() map[string]string {
+	return msg.properties
+}
+
+func (msg *mockMessage1) Payload() []byte {
+	return nil
+}
+
+func (msg *mockMessage1) ID() MessageID {
+	return messageID{
+		ledgerID: 1,
+		entryID:  1,
+		batchIdx: 1,
+	}
+}
+
+func (msg *mockMessage1) PublishTime() time.Time {
+	return time.Time{}
+}
+
+func (msg *mockMessage1) EventTime() time.Time {
+	return time.Time{}
+}
+
+func (msg *mockMessage1) Key() string {
+	return ""
+}
+
+func (msg *mockMessage1) OrderingKey() string {
+	return ""
+}
+
+func (msg *mockMessage1) RedeliveryCount() uint32 {
+	return 0
+}
+
+func (msg *mockMessage1) IsReplicated() bool {
+	return false
+}
+
+func (msg *mockMessage1) GetReplicatedFrom() string {
+	return ""
+}
+
+func (msg *mockMessage1) GetSchemaValue(v interface{}) error {
+	return nil
+}
+
+func (msg *mockMessage1) ProducerName() string {
+	return ""
+}
+
+func (msg *mockMessage1) GetEncryptionContext() *EncryptionContext {
+	return &EncryptionContext{}
+}
+
+type mockMessage2 struct {
+	properties map[string]string
+}
+
+func (msg *mockMessage2) Topic() string {
+	return ""
+}
+
+func (msg *mockMessage2) Properties() map[string]string {
+	return msg.properties
+}
+
+func (msg *mockMessage2) Payload() []byte {
+	return nil
+}
+
+func (msg *mockMessage2) ID() MessageID {
+	return messageID{
+		ledgerID: 2,
+		entryID:  2,
+		batchIdx: 1,
+	}
+}
+
+func (msg *mockMessage2) PublishTime() time.Time {
+	return time.Time{}
+}
+
+func (msg *mockMessage2) EventTime() time.Time {
+	return time.Time{}
+}
+
+func (msg *mockMessage2) Key() string {
+	return ""
+}
+
+func (msg *mockMessage2) OrderingKey() string {
+	return ""
+}
+
+func (msg *mockMessage2) RedeliveryCount() uint32 {
+	return 0
+}
+
+func (msg *mockMessage2) IsReplicated() bool {
+	return false
+}
+
+func (msg *mockMessage2) GetReplicatedFrom() string {
+	return ""
+}
+
+func (msg *mockMessage2) GetSchemaValue(v interface{}) error {
+	return nil
+}
+
+func (msg *mockMessage2) ProducerName() string {
+	return ""
+}
+
+func (msg *mockMessage2) GetEncryptionContext() *EncryptionContext {
+	return &EncryptionContext{}
+}

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -75,7 +75,7 @@ func (nmc *nackMockedConsumer) Wait() <-chan messageID {
 
 func TestNacksTracker(t *testing.T) {
 	nmc := newNackMockedConsumer()
-	nacks := newNegativeAcksTracker(nmc, testNackDelay, log.DefaultNopLogger())
+	nacks := newNegativeAcksTracker(nmc, testNackDelay, nil, log.DefaultNopLogger())
 
 	nacks.Add(messageID{
 		ledgerID: 1,
@@ -108,7 +108,7 @@ func TestNacksTracker(t *testing.T) {
 
 func TestNacksWithBatchesTracker(t *testing.T) {
 	nmc := newNackMockedConsumer()
-	nacks := newNegativeAcksTracker(nmc, testNackDelay, log.DefaultNopLogger())
+	nacks := newNegativeAcksTracker(nmc, testNackDelay, nil, log.DefaultNopLogger())
 
 	nacks.Add(messageID{
 		ledgerID: 1,

--- a/pulsar/negative_backoff_policy.go
+++ b/pulsar/negative_backoff_policy.go
@@ -32,7 +32,7 @@ type NackBackoffPolicy interface {
 }
 
 // defaultNackBackoffPolicy is default impl for NackBackoffPolicy.
-type defaultNackBackoffPolicy struct {}
+type defaultNackBackoffPolicy struct{}
 
 func (nbp *defaultNackBackoffPolicy) Next(redeliveryCount uint32) int64 {
 	minNackTimeMs := int64(1000 * 10) // 10sec

--- a/pulsar/negative_backoff_policy.go
+++ b/pulsar/negative_backoff_policy.go
@@ -35,7 +35,7 @@ type NackBackoffPolicy interface {
 type defaultNackBackoffPolicy struct{}
 
 func (nbp *defaultNackBackoffPolicy) Next(redeliveryCount uint32) int64 {
-	minNackTimeMs := int64(1000 * 10) // 10sec
+	minNackTimeMs := int64(1000 * 30) // 30sec
 	maxNackTimeMs := 1000 * 60 * 10   // 10min
 
 	if redeliveryCount < 0 {

--- a/pulsar/negative_backoff_policy.go
+++ b/pulsar/negative_backoff_policy.go
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import "math"
+
+// NackBackoffPolicy is a interface for custom message negativeAcked policy, users can specify a NackBackoffPolicy
+// for a consumer.
+//
+// > Notice: the consumer crashes will trigger the redelivery of the unacked message, this case will not respect the
+// > NackBackoffPolicy, which means the message might get redelivered earlier than the delay time
+// > from the backoff.
+type NackBackoffPolicy interface {
+	// The redeliveryCount indicates the number of times the message was redelivered.
+	// We can get the redeliveryCount from the CommandMessage.
+	Next(redeliveryCount uint32) int64
+}
+
+type defaultNackBackoffPolicy struct {}
+
+func (nbp *defaultNackBackoffPolicy) Next(redeliveryCount uint32) int64 {
+	minNackTimeMs := int64(1000 * 10) // 10sec
+	maxNackTimeMs := 1000 * 60 * 10   // 10min
+
+	if redeliveryCount < 0 {
+		return minNackTimeMs
+	}
+
+	return int64(math.Min(math.Abs(float64(minNackTimeMs<<redeliveryCount)), float64(maxNackTimeMs)))
+}

--- a/pulsar/negative_backoff_policy.go
+++ b/pulsar/negative_backoff_policy.go
@@ -31,6 +31,7 @@ type NackBackoffPolicy interface {
 	Next(redeliveryCount uint32) int64
 }
 
+// defaultNackBackoffPolicy is default impl for NackBackoffPolicy.
 type defaultNackBackoffPolicy struct {}
 
 func (nbp *defaultNackBackoffPolicy) Next(redeliveryCount uint32) int64 {

--- a/pulsar/negative_backoff_policy_test.go
+++ b/pulsar/negative_backoff_policy_test.go
@@ -27,8 +27,8 @@ func TestDefaultNackBackoffPolicy_Next(t *testing.T) {
 	defaultNackBackoff := new(defaultNackBackoffPolicy)
 
 	res0 := defaultNackBackoff.Next(0)
-	assert.Equal(t, int64(1000*10), res0)
+	assert.Equal(t, int64(1000*30), res0)
 
 	res5 := defaultNackBackoff.Next(5)
-	assert.Equal(t, int64(320000), res5)
+	assert.Equal(t, int64(600000), res5)
 }

--- a/pulsar/negative_backoff_policy_test.go
+++ b/pulsar/negative_backoff_policy_test.go
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultNackBackoffPolicy_Next(t *testing.T) {
+	defaultNackBackoff := new(defaultNackBackoffPolicy)
+
+	res0 := defaultNackBackoff.Next(0)
+	assert.Equal(t, int64(1000*10), res0)
+
+	res5 := defaultNackBackoff.Next(5)
+	assert.Equal(t, int64(320000), res5)
+}


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


Master Issue: #658

### Motivation

Support nack backoff policy

### Modifications

- Add `EnableDefaultNackBackoffPolicy` and `NackBackoffPolicy` options in ConsumerOptions.
- Modify the original implementation of the `Nack(Message)` interface
- Add test case
- Add defaultNackBackoffPolicy 

