### PR TITLE
[Issue 763][producer] Fix deadlock in Producer Send when message fails to encode.

### DIFF
--- a/pulsar/error.go
+++ b/pulsar/error.go
@@ -101,6 +101,8 @@ const (
 	SeekFailed
 	// ProducerClosed means producer already been closed
 	ProducerClosed
+	// SchemaFailure means the payload could not be encoded using the Schema
+	SchemaFailure
 )
 
 // Error implement error interface, composed of two parts: msg and result.
@@ -205,6 +207,8 @@ func getResultStr(r Result) string {
 		return "SeekFailed"
 	case ProducerClosed:
 		return "ProducerClosed"
+	case SchemaFailure:
+		return "SchemaFailure"
 	default:
 		return fmt.Sprintf("Result(%d)", r)
 	}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -420,7 +420,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		schemaPayload, err = p.options.Schema.Encode(msg.Value)
 		if err != nil {
 			p.publishSemaphore.Release()
-			request.callback(nil, request.msg, err)
+			request.callback(nil, request.msg, newError(SchemaFailure, err.Error()))
 			p.log.WithError(err).Errorf("Schema encode message failed %s", msg.Value)
 			return
 		}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -419,6 +419,8 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		var schemaPayload []byte
 		schemaPayload, err = p.options.Schema.Encode(msg.Value)
 		if err != nil {
+			p.publishSemaphore.Release()
+			request.callback(nil, request.msg, err)
 			p.log.WithError(err).Errorf("Schema encode message failed %s", msg.Value)
 			return
 		}


### PR DESCRIPTION
Add tests for producer schema encode.

Fixes #763

### Motivation
When using Producer, if the ProducerMessage.Value fails to encode using the producer's Schema, the code never returns when using `producer.Send()` and never executes the callback when using `producer.SendAsync()`. Additionally, the publishSemaphore that was Acquired is never released.

### Modifications
When an error is returned by Schema Encode, release the Semaphore and execute the callback.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - *Added integration test with failure to encode schema*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
