### PR TITLE
Fix producer unable register when cnx closed

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -54,7 +54,7 @@ type TLSOptions struct {
 
 var (
 	errConnectionClosed       = errors.New("connection closed")
-	errUnableRegisterListener = errors.New("Unable register listener when con closed")
+	errUnableRegisterListener = errors.New("unable register listener when con closed")
 )
 
 // ConnectionListener is a user of a connection (eg. a producer or

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -262,11 +262,14 @@ func (p *partitionProducer) grabCnx() error {
 		p.sequenceIDGenerator = &nextSequenceID
 	}
 	p._setConn(res.Cnx)
-	p._getConn().RegisterListener(p.producerID, p)
+	err = p._getConn().RegisterListener(p.producerID, p)
+	if err != nil {
+		return err
+	}
 	p.log.WithFields(log.Fields{
 		"cnx":   res.Cnx.ID(),
 		"epoch": atomic.LoadUint64(&p.epoch),
-	}).Debug("Connected producer")
+	}).Info("Connected producer")
 
 	pendingItems := p.pendingQueue.ReadableSlice()
 	viewSize := len(pendingItems)


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


### Motivation

At present, it is assumed that there are multiple topics multiplexing the same TCP connection, then any topic may trigger the reconnection operation of this TCP connection. In the actual production environment, we see that a small number of producers will report the following errors:

```
time="2022-04-19T21:43:28+08:00" level=warning msg="Connection closed unable register listener id=41" local_addr="9.xcxx:43051" remote_addr="pulsar://1.xxxx:6650"
```

The specific code logic is as follows:

https://github.com/apache/pulsar-client-go/blob/master/pulsar/internal/connection.go#L851-L855

We can see that when we try to register the producer, we will first check the status of the current connection. If the connection is closed, then we will not continue to register the producer object with the connection, but at the same time we will not do any processing and cause some topics to continue to hold the old connection before, causing the sending to time out.




### Modifications

- return an error when unable to register listener
