### PR TITLE
[ClientOptions] Allow callers to specify custom metric name qualifiers

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -123,6 +123,10 @@ type ClientOptions struct {
 
 	// Add custom labels to all the metrics reported by this client instance
 	CustomMetricsLabels map[string]string
+
+	// These qualifiers are components of the fully-qualified name of each
+	// metric (created by joining these components with "_" and the metric name)
+	CustomMetricsQualifiers CustomMetricsQualifiers
 }
 
 // Client represents a pulsar client
@@ -165,3 +169,13 @@ const (
 	MetricsCardinalityNamespace                    // Label metrics by tenant and namespace
 	MetricsCardinalityTopic                        // Label metrics by topic
 )
+
+// CustomMetricsQualifiers represent name components that are added to each metric name on
+// registration.  The resulting fully-qualified metric names will be of the form:
+// "Namespace_Subsystem_Name"
+// Note that the fully-qualified name of the metric must be a
+// valid Prometheus metric name.
+type CustomMetricsQualifiers struct {
+	Namespace string
+	Subsystem string
+}

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -113,9 +113,17 @@ func newClient(options ClientOptions) (Client, error) {
 
 	var metrics *internal.Metrics
 	if options.CustomMetricsLabels != nil {
-		metrics = internal.NewMetricsProvider(int(options.MetricsCardinality), options.CustomMetricsLabels)
+		metrics = internal.NewMetricsProvider(
+			int(options.MetricsCardinality),
+			options.CustomMetricsQualifiers.Namespace,
+			options.CustomMetricsQualifiers.Subsystem,
+			options.CustomMetricsLabels)
 	} else {
-		metrics = internal.NewMetricsProvider(int(options.MetricsCardinality), map[string]string{})
+		metrics = internal.NewMetricsProvider(
+			int(options.MetricsCardinality),
+			options.CustomMetricsQualifiers.Namespace,
+			options.CustomMetricsQualifiers.Subsystem,
+			map[string]string{})
 	}
 
 	c := &client{

--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -36,7 +36,7 @@ func TestSingleMessageIDNoAckTracker(t *testing.T) {
 		eventsCh:             eventsCh,
 		compressionProviders: make(map[pb.CompressionType]compression.Provider),
 		options:              &partitionConsumerOpts{},
-		metrics:              internal.NewMetricsProvider(4, map[string]string{}).GetLeveledMetrics("topic"),
+		metrics:              internal.NewMetricsProvider(4, "", "", map[string]string{}).GetLeveledMetrics("topic"),
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
 
@@ -68,7 +68,7 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 		eventsCh:             eventsCh,
 		compressionProviders: make(map[pb.CompressionType]compression.Provider),
 		options:              &partitionConsumerOpts{},
-		metrics:              internal.NewMetricsProvider(4, map[string]string{}).GetLeveledMetrics("topic"),
+		metrics:              internal.NewMetricsProvider(4, "", "", map[string]string{}).GetLeveledMetrics("topic"),
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
 
@@ -100,7 +100,7 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 		eventsCh:             eventsCh,
 		compressionProviders: make(map[pb.CompressionType]compression.Provider),
 		options:              &partitionConsumerOpts{},
-		metrics:              internal.NewMetricsProvider(4, map[string]string{}).GetLeveledMetrics("topic"),
+		metrics:              internal.NewMetricsProvider(4, "", "", map[string]string{}).GetLeveledMetrics("topic"),
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
 

--- a/pulsar/internal/lookup_service_test.go
+++ b/pulsar/internal/lookup_service_test.go
@@ -138,7 +138,7 @@ func TestLookupSuccess(t *testing.T) {
 				BrokerServiceUrl: proto.String("pulsar://broker-1:6650"),
 			},
 		},
-	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -172,7 +172,7 @@ func TestTlsLookupSuccess(t *testing.T) {
 				BrokerServiceUrlTls: proto.String("pulsar+ssl://broker-1:6651"),
 			},
 		},
-	}, url, serviceNameResolver, true, "", log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+	}, url, serviceNameResolver, true, "", log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -207,7 +207,7 @@ func TestLookupWithProxy(t *testing.T) {
 				ProxyThroughServiceUrl: proto.Bool(true),
 			},
 		},
-	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -242,7 +242,7 @@ func TestTlsLookupWithProxy(t *testing.T) {
 			},
 		},
 	}, url, NewPulsarServiceNameResolver(url), true, "", log.DefaultNopLogger(),
-		NewMetricsProvider(4, map[string]string{}))
+		NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -289,7 +289,7 @@ func TestLookupWithRedirect(t *testing.T) {
 			},
 		},
 	}, url, NewPulsarServiceNameResolver(url), false, "", log.DefaultNopLogger(),
-		NewMetricsProvider(4, map[string]string{}))
+		NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -336,7 +336,7 @@ func TestTlsLookupWithRedirect(t *testing.T) {
 			},
 		},
 	}, url, NewPulsarServiceNameResolver(url), true, "", log.DefaultNopLogger(),
-		NewMetricsProvider(4, map[string]string{}))
+		NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -371,7 +371,7 @@ func TestLookupWithInvalidUrlResponse(t *testing.T) {
 			},
 		},
 	}, url, NewPulsarServiceNameResolver(url), false, "", log.DefaultNopLogger(),
-		NewMetricsProvider(4, map[string]string{}))
+		NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.Error(t, err)
@@ -401,7 +401,7 @@ func TestLookupWithLookupFailure(t *testing.T) {
 			},
 		},
 	}, url, NewPulsarServiceNameResolver(url), false, "", log.DefaultNopLogger(),
-		NewMetricsProvider(4, map[string]string{}))
+		NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.Error(t, err)
@@ -488,7 +488,7 @@ func TestGetPartitionedTopicMetadataSuccess(t *testing.T) {
 				Response:   pb.CommandPartitionedTopicMetadataResponse_Success.Enum(),
 			},
 		},
-	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	metadata, err := ls.GetPartitionedTopicMetadata("my-topic")
 	assert.NoError(t, err)
@@ -520,7 +520,7 @@ func TestLookupSuccessWithMultipleHosts(t *testing.T) {
 				BrokerServiceUrl: proto.String("pulsar://broker-1:6650"),
 			},
 		},
-	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+	}, url, serviceNameResolver, false, "", log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -581,7 +581,7 @@ func TestHttpLookupSuccess(t *testing.T) {
 	serviceNameResolver := NewPulsarServiceNameResolver(url)
 	httpClient := NewMockHTTPClient(serviceNameResolver)
 	ls := NewHTTPLookupService(httpClient, url, serviceNameResolver, false,
-		log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+		log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	lr, err := ls.Lookup("my-topic")
 	assert.NoError(t, err)
@@ -597,7 +597,7 @@ func TestHttpGetPartitionedTopicMetadataSuccess(t *testing.T) {
 	serviceNameResolver := NewPulsarServiceNameResolver(url)
 	httpClient := NewMockHTTPClient(serviceNameResolver)
 	ls := NewHTTPLookupService(httpClient, url, serviceNameResolver, false,
-		log.DefaultNopLogger(), NewMetricsProvider(4, map[string]string{}))
+		log.DefaultNopLogger(), NewMetricsProvider(4, "", "", map[string]string{}))
 
 	tMetadata, err := ls.GetPartitionedTopicMetadata("my-topic")
 	assert.NoError(t, err)

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -88,7 +88,8 @@ type LeveledMetrics struct {
 	ReadersClosed       prometheus.Counter
 }
 
-func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]string) *Metrics {
+func NewMetricsProvider(metricsCardinality int, userDefinedMetricsNamespace, userDefinedMetricsSubsystem string,
+	userDefinedLabels map[string]string) *Metrics {
 	constLabels := map[string]string{
 		"client": "go",
 	}
@@ -114,36 +115,48 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 	metrics := &Metrics{
 		metricsLevel: metricsCardinality,
 		messagesPublished: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_messages_published",
 			Help:        "Counter of messages published by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		bytesPublished: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_bytes_published",
 			Help:        "Counter of messages published by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		messagesPending: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producer_pending_messages",
 			Help:        "Counter of messages pending to be published by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		bytesPending: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producer_pending_bytes",
 			Help:        "Counter of bytes pending to be published by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		publishErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producer_errors",
 			Help:        "Counter of publish errors",
 			ConstLabels: constLabels,
 		}, append(metricsLevelLabels, "error")),
 
 		publishLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producer_latency_seconds",
 			Help:        "Publish latency experienced by the client",
 			ConstLabels: constLabels,
@@ -151,6 +164,8 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 		}, metricsLevelLabels),
 
 		publishRPCLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producer_rpc_latency_seconds",
 			Help:        "Publish RPC latency experienced internally by the client when sending data to receiving an ack",
 			ConstLabels: constLabels,
@@ -158,84 +173,112 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 		}, metricsLevelLabels),
 
 		producersOpened: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producers_opened",
 			Help:        "Counter of producers created by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		producersClosed: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producers_closed",
 			Help:        "Counter of producers closed by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		producersPartitions: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_producers_partitions_active",
 			Help:        "Counter of individual partitions the producers are currently active",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		consumersOpened: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumers_opened",
 			Help:        "Counter of consumers created by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		consumersClosed: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumers_closed",
 			Help:        "Counter of consumers closed by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		consumersPartitions: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumers_partitions_active",
 			Help:        "Counter of individual partitions the consumers are currently active",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		messagesReceived: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_messages_received",
 			Help:        "Counter of messages received by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		bytesReceived: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_bytes_received",
 			Help:        "Counter of bytes received by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		prefetchedMessages: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumer_prefetched_messages",
 			Help:        "Number of messages currently sitting in the consumer pre-fetch queue",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		prefetchedBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumer_prefetched_bytes",
 			Help:        "Total number of bytes currently sitting in the consumer pre-fetch queue",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		acksCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumer_acks",
 			Help:        "Counter of messages acked by client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		nacksCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumer_nacks",
 			Help:        "Counter of messages nacked by client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		dlqCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumer_dlq_messages",
 			Help:        "Counter of messages sent to Dead letter queue",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		processingTime: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_consumer_processing_time_seconds",
 			Help:        "Time it takes for application to process messages",
 			Buckets:     []float64{.0005, .001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
@@ -243,54 +286,72 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 		}, metricsLevelLabels),
 
 		readersOpened: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_readers_opened",
 			Help:        "Counter of readers created by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		readersClosed: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_readers_closed",
 			Help:        "Counter of readers closed by the client",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
 		ConnectionsOpened: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_connections_opened",
 			Help:        "Counter of connections created by the client",
 			ConstLabels: constLabels,
 		}),
 
 		ConnectionsClosed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_connections_closed",
 			Help:        "Counter of connections closed by the client",
 			ConstLabels: constLabels,
 		}),
 
 		ConnectionsEstablishmentErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_connections_establishment_errors",
 			Help:        "Counter of errors in connections establishment",
 			ConstLabels: constLabels,
 		}),
 
 		ConnectionsHandshakeErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_connections_handshake_errors",
 			Help:        "Counter of errors in connections handshake (eg: authz)",
 			ConstLabels: constLabels,
 		}),
 
 		LookupRequestsCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_lookup_count",
 			Help:        "Counter of lookup requests made by the client",
 			ConstLabels: constLabels,
 		}),
 
 		PartitionedTopicMetadataRequestsCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_partitioned_topic_metadata_count",
 			Help:        "Counter of partitioned_topic_metadata requests made by the client",
 			ConstLabels: constLabels,
 		}),
 
 		RPCRequestCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   userDefinedMetricsNamespace,
+			Subsystem:   userDefinedMetricsSubsystem,
 			Name:        "pulsar_client_rpc_count",
 			Help:        "Counter of RPC requests made by the client",
 			ConstLabels: constLabels,


### PR DESCRIPTION
### Motivation

This change exposes the full metric name qualification supported in the
underlying prometheus client library by allowing metric names to be
qualified by both a "namespace" and "subsystem".  See the documentation for
the prometheus metric options structure:
https://pkg.go.dev/github.com/prometheus/client_golang@v1.11.0/prometheus#Opts

This is helpful to disambiguate metrics when there is more than one
component in a distributed system that makes use of pulsar-client-go.

### Modifications

A new, optional field has been added to the `ClientOptions` struct to allow for metrics namespaces

### Verifying this change

This change is trivial plumbing without any test coverage.

### Does this pull request potentially affect one of the following parts:

The public API: Yes, a new, optional field has been added to the `ClientOptions` struct

### Documentation

Does this pull request introduce a new feature? Yes

If yes, how is the feature documented? GoDocs
