### PR TITLE
Close the old connection to make sure the broker drops the producer on its side

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -858,13 +858,14 @@ func (c *connection) Close() {
 		c.Lock()
 		cnx := c.cnx
 		c.Unlock()
-		c.changeState(connectionClosed)
+		c.changeState(connectionClosing)
 
 		if cnx != nil {
 			_ = cnx.Close()
 		}
 
 		close(c.closeCh)
+                c.changeState(connectionClosed)
 
 		listeners := make(map[uint64]ConnectionListener)
 		c.listenersLock.Lock()

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -865,7 +865,7 @@ func (c *connection) Close() {
 		}
 
 		close(c.closeCh)
-                c.changeState(connectionClosed)
+		c.changeState(connectionClosed)
 
 		listeners := make(map[uint64]ConnectionListener)
 		c.listenersLock.Lock()


### PR DESCRIPTION
Master Issue: #676 

### Motivation
When reconnecting to the server, the old connection should be closed.

### Modifications

Close the old connection to make sure the broker drops the producer on its side

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
