### PR TITLE
[cleanup] Fix to follow lint error (File is not `goimports`-ed (goimports))

### DIFF
--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -70,7 +70,6 @@ func NewMessageReaderFromArray(headersAndPayload []byte) *MessageReader {
 // Batch format
 // [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA] [METADATA_SIZE][METADATA][PAYLOAD]
 // [METADATA_SIZE][METADATA][PAYLOAD]
-//
 type MessageReader struct {
 	buffer Buffer
 	// true if we are parsing a batched message - set after parsing the message metadata


### PR DESCRIPTION
### Motivation

Currently, the golangci-lint returns an error about coding style like below.

```
bash-4.2# /root/go/bin/golangci-lint run -v
INFO [config_reader] Config search paths: [./ /pulsar-client-go / /root]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 16 linters: [bodyclose deadcode goimports gosimple govet ineffassign lll misspell prealloc revive stylecheck typecheck unconvert unparam unused varcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|types_sizes|deps|exports_file|files|imports|name) took 2.153604501s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 242.078666ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner/skip dirs] Skipped 2 issues from dir examples/producer by pattern (^|/)examples($|/)
INFO [runner] Issues before processing: 804, after processing: 1
INFO [runner] Processors filtering stat (out/in): severity-rules: 1/1, exclude-rules: 2/317, nolint: 1/2, uniq_by_line: 1/1, sort_results: 1/1, path_prettifier: 804/804, autogenerated_exclude: 317/802, identifier_marker: 317/317, skip_dirs: 802/804, exclude: 317/317, diff: 1/1, max_same_issues: 1/1, path_shortener: 1/1, cgo: 804/804, filename_unadjuster: 804/804, skip_files: 804/804, path_prefixer: 1/1, max_per_file_from_linter: 1/1, max_from_linter: 1/1, source_code: 1/1
INFO [runner] processing took 200.131536ms with stages: exclude-rules: 80.570624ms, autogenerated_exclude: 61.830875ms, identifier_marker: 41.972667ms, nolint: 7.293417ms, path_prettifier: 3.747624ms, skip_dirs: 1.673709ms, source_code: 1.1035ms, cgo: 502.291µs, severity-rules: 385.792µs, filename_unadjuster: 274.75µs, max_same_issues: 188.874µs, max_from_linter: 101.958µs, uniq_by_line: 93.333µs, path_shortener: 92.584µs, max_per_file_from_linter: 89.291µs, diff: 69.5µs, sort_results: 43.707µs, skip_files: 43.208µs, exclude: 33.958µs, path_prefixer: 19.874µs
INFO [runner] linters took 563.266709ms with stages: goanalysis_metalinter: 361.755959ms
pulsar/internal/commands.go:73: File is not `goimports`-ed (goimports)
//
INFO File cache stats: 1 entries of total size 10.0KiB
INFO Memory: 32 samples, avg is 54.6MB, max is 83.1MB
INFO Execution took 3.056773293s
```

### Modifications

Fix to follow lint error.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
