### PR TITLE
[Issue 729]stop ticker when create producer failed

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -145,6 +145,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 	}
 	err := p.grabCnx()
 	if err != nil {
+		p.batchFlushTicker.Stop()
 		logger.WithError(err).Error("Failed to create producer at newPartitionProducer")
 		return nil, err
 	}


### PR DESCRIPTION
Master Issue: [#729 ]

### Motivation


I received an alarm indicating that the server load was too high, used the pprof tool to locate the problem and determined that the cause was a ticker leak while a large number of producer creating failed.
Here are some screenshots to show it:
- pprof heap, there are a number of SDK-started ticker, accounted for 90%
![image](https://user-images.githubusercontent.com/15198796/154658829-e7bfc501-31cf-4f5e-9468-7a690d6b9a23.png)
- pprof cpu, cpu consumption is also here
![image](https://user-images.githubusercontent.com/15198796/154659229-3f2506e1-59fd-4ec0-b1f9-230fa4a48d96.png)



### Modifications

stop ticker when create producer failed
