### PR TITLE
allow config reader subscription name

### DIFF
--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -68,6 +68,9 @@ type ReaderOptions struct {
 	// SubscriptionRolePrefix sets the subscription role prefix. The default prefix is "reader".
 	SubscriptionRolePrefix string
 
+	// SubscriptionName sets the subscription name. If subscriptionRolePrefix is set at the same time, this configuration will prevail
+	SubscriptionName string
+
 	// ReadCompacted, if enabled, the reader will read messages from the compacted topic rather than reading the
 	// full message backlog of the topic. This means that, if the topic has been compacted, the reader will only
 	// see the latest value for each key in the topic, up until the point in the topic message backlog that has

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -68,7 +68,8 @@ type ReaderOptions struct {
 	// SubscriptionRolePrefix sets the subscription role prefix. The default prefix is "reader".
 	SubscriptionRolePrefix string
 
-	// SubscriptionName sets the subscription name. If subscriptionRolePrefix is set at the same time, this configuration will prevail
+	// SubscriptionName sets the subscription name.
+	// If subscriptionRolePrefix is set at the same time, this configuration will prevail
 	SubscriptionName string
 
 	// ReadCompacted, if enabled, the reader will read messages from the compacted topic rather than reading the

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -66,11 +66,14 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 		}
 	}
 
-	subscriptionName := options.SubscriptionRolePrefix
+	subscriptionName := options.SubscriptionName
 	if subscriptionName == "" {
-		subscriptionName = "reader"
+		subscriptionName = options.SubscriptionRolePrefix
+		if subscriptionName == "" {
+			subscriptionName = "reader"
+		}
+		subscriptionName += "-" + generateRandomName()
 	}
-	subscriptionName += "-" + generateRandomName()
 
 	receiverQueueSize := options.ReceiverQueueSize
 	if receiverQueueSize <= 0 {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -20,11 +20,11 @@ package pulsar
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 	"testing"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/crypto"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"testing"
 	"time"
 
@@ -46,6 +47,27 @@ func TestReaderConfigErrors(t *testing.T) {
 	})
 	assert.Nil(t, consumer)
 	assert.NotNil(t, err)
+}
+
+func TestReaderConfigSubscribeName(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	consumer, err := client.CreateReader(ReaderOptions{
+		StartMessageID:   EarliestMessageID(),
+		Topic:            uuid.New().String(),
+		SubscriptionName: uuid.New().String(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+	assert.NotNil(t, consumer)
 }
 
 func TestReader(t *testing.T) {


### PR DESCRIPTION
### Motivation
allow config reader's subscription name, follow java's feature https://github.com/apache/pulsar/pull/8801

### Modifications
add param `SubscriptionName` in `ReaderOptions`

### Verifying this change
add the test for setting the subscritpion name
