### PR TITLE
Fix ack timeout cause reconnect

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -780,10 +780,7 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 
 	if !ok {
 		// if we receive a receipt although the pending queue is empty, the state of the broker and the producer differs.
-		// At that point, it is better to close the connection to the broker to reconnect to a broker hopping it solves
-		// the state discrepancy.
-		p.log.Warnf("Received ack for %v although the pending queue is empty, closing connection", response.GetMessageId())
-		p._getConn().Close()
+		p.log.Warnf("Got ack %v for timed out msg", response.GetMessageId())
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


### Motivation

Most of this situation is caused by the timeout of sending the message. When the sending of the message times out, we will try to remove the object from the local pendingQueue, but after a period of time, the broker may push the message back, resulting in the connection reconnect occurs.



![image](https://user-images.githubusercontent.com/20965307/161379243-7720f188-71ef-48de-b13b-0c13d28d1fe7.png)


Follow Java SDK process logic:

```
            op = pendingMessages.peek();
            if (op == null) {
                if (log.isDebugEnabled()) {
                    log.debug("[{}] [{}] Got ack for timed out msg {} - {}", topic, producerName, sequenceId, highestSequenceId);
                }
                return;
            }
```

When a timeout occurs, we just need to drop the request instead of closing the connection.

### Modifications

- Remove reconnection timeout when sendReceipt timeout.

