### PR TITLE
Revert "Fix stuck when reconnect broker (#703)"

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -823,8 +823,6 @@ func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer)
 	consumerID := closeConsumer.GetConsumerId()
 	c.log.Infof("Broker notification of Closed consumer: %d", consumerID)
 
-	c.changeState(connectionClosed)
-
 	if consumer, ok := c.consumerHandler(consumerID); ok {
 		consumer.ConnectionClosed()
 		c.DeleteConsumeHandler(consumerID)
@@ -836,8 +834,6 @@ func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer)
 func (c *connection) handleCloseProducer(closeProducer *pb.CommandCloseProducer) {
 	c.log.Infof("Broker notification of Closed producer: %d", closeProducer.GetProducerId())
 	producerID := closeProducer.GetProducerId()
-
-	c.changeState(connectionClosed)
 
 	producer, ok := c.deletePendingProducers(producerID)
 	// did we find a producer?

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -80,7 +80,7 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 
 		// remove stale/failed connection
 		if conn.closed() {
-			p.log.Infof("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
+			p.log.Debugf("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
 				key, conn.logicalAddr, conn.physicalAddr)
 			delete(p.connections, key)
 			conn.Close()


### PR DESCRIPTION
Fixes #766 

### Motivation

The change made in #703 is invalid. See #766 .

One of the motivation of #703 was to implement similar behavior as there is in Java SDK. The change didn't do that.
In the Java SDK, the concepts (classes) are fairly misleading, and something that might seem to be a connection close isn't one. The ClientHandler is really a reference to a connection in the Java SDK. The ClientCnx (which holds the TCP/IP connection) isn't closed in the Java SDK in ClientHandler.connectionClosed:
https://github.com/apache/pulsar/blob/04aa9e8e51869d1621a7e25402a656084eebfc09/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java#L122-L141

### Modifications

This reverts #703 / commit 1a8432cfd3aa231f8eb3c97171a47eab98a8f20a.



