### PR TITLE
Fix slice bounds out of range for readSingleMessage

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -585,7 +585,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 
 	for i := 0; i < numMsgs; i++ {
 		smm, payload, err := reader.ReadMessage()
-		if err != nil {
+		if err != nil || payload == nil {
 			pc.discardCorruptedMessage(pbMsgID, pb.CommandAck_BatchDeSerializeError)
 			return err
 		}

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -19,6 +19,7 @@ package internal
 
 import (
 	"encoding/binary"
+	log "github.com/sirupsen/logrus"
 )
 
 // Buffer is a variable-sized buffer of bytes with Read and Write methods.
@@ -110,6 +111,11 @@ func (b *buffer) IsWritable() bool {
 }
 
 func (b *buffer) Read(size uint32) []byte {
+	// Check []byte slice size, avoid slice bounds out of range
+	if b.readerIdx+size > uint32(len(b.data)) {
+		log.Errorf("The input size [%d] > byte slice of data size [%d]", b.readerIdx+size, len(b.data))
+		return nil
+	}
 	res := b.data[b.readerIdx : b.readerIdx+size]
 	b.readerIdx += size
 	return res

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -19,6 +19,7 @@ package internal
 
 import (
 	"encoding/binary"
+
 	log "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

Fixes #702

### Motivation


As #702 desc, In some scenarios, when the `Read(size uint32) []byte` interface in **Buffer** is called, the panic of a slice out of bounds may occur. So in this pr, the judgment of boundary conditions is added. When the slice is out of bounds, a `CommandAck_BatchDeSerializeError` error will be sent to the Broker to avoid the Go SDK process being down due to the panic.

![image](https://user-images.githubusercontent.com/20965307/149326745-f12559ea-4909-47a0-97c1-1cff52602709.png)

After adding the current logic, the effect of execution is as follows:



![image](https://user-images.githubusercontent.com/20965307/149327302-62c0a641-38fd-4f26-93d6-92dfc18e2724.png)



### Modifications

- Add logic to check slice boundaries for `Read()` of Buffer

