### PR TITLE
Temporarily point ci to pulsar 2.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-ARG GO_VERSION=golang:1.13
-FROM apachepulsar/pulsar:latest as pulsar
+ARG GO_VERSION=golang:1.15
+FROM apachepulsar/pulsar:2.8.2 as pulsar
 FROM $GO_VERSION as go
 
 RUN apt-get update && apt-get install -y openjdk-11-jre-headless ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG GO_VERSION=golang:1.15
+ARG GO_VERSION=golang:1.13
 FROM apachepulsar/pulsar:2.8.2 as pulsar
 FROM $GO_VERSION as go
 


### PR DESCRIPTION
Fixes #748 

we should temporarily point to 2.8.2 for non-blocking pr until 2.10 is published to `pulsar:latest`