### PR TITLE
[build] make go version consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG GO_VERSION=golang:1.13
+ARG GO_VERSION=golang:1.15
 FROM apachepulsar/pulsar:2.8.2 as pulsar
 FROM $GO_VERSION as go
 


### PR DESCRIPTION
### Motivation
Make dockerfile go version consistent with the `go.mod` file and `README doc` 

### Modifications
- update go version from 1.13 to 1.15