### PR TITLE
Fix sequenceID is not equal to cause the connection to be closed incorrectly

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -788,12 +788,12 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 		// Ignoring the ack since it's referring to a message that has already timed out.
 		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
 			response.GetSequenceId(), pi.sequenceID)
+		p._getConn().Close()
 		return
 	} else if pi.sequenceID > response.GetSequenceId() {
 		// Force connection closing so that messages can be re-transmitted in a new connection
 		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
 			response.GetSequenceId(), pi.sequenceID)
-		p._getConn().Close()
 		return
 	} else {
 		// The ack was indeed for the expected item in the queue, we can remove it and trigger the callback

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -785,13 +785,13 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 	}
 
 	if pi.sequenceID < response.GetSequenceId() {
-		// Ignoring the ack since it's referring to a message that has already timed out.
+		// Force connection closing so that messages can be re-transmitted in a new connection
 		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
 			response.GetSequenceId(), pi.sequenceID)
 		p._getConn().Close()
 		return
 	} else if pi.sequenceID > response.GetSequenceId() {
-		// Force connection closing so that messages can be re-transmitted in a new connection
+		// Ignoring the ack since it's referring to a message that has already timed out.
 		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
 			response.GetSequenceId(), pi.sequenceID)
 		return


### PR DESCRIPTION
### Motivation

When processing the sendReceipt command, if the sequenceID returned by the broker is greater than the sequenceID in the current pendingQueue, we need to close the current connection to fix the inconsistency between the broker and the client state.
When the sequenceID returned by the broker is smaller than the sequenceID in the current pendingQueue, we do not need to close the current connection, and expect to increment the value of the returned sequenceID when the broker retries next time.

The current code processing logic is just the opposite, resulting in the failure to recover after the first situation occurs, and a phenomenon similar to the following occurs:

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/20965307/167880602-0251dcd6-5a95-4faf-8e27-943bbdbbd6d0.png">


