### PR TITLE
Cleanup topics after unit tests

### DIFF
--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -348,7 +348,9 @@ func TestTopicPartitions(t *testing.T) {
 	defer client.Close()
 
 	// Create topic with 5 partitions
-	err = httpPut("admin/v2/persistent/public/default/TestGetTopicPartitions/partitions", 5)
+	topicAdminURL := "admin/v2/persistent/public/default/TestGetTopicPartitions/partitions"
+	err = httpPut(topicAdminURL, 5)
+	defer httpDelete(topicAdminURL)
 	assert.Nil(t, err)
 
 	partitionedTopic := "persistent://public/default/TestGetTopicPartitions"
@@ -697,7 +699,9 @@ func TestHTTPTopicPartitions(t *testing.T) {
 	defer client.Close()
 
 	// Create topic with 5 partitions
-	err = httpPut("admin/v2/persistent/public/default/TestHTTPTopicPartitions/partitions", 5)
+	topicAdminURL := "admin/v2/persistent/public/default/TestHTTPTopicPartitions/partitions"
+	err = httpPut(topicAdminURL, 5)
+	defer httpDelete(topicAdminURL)
 	assert.Nil(t, err)
 
 	partitionedTopic := "persistent://public/default/TestHTTPTopicPartitions"

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -509,7 +509,9 @@ func TestRoundRobinRouterPartitionedProducer(t *testing.T) {
 
 func TestMessageRouter(t *testing.T) {
 	// Create topic with 5 partitions
-	err := httpPut("admin/v2/persistent/public/default/my-partitioned-topic/partitions", 5)
+	topicAdminURL := "admin/v2/persistent/public/default/my-partitioned-topic/partitions"
+	err := httpPut(topicAdminURL, 5)
+	defer httpDelete(topicAdminURL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Motivation

Currently a few of the test topics aren't cleaned up after use, so if the same test is ran twice topic creation would fail.

### Modifications

`defer` topic cleanup in unit tests.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests. For example, before the change,

`go test -timeout 5s -run ^TestHTTPTopicPartitions$ github.com/apache/pulsar-client-go/pulsar -count=2`

would fail, and now it would pass.

### Documentation

  - Does this pull request introduce a new feature? no