### PR TITLE
Set default go version to 1.13 in CI related files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG GO_VERSION=golang:1.12
+ARG GO_VERSION=golang:1.13
 FROM apachepulsar/pulsar:latest as pulsar
 FROM $GO_VERSION as go
 

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -25,7 +25,7 @@ cd ${SRC_DIR}
 
 IMAGE_NAME=pulsar-client-go-test:latest
 
-GO_VERSION=${1:-1.12}
+GO_VERSION=${1:-1.13}
 docker rmi --force ${IMAGE_NAME} || true
 docker rmi --force apachepulsar/pulsar:latest || true
 docker build -t ${IMAGE_NAME} --build-arg GO_VERSION="golang:${GO_VERSION}" .


### PR DESCRIPTION
### Motivation
Set the default go version to 1.13 in the CI related files as per the minimum version requirements.