### PR TITLE
[optimize] Stop batchFlushTicker when Disable batching

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -126,6 +126,9 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 		metrics:          metrics,
 		epoch:            0,
 	}
+	if p.options.DisableBatching {
+		p.batchFlushTicker.Stop()
+	}
 	p.setProducerState(producerInit)
 
 	if options.Schema != nil && options.Schema.GetSchemaInfo() != nil {


### PR DESCRIPTION
### Motivation

Disable batchFlushTicker when Disable batching, reduce cpu cost

### Modifications

Stop the batchFlushTicker when Disable batching

