### PR TITLE
Add schema support to Reader

### DIFF
--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -79,6 +79,9 @@ type ReaderOptions struct {
 
 	// Decryption represents the encryption related fields required by the reader to decrypt a message.
 	Decryption *MessageDecryptionInfo
+
+	// Schema represents the schema implementation.
+	Schema Schema
 }
 
 // Reader can be used to scan through all the messages currently available in a topic.

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -102,6 +102,7 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 		nackRedeliveryDelay:        defaultNackRedeliveryDelay,
 		replicateSubscriptionState: false,
 		decryption:                 options.Decryption,
+		schema:                     options.Schema,
 	}
 
 	reader := &reader{


### PR DESCRIPTION
Master Issue: #344

### Motivation

#368 adds support for schemas in consumer and producer, but didn't add the corresponding option to reader. This fixes that.

### Modifications

Add `schema` field to `ReaderOptions` and pass the value to the consumer so messages can be read with a schema.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

`go test -run ^TestReaderWithSchema$ ./pulsar`

### Does this pull request potentially affect one of the following parts:

  - The public API: yes

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? GoDoc
