### PR TITLE
Bump oauth2 package version to the latest in master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/AthenZ/athenz v1.10.39
 	github.com/DataDog/zstd v1.5.0
-	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20201120111947-b8bd55bc02bd
+	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20211108044248-fe3b7c4e445b
 	github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/AthenZ/athenz v1.10.39
 	github.com/DataDog/zstd v1.5.0
-	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20211108044248-fe3b7c4e445b
+	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20220120090717-25e59572242e
 	github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
### Motivation

1. `github.com/dgrijalva/jwt-go` contains a known CVE [vulnerability](https://github.com/advisories/GHSA-w73w-5m7g-f7qc)
2. This dependency was replaced with another jwt package.
3. But `oauth2` package version wasn't updated in master, so `github.com/apache/pulsar-client-go` still depends on it at the moment:

<img width="568" alt="image" src="https://user-images.githubusercontent.com/93676586/150176886-0aae211e-274d-478a-beaa-57fedb7e99c4.png">


### Modifications

Update the version of `oauth2` to the latest commit to that package

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

```
$ go get github.com/apache/pulsar-client-go/oauth2@fe3b7c4e445b
$ cd $(go env GOPATH)/pkg/mod/github.com/apache/pulsar-client-go/oauth2@v0.0.0-20211108044248-fe3b7c4e445b/
$ go mod why github.com/dgrijalva/jwt-go
```
<img width="752" alt="image" src="https://user-images.githubusercontent.com/93676586/150177986-e1461672-d6fa-4094-87cf-cab2f43eabd1.png">


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): yes, upgrades oauth2 package version to the latest in master
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? version update
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
