### PR TITLE
Fix data race while accessing connection in partitionProducer

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -66,7 +66,6 @@ type partitionProducer struct {
 	client *client
 	topic  string
 	log    log.Logger
-	//cnx    internal.Connection
 
 	conn atomic.Value
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -963,4 +963,3 @@ func (p *partitionProducer) _getConn() internal.Connection {
 	//            invariant is broken
 	return p.conn.Load().(internal.Connection)
 }
-


### PR DESCRIPTION
Signed-off-by: xiaolongran <rxl@apache.org>

### Motivation

In https://github.com/apache/pulsar-client-go/pull/700, we use a separate go rutine to handle the logic of reconnect, so here you may encounter the same data race problem as https://github.com/apache/pulsar-client-go/pull/535

### Modifications

Now, the conn field is read and written atomically; avoiding race conditions.