### PR TITLE
Fix stuck when reconnect broker

### DIFF
--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -78,10 +78,8 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 		p.log.Infof("Found connection in pool key=%s logical_addr=%+v physical_addr=%+v",
 			key, conn.logicalAddr, conn.physicalAddr)
 
-		// When the current connection is in a closed state or the broker actively notifies that the
-		// current connection is closed, we need to remove the connection object from the current
-		// connection pool and create a new connection.
-		if conn.closed() || conn.reconnectFlag {
+		// remove stale/failed connection
+		if conn.closed() {
 			delete(p.connections, key)
 			p.log.Infof("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
 				key, conn.logicalAddr, conn.physicalAddr)


### PR DESCRIPTION
Signed-off-by: xiaolongran <rxl@apache.org>

Fixes #697

### Motivation

As #697 said, In Go SDK, when the reconnection logic is triggered under certain conditions, the reconnection will not succeed due to request timeout.

Comparing the implementation of the Java SDK, we can see that each time the reconnection logic is triggered, the original connection will be closed and a new connection will be created.

![image](https://user-images.githubusercontent.com/20965307/148906906-1cfc5c07-1836-4185-94ec-e43f5565a4a8.png)


So in this pr, we introduced a new `reconnectFlag` field in the `connection` struct to mark the reconnection state. When the broker actively informs the client to close the connection to trigger the reconnection logic, we will store it from the `connections` cache of the `connectionPool`. The old connection object is deleted, and a new connection is created to complete the reconnection

### Modifications

- Add `reconnectFlag` in `connection` struct

