### PR TITLE
fix batchIdx error for non-batch message

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -596,7 +596,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		msgID := newTrackingMessageID(
 			int64(pbMsgID.GetLedgerId()),
 			int64(pbMsgID.GetEntryId()),
-			int32(i),
+			pbMsgID.GetBatchIndex(),
 			pc.partitionIdx,
 			ackTracker)
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -813,7 +813,7 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 		pi.Lock()
 		defer pi.Unlock()
 		p.metrics.PublishRPCLatency.Observe(float64(now-pi.sentAt.UnixNano()) / 1.0e9)
-		for idx, i := range pi.sendRequests {
+		for _, i := range pi.sendRequests {
 			sr := i.(*sendRequest)
 			if sr.msg != nil {
 				atomic.StoreInt64(&p.lastSequenceID, int64(pi.sequenceID))
@@ -831,7 +831,7 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 				msgID := newMessageID(
 					int64(response.MessageId.GetLedgerId()),
 					int64(response.MessageId.GetEntryId()),
-					int32(idx),
+					response.MessageId.GetBatchIndex(),
 					p.partitionIdx,
 				)
 


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

### Motivation

When producer send message or consumer receive message in non-batch, return the batchIdx is `0`

```
msgId: pulsar.trackingMessageID{messageID:pulsar.messageID{ledgerID:11653378, entryID:3807, batchIdx:0, partitionIdx:2}
```

In fact, when we disable batch in ProducerOptions, the batchIdx is `-1`

```
msgId: pulsar.trackingMessageID{messageID:pulsar.messageID{ledgerID:11653378, entryID:3807, batchIdx:0, partitionIdx:2}
```

### Modifications

- Get batchIdx from broker

