### PR TITLE
[PIP 90] go client retrieve broker metadata

### DIFF
--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -241,6 +241,8 @@ type message struct {
 	redeliveryCount     uint32
 	schema              Schema
 	encryptionContext   *EncryptionContext
+	index               *uint64
+	brokerPublishTime   *time.Time
 }
 
 func (msg *message) Topic() string {
@@ -297,6 +299,14 @@ func (msg *message) ProducerName() string {
 
 func (msg *message) GetEncryptionContext() *EncryptionContext {
 	return msg.encryptionContext
+}
+
+func (msg *message) Index() *uint64 {
+	return msg.index
+}
+
+func (msg *message) BrokerPublishTime() *time.Time {
+	return msg.brokerPublishTime
 }
 
 func newAckTracker(size int) *ackTracker {

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -38,6 +38,8 @@ type Buffer interface {
 
 	Read(size uint32) []byte
 
+	Skip(size uint32)
+
 	Get(readerIndex uint32, size uint32) []byte
 
 	ReadableSlice() []byte
@@ -120,6 +122,10 @@ func (b *buffer) Read(size uint32) []byte {
 	res := b.data[b.readerIdx : b.readerIdx+size]
 	b.readerIdx += size
 	return res
+}
+
+func (b *buffer) Skip(size uint32) {
+	b.readerIdx += size
 }
 
 func (b *buffer) Get(readerIdx uint32, size uint32) []byte {

--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -18,7 +18,6 @@
 package internal
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,7 +81,6 @@ func TestReadBrokerEntryMetadata(t *testing.T) {
 	assert.Equal(t, expectedBrokerTimestamp, *meta.BrokerTimestamp)
 	var expectedIndex uint64 = 5
 	assert.Equal(t, expectedIndex, *meta.Index)
-	fmt.Println(meta)
 }
 
 func TestReadMessageOldFormat(t *testing.T) {

--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -18,6 +18,7 @@
 package internal
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,20 @@ func TestReadMessageMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, 10, int(meta.GetNumMessagesInBatch()))
+}
+
+func TestReadBrokerEntryMetadata(t *testing.T) {
+	// read old style message (not batched)
+	reader := NewMessageReaderFromArray(brokerEntryMeta)
+	meta, err := reader.ReadBrokerMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expectedBrokerTimestamp uint64 = 1646983036054
+	assert.Equal(t, expectedBrokerTimestamp, *meta.BrokerTimestamp)
+	var expectedIndex uint64 = 5
+	assert.Equal(t, expectedIndex, *meta.Index)
+	fmt.Println(meta)
 }
 
 func TestReadMessageOldFormat(t *testing.T) {
@@ -209,4 +224,9 @@ var rawBatchMessage10 = []byte{
 	0x0a, 0x01, 0x62, 0x12, 0x01, 0x32, 0x18, 0x05,
 	0x28, 0x05, 0x40, 0x09, 0x68, 0x65, 0x6c, 0x6c,
 	0x6f,
+}
+
+var brokerEntryMeta = []byte{
+	0x0e, 0x02, 0x00, 0x00, 0x00, 0x09, 0x08, 0x96,
+	0xf9, 0xda, 0xbe, 0xf7, 0x2f, 0x10, 0x05,
 }

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -43,7 +43,7 @@ const (
 	PulsarVersion       = "0.1"
 	ClientVersionString = "Pulsar Go " + PulsarVersion
 
-	PulsarProtocolVersion = int32(pb.ProtocolVersion_v13)
+	PulsarProtocolVersion = int32(pb.ProtocolVersion_v18)
 )
 
 type TLSOptions struct {
@@ -292,7 +292,8 @@ func (c *connection) doHandshake() bool {
 		AuthMethodName:  proto.String(c.auth.Name()),
 		AuthData:        authData,
 		FeatureFlags: &pb.FeatureFlags{
-			SupportsAuthRefresh: proto.Bool(true),
+			SupportsAuthRefresh:         proto.Bool(true),
+			SupportsBrokerEntryMetadata: proto.Bool(true),
 		},
 	}
 

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -122,8 +122,12 @@ type Message interface {
 	// It will be used by the application to parse the undecrypted message.
 	GetEncryptionContext() *EncryptionContext
 
+	// Index returns index from broker entry metadata,
+	// or empty if the feature is not enabled in the broker.
 	Index() *uint64
 
+	// BrokerPublishTime returns broker publish time from broker entry metadata,
+	// or empty if the feature is not enabled in the broker.
 	BrokerPublishTime() *time.Time
 }
 

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -121,6 +121,10 @@ type Message interface {
 	// GetEncryptionContext returns the ecryption context of the message.
 	// It will be used by the application to parse the undecrypted message.
 	GetEncryptionContext() *EncryptionContext
+
+	Index() *uint64
+
+	BrokerPublishTime() *time.Time
 }
 
 // MessageID identifier for a particular message


### PR DESCRIPTION
### Motivation
Adapt [PIP 90](https://github.com/apache/pulsar/wiki/PIP-90%3A-Expose-broker-entry-metadata-to-the-client) in go client
allow go client retrieve brokermetadata

### Modifications
- modify `CommandConnect` featureflags, turn `SupportsBrokerEntryMetadata` to true
- add `index()` `brokerPublishTime` methods on `message` interface
- add `Skip` method on bytebuffer
