### PR TITLE
[issue #752] replace go-rate rate limiter with a buffered channel implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/AthenZ/athenz v1.10.39
 	github.com/DataDog/zstd v1.5.0
 	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20220120090717-25e59572242e
-	github.com/beefsack/go-rate v0.0.0-20220214233405-116f4ca011a0
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,6 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.32.6/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/beefsack/go-rate v0.0.0-20220214233405-116f4ca011a0 h1:0b2vaepXIfMsG++IsjHiI2p4bxALD1Y2nQKGMR5zDQM=
-github.com/beefsack/go-rate v0.0.0-20220214233405-116f4ca011a0/go.mod h1:6YNgTHLutezwnBvyneBbwvB8C82y3dcoOj5EQJIdGXA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -103,12 +103,9 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 	rateLimitCh := make(chan time.Time, produceArgs.Rate)
 	go func(rateLimit int, interval time.Duration) {
 		for {
-			select {
-			case last := <-rateLimitCh:
-				if rateLimit > 0 {
-					remaining := interval - time.Since(last)
-					time.Sleep(remaining)
-				}
+			last := <-rateLimitCh
+			if rateLimit > 0 { // 0 is defined as no limit enforced
+				time.Sleep(interval - time.Since(last))
 			}
 		}
 	}(produceArgs.Rate, time.Second)

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -102,11 +102,12 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 	ch := make(chan float64)
 	rateLimitCh := make(chan time.Time, produceArgs.Rate)
 	go func(rateLimit int, interval time.Duration) {
+		if rateLimit <= 0 { // 0 as no limit enforced
+			return
+		}
 		for {
 			oldest := <-rateLimitCh
-			if rateLimit > 0 { // 0 is defined as no limit enforced
-				time.Sleep(interval - time.Since(oldest))
-			}
+			time.Sleep(interval - time.Since(oldest))
 		}
 	}(produceArgs.Rate, time.Second)
 


### PR DESCRIPTION
Fixes #752 

### Motivation

The go rate limiter library, beefsack/go-rate, is an MIT license. We need update the license. The PR removes this dependency.

### Modifications

In Go, it is rather simple to implement a rate limiter directly. A buffered channel is used to store a request timestamp as message. The channel receiver check each timestamp (in the message) to sleep on the remaining time duration. 

The per second rate is the size of channel buffer. If the buffer is full, the main producing go routine blocks on producing Pulsar message, until the sleep expires and move to on the next message in the channel thus free up a slot in the channel.

It resembles leaky bucket rate limiting implementation. Because of leveraging go channel, it uses less than 10 lines of code and remove the dependency entirely. Since the implementation only uses one buffered channel, avoid using expensive mutex lock/unlocking and a list by the original library implementation.

### Verifying this change

Since the change only affects the perf utility, I built the tool and verify the producing rate is accurate.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes)
      Removes beefsak/go-rate dependency
  - The public API: ( no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
