### PR TITLE
Fix negative WaitGroup counter issue

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -33,7 +33,7 @@ import (
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/apache/pulsar-client-go/pulsar/log"
 
-	"go.uber.org/atomic"
+	uAtomic "go.uber.org/atomic"
 )
 
 var (
@@ -110,10 +110,10 @@ type partitionConsumer struct {
 
 	// this is needed for sending ConsumerMessage on the messageCh
 	parentConsumer Consumer
-	state          atomic.Int32
+	state          uAtomic.Int32
 	options        *partitionConsumerOpts
 
-	conn atomic.Value
+	conn uAtomic.Value
 
 	topic        string
 	name         string

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -735,8 +735,7 @@ func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (Mes
 	p.internalSendAsync(ctx, msg, func(ID MessageID, message *ProducerMessage, e error) {
 		err = e
 		msgID = ID
-		if !isDone.Load() {
-			isDone.Store(true)
+		if isDone.CAS(false, true) {
 			close(doneCh)
 		}
 	}, true)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -733,9 +733,9 @@ func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (Mes
 	doneCh := make(chan struct{})
 
 	p.internalSendAsync(ctx, msg, func(ID MessageID, message *ProducerMessage, e error) {
-		err = e
-		msgID = ID
 		if isDone.CAS(false, true) {
+			err = e
+			msgID = ID
 			close(doneCh)
 		}
 	}, true)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -35,7 +35,7 @@ import (
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/apache/pulsar-client-go/pulsar/log"
 
-	ua "go.uber.org/atomic"
+	uAtomic "go.uber.org/atomic"
 )
 
 type producerState int32
@@ -62,12 +62,12 @@ var (
 var errTopicNotFount = "TopicNotFound"
 
 type partitionProducer struct {
-	state  ua.Int32
+	state  uAtomic.Int32
 	client *client
 	topic  string
 	log    log.Logger
 
-	conn atomic.Value
+	conn uAtomic.Value
 
 	options                  *ProducerOptions
 	producerName             string
@@ -696,7 +696,7 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 
 	pi, ok := p.pendingQueue.PeekLast().(*pendingItem)
 	if !ok {
-		fr.waitGroup.Done()
+		close(fr.doneCh)
 		return
 	}
 
@@ -709,7 +709,7 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		// The last item in the queue has been completed while we were
 		// looking at it. It's safe at this point to assume that every
 		// message enqueued before Flush() was called are now persisted
-		fr.waitGroup.Done()
+		close(fr.doneCh)
 		return
 	}
 
@@ -717,7 +717,7 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 		msg: nil,
 		callback: func(id MessageID, message *ProducerMessage, e error) {
 			fr.err = e
-			fr.waitGroup.Done()
+			close(fr.doneCh)
 		},
 	}
 
@@ -725,19 +725,24 @@ func (p *partitionProducer) internalFlush(fr *flushRequest) {
 }
 
 func (p *partitionProducer) Send(ctx context.Context, msg *ProducerMessage) (MessageID, error) {
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
 	var err error
 	var msgID MessageID
+
+	// use atomic bool to avoid race
+	isDone := uAtomic.NewBool(false)
+	doneCh := make(chan struct{})
 
 	p.internalSendAsync(ctx, msg, func(ID MessageID, message *ProducerMessage, e error) {
 		err = e
 		msgID = ID
-		wg.Done()
+		if !isDone.Load() {
+			isDone.Store(true)
+			close(doneCh)
+		}
 	}, true)
 
-	wg.Wait()
+	// wait for send request to finish
+	<-doneCh
 	return msgID, err
 }
 
@@ -849,7 +854,7 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 }
 
 func (p *partitionProducer) internalClose(req *closeProducer) {
-	defer req.waitGroup.Done()
+	defer close(req.doneCh)
 	if !p.casProducerState(producerReady, producerClosing) {
 		return
 	}
@@ -884,14 +889,15 @@ func (p *partitionProducer) LastSequenceID() int64 {
 }
 
 func (p *partitionProducer) Flush() error {
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	flushReq := &flushRequest{
+		doneCh: make(chan struct{}),
+		err:    nil,
+	}
+	p.eventsChan <- flushReq
 
-	cp := &flushRequest{&wg, nil}
-	p.eventsChan <- cp
-
-	wg.Wait()
-	return cp.err
+	// wait for the flush request to complete
+	<-flushReq.doneCh
+	return flushReq.err
 }
 
 func (p *partitionProducer) getProducerState() producerState {
@@ -914,13 +920,11 @@ func (p *partitionProducer) Close() {
 		return
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	cp := &closeProducer{&wg}
+	cp := &closeProducer{doneCh: make(chan struct{})}
 	p.eventsChan <- cp
 
-	wg.Wait()
+	// wait for close producer request to complete
+	<-cp.doneCh
 }
 
 type sendRequest struct {
@@ -932,12 +936,12 @@ type sendRequest struct {
 }
 
 type closeProducer struct {
-	waitGroup *sync.WaitGroup
+	doneCh chan struct{}
 }
 
 type flushRequest struct {
-	waitGroup *sync.WaitGroup
-	err       error
+	doneCh chan struct{}
+	err    error
 }
 
 func (i *pendingItem) Complete() {


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>

Fixes #711

### Motivation

As #711 desc, when the user calls `Send()`, we introduced **waitgroup** to ensure that the messageID is returned synchronously, but in `internalSendAsync()`, the callback may be triggered multiple times, causing the issue of #711

### Modifications

- Replace `waitgroup` with `doneCh`, consistent with the implementation on the consumer side to facilitate subsequent code maintenance
- Introduce an atomic variable isDone to ensure that `close(channel)` will only be triggered once

