### PR TITLE
Update email template of release docs

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -114,7 +114,7 @@ It fixes the following issues:
 https://github.com/apache/pulsar-client-go/milestone/1?closed=1
 
 Pulsar Client Go's KEYS file contains PGP keys we used to sign this release:
-https://dist.apache.org/repos/dist/release/pulsar/KEYS
+https://dist.apache.org/repos/dist/dev/pulsar/KEYS
 
 Please download these packages and review this release candidate:
 - Review release notes
@@ -124,7 +124,7 @@ README.md to build and run the pulsar-client-go.
 The vote will be open for at least 72 hours. It is adopted by majority approval, with at least 3 PMC affirmative votes.
 
 Source file:
-https://dist.apache.org/repos/dist/dev/pulsar/pulsar-client-go-0.X.0-candidate-1/apache-pulsar-client-go-0.X.0-src.tar.gz
+https://dist.apache.org/repos/dist/dev/pulsar/pulsar-client-go-0.X.0-candidate-1/
 
 The tag to be voted upon:
 v0.X.0


### PR DESCRIPTION
### Motivation

As I mentioned in [this email](http://mail-archives.apache.org/mod_mbox/pulsar-dev/202111.mbox/%3C4416E302-58BF-4ED4-98B4-8FC91B89B9BC%40yahoo-corp.jp%3E), it is better to use dev KEYS instead of release KEYS in a vote email because release KEYS only include keys of PMC.
Ref. https://github.com/apache/pulsar/wiki/Create-GPG-keys-to-sign-release-artifacts

I also modify URL of source file so that we can easily find asc and shasum.