### PR TITLE
[Issue 662] Fix race in connection.go waitUntilReady()

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -327,8 +327,8 @@ func (c *connection) doHandshake() bool {
 }
 
 func (c *connection) waitUntilReady() error {
-	c.Lock()
-	defer c.Unlock()
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
 
 	for c.getState() != connectionReady {
 		c.log.Debugf("Wait until connection is ready state=%s", c.getState().String())
@@ -894,6 +894,9 @@ func (c *connection) Close() {
 }
 
 func (c *connection) changeState(state connectionState) {
+	c.cond.L.Lock()
+	defer c.cond.L.Unlock()
+
 	c.setState(state)
 	c.cond.Broadcast()
 }

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -327,8 +327,9 @@ func (c *connection) doHandshake() bool {
 }
 
 func (c *connection) waitUntilReady() error {
-	// The lock is held here to prevent changeState() from modifying state and broadcasting
-	// in the time between we check the state and the time that we call cond.Wait().
+	// If we are going to call cond.Wait() at all, then we must call it _before_ we call cond.Broadcast().
+	// The lock is held here to prevent changeState() from calling cond.Broadcast() in the time between
+	// the state check and call to cond.Wait().
 	c.Lock()
 	defer c.Unlock()
 


### PR DESCRIPTION
Fixes #662

### Motivation

As described in #662, there appears to be a potential race condition in connection.go function _waitUntilReady()_: the `cond.Broadcast()` can occur before the `cond.Wait()`.

[EDIT:] To be explicit, this is the issue:

[goroutine A] calls c.getState() and sees that it is not set to connectionReady
[goroutine B] changes the state to connectionReady
[goroutine B] sends a cond.Broadcast(), which goes nowhere because no goroutine is waiting.
[goroutine A] calls cond.Wait(), which never completes

### Modifications

Function _waitUntilReady()_ was previously holding the global `c.Lock()` on the connection. From my reading of the code, this mutex is intended to protect the `cnx` variable. I think that the use of `c.Lock()` in _waitUntilReady()_ was probably just a typo.

Instead, I think the author probably intended to grab the lock associated with the `sync.Cond`, i.e. `c.cond.L.Lock()`. This looks like the correct thing to do when using a `sync.Cond`. I think there should be a corresponding lock around the `cond.Broadcast()` also. See https://stackoverflow.com/questions/36857167/how-to-correctly-use-sync-cond/42772799#42772799 for more details.

### Verifying this change

I am unsure if this change is covered by existing tests. It fixes a rare race condition, so I think it would be quite difficult to test for.

I have deployed this change on my own production system, and it doesn't obviously break anything. I will report back if I see any issues that might be related to it.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
