### PR TITLE
Support dynamic set go sdk version in connection

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -1061,7 +1061,3 @@ func getClientVersion() string {
 	}
 	return time.Unix(time.Now().Unix(), 0).Format("2006-01-02 15:04:05")
 }
-
-func init() {
-	getClientVersion()
-}

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -33,6 +32,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/sirupsen/logrus"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal/auth"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -1030,6 +1030,7 @@ func (c *connection) GetMaxMessageSize() int32 {
 	return c.maxMessageSize
 }
 
+// FIXME: Maybe there is a better way to get Version information.
 func getClientVersion() string {
 	// open version file
 	var versionFile = "/VERSION"


### PR DESCRIPTION
Signed-off-by: xiaolongran <xiaolongran@tencent.com>



### Motivation

Currently, when Go SDK creates a connection, the version information set is fixed to Pulsar Go 0.1. When we maintain multiple versions of Go SDK in the production environment, we want to obtain the specific version information used by users through operations such as tcpdump .

### Modifications

Support dynamic set go sdk version in connection

![企业微信截图_77defb3a-bf37-4fc1-8640-7e2c076a4f78](https://user-images.githubusercontent.com/20965307/182090232-5ec838ca-a513-43c9-87bb-8e5f279fedd0.png)


