### PR TITLE
Add properties filed for batch container

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -191,6 +191,7 @@ func (bc *batchContainer) Add(
 		bc.msgMetadata.ProducerName = &bc.producerName
 		bc.msgMetadata.ReplicateTo = replicateTo
 		bc.msgMetadata.PartitionKey = metadata.PartitionKey
+		bc.msgMetadata.Properties = metadata.Properties
 
 		if deliverAt.UnixNano() > 0 {
 			bc.msgMetadata.DeliverAtTime = proto.Int64(int64(TimestampMillis(deliverAt)))
@@ -211,6 +212,7 @@ func (bc *batchContainer) reset() {
 	bc.callbacks = []interface{}{}
 	bc.msgMetadata.ReplicateTo = nil
 	bc.msgMetadata.DeliverAtTime = nil
+	bc.msgMetadata.Properties = nil
 }
 
 // Flush all the messages buffered in the client and wait until all messages have been successfully persisted.


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

### Motivation

Currently, when we disable batch in Producer, in `handleSend()` of `serverCnx.java`, the `msgMetadata.hasNumMessagesInBatch()` is **true** and `msgMetadata.getNumMessagesInBatch()` is **1**.

At this point, if we get the Properties object we set on the producer side on the broker side, the display is empty.

Go SDK set Properties:

```

// disable batch
producer, err := client.CreateProducer(pulsar.ProducerOptions{
	Topic: "topic-1",
	DisableBatching: true,
})

// set properties for every message
producer.Send(ctx, &pulsar.ProducerMessage{
	Payload: []byte(fmt.Sprintf("hello-%d", i)),
	Properties: map[string]string{
		"key-1": "value-1",
	},
});
```

Broker get message properties from entry metadata is null:

```
ByteBuf metadataAndPayload = entry.getDataBuffer();

MessageMetadata msgMetadata = Commands.peekMessageMetadata(metadataAndPayload, subscription.toString(), -1);
```

And `msgMetadata.getPropertiesCount() <= 0`.


### Modifications

Add properties filed in Add single message to batchContainer

