### PR TITLE
Introduce doneCh for ack error

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -325,6 +325,7 @@ func (pc *partitionConsumer) AckID(msgID trackingMessageID) error {
 	}
 
 	ackReq := new(ackRequest)
+	ackReq.doneCh = make(chan struct{})
 	if !msgID.Undefined() && msgID.ack() {
 		pc.metrics.AcksCounter.Inc()
 		pc.metrics.ProcessingTime.Observe(float64(time.Now().UnixNano()-msgID.receivedTime.UnixNano()) / 1.0e9)
@@ -335,6 +336,8 @@ func (pc *partitionConsumer) AckID(msgID trackingMessageID) error {
 		pc.options.interceptors.OnAcknowledge(pc.parentConsumer, msgID)
 	}
 
+	// wait for the request to complete
+	<-ackReq.doneCh
 	return ackReq.err
 }
 
@@ -514,6 +517,7 @@ func (pc *partitionConsumer) clearMessageChannels() {
 }
 
 func (pc *partitionConsumer) internalAck(req *ackRequest) {
+	defer close(req.doneCh)
 	if state := pc.getConsumerState(); state == consumerClosed || state == consumerClosing {
 		pc.log.WithField("state", state).Error("Failed to ack by closing or closed consumer")
 		return
@@ -933,8 +937,9 @@ func (pc *partitionConsumer) dispatcher() {
 }
 
 type ackRequest struct {
-	msgID trackingMessageID
-	err   error
+	doneCh chan struct{}
+	msgID  trackingMessageID
+	err    error
 }
 
 type unsubscribeRequest struct {


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>


### Motivation


In #456, we support the error information that may occur when the Go SDK side processes the Ack Command, but there is a bug in this implementation. We do not wait for the error information to return directly, so the error obtained in the Ack interface will always be nil.

### Modifications

Introduce `doneCh` to wait for the information of ack error to return
