### PR TITLE
[Issue 827][bugfix]  fix error delay of default backoff policy

### DIFF
--- a/pulsar/negative_backoff_policy.go
+++ b/pulsar/negative_backoff_policy.go
@@ -35,8 +35,8 @@ type NackBackoffPolicy interface {
 type defaultNackBackoffPolicy struct{}
 
 func (nbp *defaultNackBackoffPolicy) Next(redeliveryCount uint32) int64 {
-	minNackTimeMs := int64(1000 * 30) // 30sec
-	maxNackTimeMs := 1000 * 60 * 10   // 10min
+	minNackTimeMs := int64(30 * 1000 * 1000 * 1000) // 30sec
+	maxNackTimeMs := int64(10 * 60 * 1000 * 1000 * 1000)   // 10min
 
 	if redeliveryCount < 0 {
 		return minNackTimeMs


### PR DESCRIPTION
Signed-off-by: simonisacoder <921181549@qq.com>



Fixes [#issue 827](https://github.com/apache/pulsar-client-go/issues/827)


Master Issue: #<827>

### Motivation


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

fix the return value of the default negative backoff policy which is with a wrong comment or wrong unit.

### Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: ( no)

### Documentation
  - Does this pull request introduce a new feature? ( no)
