### PR TITLE
Add error response for Ack func

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -200,10 +200,10 @@ type Consumer interface {
 	Chan() <-chan ConsumerMessage
 
 	// Ack the consumption of a single message
-	Ack(Message)
+	Ack(Message) error
 
 	// AckID the consumption of a single message, identified by its MessageID
-	AckID(MessageID)
+	AckID(MessageID) error
 
 	// ReconsumeLater mark a message for redelivery after custom delay
 	ReconsumeLater(msg Message, delay time.Duration)

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -34,7 +35,7 @@ import (
 const defaultNackRedeliveryDelay = 1 * time.Minute
 
 type acker interface {
-	AckID(id trackingMessageID)
+	AckID(id trackingMessageID) error
 	NackID(id trackingMessageID)
 	NackMsg(msg Message)
 }
@@ -438,29 +439,28 @@ func (c *consumer) Receive(ctx context.Context) (message Message, err error) {
 	}
 }
 
-// Messages
+// Chan return the message chan to users
 func (c *consumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh
 }
 
 // Ack the consumption of a single message
-func (c *consumer) Ack(msg Message) {
-	c.AckID(msg.ID())
+func (c *consumer) Ack(msg Message) error {
+	return c.AckID(msg.ID())
 }
 
-// Ack the consumption of a single message, identified by its MessageID
-func (c *consumer) AckID(msgID MessageID) {
+// AckID the consumption of a single message, identified by its MessageID
+func (c *consumer) AckID(msgID MessageID) error {
 	mid, ok := c.messageID(msgID)
 	if !ok {
-		return
+		return errors.New("failed to convert trackingMessageID")
 	}
 
 	if mid.consumer != nil {
-		mid.Ack()
-		return
+		return mid.Ack()
 	}
 
-	c.consumers[mid.partitionIdx].AckID(mid)
+	return c.consumers[mid.partitionIdx].AckID(mid)
 }
 
 // ReconsumeLater mark a message for redelivery after custom delay

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -112,30 +113,30 @@ func (c *multiTopicConsumer) Receive(ctx context.Context) (message Message, err 
 	}
 }
 
-// Messages
+// Chan return the message chan to users
 func (c *multiTopicConsumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh
 }
 
 // Ack the consumption of a single message
-func (c *multiTopicConsumer) Ack(msg Message) {
-	c.AckID(msg.ID())
+func (c *multiTopicConsumer) Ack(msg Message) error {
+	return c.AckID(msg.ID())
 }
 
-// Ack the consumption of a single message, identified by its MessageID
-func (c *multiTopicConsumer) AckID(msgID MessageID) {
+// AckID the consumption of a single message, identified by its MessageID
+func (c *multiTopicConsumer) AckID(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return
+		return errors.New("invalid message id type in multi_consumer")
 	}
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
-		return
+		return errors.New("unable to ack message because consumer is nil")
 	}
 
-	mid.Ack()
+	return mid.Ack()
 }
 
 func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -152,34 +153,34 @@ func (c *regexConsumer) Receive(ctx context.Context) (message Message, err error
 	}
 }
 
-// Chan
+// Chan return the messages chan to user
 func (c *regexConsumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh
 }
 
 // Ack the consumption of a single message
-func (c *regexConsumer) Ack(msg Message) {
-	c.AckID(msg.ID())
+func (c *regexConsumer) Ack(msg Message) error {
+	return c.AckID(msg.ID())
 }
 
 func (c *regexConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 	c.log.Warnf("regexp consumer not support ReconsumeLater yet.")
 }
 
-// Ack the consumption of a single message, identified by its MessageID
-func (c *regexConsumer) AckID(msgID MessageID) {
+// AckID the consumption of a single message, identified by its MessageID
+func (c *regexConsumer) AckID(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return
+		return errors.New("invalid message id type")
 	}
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
-		return
+		return errors.New("consumer is nil in consumer_regex")
 	}
 
-	mid.Ack()
+	return mid.Ack()
 }
 
 func (c *regexConsumer) Nack(msg Message) {

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -63,13 +64,15 @@ func (id trackingMessageID) Undefined() bool {
 	return id == trackingMessageID{}
 }
 
-func (id trackingMessageID) Ack() {
+func (id trackingMessageID) Ack() error {
 	if id.consumer == nil {
-		return
+		return errors.New("consumer is nil in trackingMessageID")
 	}
 	if id.ack() {
-		id.consumer.AckID(id)
+		return id.consumer.AckID(id)
 	}
+
+	return nil
 }
 
 func (id trackingMessageID) Nack() {

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -81,7 +81,7 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 		// When the current connection is in a closed state or the broker actively notifies that the
 		// current connection is closed, we need to remove the connection object from the current
 		// connection pool and create a new connection.
-		if conn.closed() || conn.reconnectFlag {
+		if conn.closed() {
 			p.log.Infof("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
 				key, conn.logicalAddr, conn.physicalAddr)
 			delete(p.connections, key)

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -78,8 +78,10 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 		p.log.Debugf("Found connection in pool key=%s logical_addr=%+v physical_addr=%+v",
 			key, conn.logicalAddr, conn.physicalAddr)
 
-		// remove stale/failed connection
-		if conn.closed() {
+		// When the current connection is in a closed state or the broker actively notifies that the
+		// current connection is closed, we need to remove the connection object from the current
+		// connection pool and create a new connection.
+		if conn.closed() || conn.reconnectFlag {
 			p.log.Infof("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
 				key, conn.logicalAddr, conn.physicalAddr)
 			delete(p.connections, key)

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -64,9 +64,13 @@ func (c *mockConsumer) Chan() <-chan pulsar.ConsumerMessage {
 	return nil
 }
 
-func (c *mockConsumer) Ack(msg pulsar.Message) {}
+func (c *mockConsumer) Ack(msg pulsar.Message) error {
+	return nil
+}
 
-func (c *mockConsumer) AckID(msgID pulsar.MessageID) {}
+func (c *mockConsumer) AckID(msgID pulsar.MessageID) error {
+	return nil
+}
 
 func (c *mockConsumer) ReconsumeLater(msg pulsar.Message, delay time.Duration) {}
 


### PR DESCRIPTION
### Motivation

There are mainly two problems fixed in this pr. 

1. The first one is to return some error information when the Go SDK handles Ack by itself to the user. Note: This is not the error information returned by the Broker side, but some errors that may occur in the Go SDK itself when processing the Ack command link. If we ignore these possible Errors here, then when the user calls Ack, because there is no return value, the user will think that the current Ack request has been successful, but in fact the Ack command may have failed when the Go SDK requested, resulting in this The Ack status of a message is lost and it becomes a hollow message. This will cause the backlog size on the broker side to continuously increase until the threshold of the backlog is triggered and the message sending fails.

For example a place where an error might occur:

```
func (pc *partitionConsumer) internalAck(req *ackRequest) {
        .....
	err := pc.client.rpcClient.RequestOnCnxNoWait(pc._getConn(), pb.BaseCommand_ACK, cmdAck)
	if err != nil {
		pc.log.Error("Connection was closed when request ack cmd")
		req.err = err
	}
}
```

In this case, the ack fails because the current connection is closed, but the user cannot capture this error message and think that the ack has succeeded, so an ack hole will occur.


### Modifications

- Add error response for Ack func.