### PR TITLE
Use a separate gorutine to handle the logic of reconnect

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -380,6 +380,9 @@ func (p *partitionProducer) runEventsLoop() {
 			case <-p.connectClosedCh:
 				p.log.Info("runEventsLoop will reconnect in producer")
 				p.reconnectToBroker()
+			case closeProducerReq := <-p.closeProducerCh:
+				p.internalClose(&closeProducerReq)
+				return
 			}
 		}
 	}()
@@ -396,9 +399,6 @@ func (p *partitionProducer) runEventsLoop() {
 			} else {
 				p.internalFlushCurrentBatch()
 			}
-		case closeProducerReq := <-p.closeProducerCh:
-			p.internalClose(&closeProducerReq)
-			return
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

Fixes #687

### Motivation

As #687 said, use a separate gorutine to handle the logic of reconnect. Avoid blocking the reconnection logic due to the gorutine block of runEventsLoop



