### PR TITLE
[Issue 718] Fix nil pointer dereference in TopicNameWithoutPartitionPart

### DIFF
--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -21,11 +21,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/apache/pulsar-client-go/pulsar/internal/crypto"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/crypto"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSingleMessageIDNoAckTracker(t *testing.T) {

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -482,7 +482,10 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 
 func (mp *Metrics) GetLeveledMetrics(t string) *LeveledMetrics {
 	labels := make(map[string]string, 3)
-	tn, _ := ParseTopicName(t)
+	tn, err := ParseTopicName(t)
+	if err != nil {
+		return nil
+	}
 	topic := TopicNameWithoutPartitionPart(tn)
 	switch mp.metricsLevel {
 	case 4:

--- a/pulsar/internal/topic_name.go
+++ b/pulsar/internal/topic_name.go
@@ -107,6 +107,9 @@ func ParseTopicName(topic string) (*TopicName, error) {
 }
 
 func TopicNameWithoutPartitionPart(tn *TopicName) string {
+	if tn == nil {
+		return ""
+	}
 	if tn.Partition < 0 {
 		return tn.Name
 	}

--- a/pulsar/internal/topic_name_test.go
+++ b/pulsar/internal/topic_name_test.go
@@ -104,20 +104,24 @@ func TestParseTopicNameErrors(t *testing.T) {
 
 func TestTopicNameWithoutPartitionPart(t *testing.T) {
 	tests := []struct {
-		tn       TopicName
+		tn       *TopicName
 		expected string
 	}{
 		{
-			tn:       TopicName{Name: "persistent://public/default/my-topic", Partition: -1},
+			tn:       &TopicName{Name: "persistent://public/default/my-topic", Partition: -1},
 			expected: "persistent://public/default/my-topic",
 		},
 		{
-			tn:       TopicName{Name: "persistent://public/default/my-topic-partition-0", Partition: 0},
+			tn:       &TopicName{Name: "persistent://public/default/my-topic-partition-0", Partition: 0},
 			expected: "persistent://public/default/my-topic",
+		},
+		{
+			tn:       nil,
+			expected: "",
 		},
 	}
 	for _, test := range tests {
-		assert.Equal(t, test.expected, TopicNameWithoutPartitionPart(&test.tn))
+		assert.Equal(t, test.expected, TopicNameWithoutPartitionPart(test.tn))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: hantmac <hantmac@outlook.com>

Fixes [#<718>](https://github.com/apache/pulsar-client-go/issues/718)

Fix nil pointer dereference in TopicNameWithoutPartitionPart
### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

`topic_name_test.go`

### Documentation

  - Does this pull request introduce a new feature? (no)

