### PR TITLE
Add new bug-resistant build constraints

### DIFF
--- a/pulsar/internal/compression/zstd.go
+++ b/pulsar/internal/compression/zstd.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !cgo
 // +build !cgo
 
 package compression

--- a/pulsar/internal/compression/zstd_cgo.go
+++ b/pulsar/internal/compression/zstd_cgo.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build cgo
 // +build cgo
 
 // If CGO is enabled, use ZSTD library that links with official

--- a/pulsar/internal/http_client_go_1.11.go
+++ b/pulsar/internal/http_client_go_1.11.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build !go1.12
 // +build !go1.12
 
 package internal

--- a/pulsar/internal/http_client_go_1.12.go
+++ b/pulsar/internal/http_client_go_1.12.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build go1.12
 // +build go1.12
 
 package internal


### PR DESCRIPTION
### Motivation
According to the [Bug-resistant build constraints proposal](https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md), //+build will be replaced by //go:build. A transition period from //+build to //go:build syntax will last from Go version 1.16 through version 1.18.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
