### PR TITLE
[issue 447] double check message size when client enable compress

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -45,6 +45,9 @@ type BatchBuilder interface {
 	// IsFull check if the size in the current batch exceeds the maximum size allowed by the batch
 	IsFull() bool
 
+	// compress the payload
+	Compress(uncompressedPayload []byte) []byte
+
 	// Add will add single message to batch.
 	Add(
 		metadata *pb.SingleMessageMetadata, sequenceIDGenerator *uint64,
@@ -150,6 +153,11 @@ func NewBatchBuilder(
 	)
 
 	return &bc, nil
+}
+
+// compress the payload
+func (bc *batchContainer) Compress(uncompressedPayload []byte) []byte {
+	return bc.compressionProvider.Compress(nil, uncompressedPayload)
 }
 
 // IsFull checks if the size in the current batch meets or exceeds the maximum size allowed by the batch

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -84,7 +84,7 @@ func (h *keyBasedBatches) Val(key string) *batchContainer {
 // NewKeyBasedBatchBuilder init batch builder and return BatchBuilder
 // pointer. Build a new key based batch message container.
 func NewKeyBasedBatchBuilder(
-	maxMessages uint, maxBatchSize uint, producerName string, producerID uint64,
+	maxMessages uint, maxBatchSize uint, maxMessageSize uint, producerName string, producerID uint64,
 	compressionType pb.CompressionType, level compression.Level,
 	bufferPool BuffersPool, logger log.Logger, encryptor crypto.Encryptor,
 ) (BatchBuilder, error) {
@@ -92,7 +92,7 @@ func NewKeyBasedBatchBuilder(
 	bb := &keyBasedBatchContainer{
 		batches: newKeyBasedBatches(),
 		batchContainer: newBatchContainer(
-			maxMessages, maxBatchSize, producerName, producerID,
+			maxMessages, maxBatchSize, maxMessageSize, producerName, producerID,
 			compressionType, level, bufferPool, logger, encryptor,
 		),
 		compressionType: compressionType,
@@ -151,7 +151,7 @@ func (bc *keyBasedBatchContainer) Add(
 	if batchPart == nil {
 		// create batchContainer for new key
 		t := newBatchContainer(
-			bc.maxMessages, bc.maxBatchSize, bc.producerName, bc.producerID,
+			bc.maxMessages, bc.maxBatchSize, bc.maxMessageSize, bc.producerName, bc.producerID,
 			bc.compressionType, bc.level, bc.buffersPool, bc.log, bc.encryptor,
 		)
 		batchPart = &t

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -520,7 +520,12 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 	}
 
 	// if msg is too large
-	if len(payload) > int(p._getConn().GetMaxMessageSize()) {
+	minMessageSize := len(payload)
+	if minMessageSize > int(p._getConn().GetMaxMessageSize()) {
+		minMessageSize = len(p.batchBuilder.Compress(payload))
+	}
+
+	if minMessageSize > int(p._getConn().GetMaxMessageSize()) {
 		p.publishSemaphore.Release()
 		request.callback(nil, request.msg, errMessageTooLarge)
 		p.log.WithError(errMessageTooLarge).

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -520,12 +520,8 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 	}
 
 	// if msg is too large
-	minMessageSize := len(payload)
-	if minMessageSize > int(p._getConn().GetMaxMessageSize()) {
-		minMessageSize = len(p.batchBuilder.Compress(payload))
-	}
-
-	if minMessageSize > int(p._getConn().GetMaxMessageSize()) {
+	if len(payload) > int(p._getConn().GetMaxMessageSize()) && 
+		len(p.batchBuilder.Compress(payload)) > int(p._getConn().GetMaxMessageSize()) {
 		p.publishSemaphore.Release()
 		request.callback(nil, request.msg, errMessageTooLarge)
 		p.log.WithError(errMessageTooLarge).


### PR DESCRIPTION
Fixes #447 
### Motivation
Try to fix issue #447. 

### Modifications
Compress the payload when the payload is too bigger, and check whever the 'compressed payload' is still bigger than expected.
