### PR TITLE
[Issue 513] Correct apparent logic error in batchContainer's hasSpace() method

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -155,7 +155,7 @@ func (bc *batchContainer) IsFull() bool {
 	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() > uint32(bc.maxBatchSize)
 }
 
-// hasSpace should return true if and only if the batch container can accommodate another message with the length of payload.
+// hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *batchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
 	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -150,15 +150,15 @@ func NewBatchBuilder(
 	return &bc, nil
 }
 
-// IsFull check if the size in the current batch exceeds the maximum size allowed by the batch
+// IsFull checks if the size in the current batch meets or exceeds the maximum size allowed by the batch
 func (bc *batchContainer) IsFull() bool {
-	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() > uint32(bc.maxBatchSize)
+	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() >= uint32(bc.maxBatchSize)
 }
 
 // hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *batchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) <= uint32(bc.maxBatchSize)
+	return bc.numMessages+1 <= bc.maxMessages && bc.buffer.ReadableBytes()+msgSize <= uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to batch.

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -155,9 +155,10 @@ func (bc *batchContainer) IsFull() bool {
 	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() > uint32(bc.maxBatchSize)
 }
 
+// hasSpace should return true if and only if the batch container can accommodate another message with the length of payload.
 func (bc *batchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 < bc.maxMessages || (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
+	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to batch.

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -158,7 +158,7 @@ func (bc *batchContainer) IsFull() bool {
 // hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *batchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
+	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) <= uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to batch.

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -115,7 +115,7 @@ func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
 	return true
 }
 
-// hasSpace should return true if and only if the batch container can accommodate another message with the length of payload.
+// hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
 	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -106,9 +106,9 @@ func NewKeyBasedBatchBuilder(
 	return bb, nil
 }
 
-// IsFull check if the size in the current batch exceeds the maximum size allowed by the batch
+// IsFull checks if the size in the current batch meets or exceeds the maximum size allowed by the batch
 func (bc *keyBasedBatchContainer) IsFull() bool {
-	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() > uint32(bc.maxBatchSize)
+	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() >= uint32(bc.maxBatchSize)
 }
 
 func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
@@ -118,7 +118,7 @@ func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
 // hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) <= uint32(bc.maxBatchSize)
+	return bc.numMessages+1 <= bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) <= uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to key-based batch with message key.

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -118,7 +118,7 @@ func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
 // hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
+	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) <= uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to key-based batch with message key.

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -115,9 +115,10 @@ func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
 	return true
 }
 
+// hasSpace should return true if and only if the batch container can accommodate another message with the length of payload.
 func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 < bc.maxMessages || (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
+	return bc.numMessages+1 < bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to key-based batch with message key.

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -118,7 +118,7 @@ func (bc *keyBasedBatchContainer) IsMultiBatches() bool {
 // hasSpace should return true if and only if the batch container can accommodate another message of length payload.
 func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
 	msgSize := uint32(len(payload))
-	return bc.numMessages+1 <= bc.maxMessages && (bc.buffer.ReadableBytes()+msgSize) <= uint32(bc.maxBatchSize)
+	return bc.numMessages+1 <= bc.maxMessages && bc.buffer.ReadableBytes()+msgSize <= uint32(bc.maxBatchSize)
 }
 
 // Add will add single message to key-based batch with message key.

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -857,6 +857,38 @@ func TestDelayAbsolute(t *testing.T) {
 	canc()
 }
 
+func TestMaxBatchSize(t *testing.T) {
+	// Set to be < serverMaxMessageSize
+	batchMaxMessageSize := 512 * 1024
+
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           newTopicName(),
+		BatchingMaxSize: uint(batchMaxMessageSize),
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, producer)
+	defer producer.Close()
+
+	for bias := -1; bias <= 1; bias++ {
+		payload := make([]byte, batchMaxMessageSize+bias)
+		ID, err := producer.Send(context.Background(), &ProducerMessage{
+			Payload: payload,
+		})
+		if bias <= 0 {
+			assert.NoError(t, err)
+			assert.NotNil(t, ID)
+		} else {
+			assert.Equal(t, errFailAddToBatch, err)
+		}
+	}
+}
+
 func TestMaxMessageSize(t *testing.T) {
 	serverMaxMessageSize := 1024 * 1024
 


### PR DESCRIPTION
Fixes issue https://github.com/apache/pulsar-client-go/issues/513.

This issue was previously partially addressed by @zzzming in PR https://github.com/apache/pulsar-client-go/pull/528.

### Motivation

Following PR https://github.com/apache/pulsar-client-go/pull/528, the logic for the `hasSpace()` function, which is used to determine whether a batch container has enough space for a new message, reads:

```
func (bc *keyBasedBatchContainer) hasSpace(payload []byte) bool {
	msgSize := uint32(len(payload))
	return bc.numMessages+1 < bc.maxMessages || (bc.buffer.ReadableBytes()+msgSize) < uint32(bc.maxBatchSize)
}
```

Currently, then, the batch container will be considered to have space (be non-full) until **both** the max-messages and the max-size limits are hit.

I think that is incorrect. Nearby in the code, the batch container is considered to be full if **either** of the conditions are hit:

```
// IsFull check if the size in the current batch exceeds the maximum size allowed by the batch
func (bc *batchContainer) IsFull() bool {
	return bc.numMessages >= bc.maxMessages || bc.buffer.ReadableBytes() > uint32(bc.maxBatchSize)
}
```

Because the logical rule is `!(A || B) = (!A) && (!B)`, the `||` in `hasSpace()` should be an `&&`.

### Modifications

Change the `||` in `hasSpace()` to an `&&`, so that the container will be considered full if either limit is hit.

### Verifying this change

~This change is a trivial rework / code cleanup without any test coverage.~

Added `TestMaxBatchSize()`.

### Documentation

  - Does this pull request introduce a new feature? no
