### PR TITLE
Enable seeking individual topic partitions

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -238,9 +238,6 @@ type Consumer interface {
 
 	// Seek resets the subscription associated with this consumer to a specific message id.
 	// The message id can either be a specific message or represent the first or last messages in the topic.
-	//
-	// Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
-	//       seek() on the individual partitions.
 	Seek(MessageID) error
 
 	// SeekByTime resets the subscription associated with this consumer to a specific message publish time.

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -580,6 +580,16 @@ func (c *consumer) Seek(msgID MessageID) error {
 		return nil
 	}
 
+	if mid.partitionIdx < 0 {
+		return newError(SeekFailed, "partitionIdx is negative")
+	}
+	if mid.partitionIdx > int32(len(c.consumers)-1) {
+		return newError(
+			SeekFailed,
+			fmt.Sprintf("partitionIdx is %d, but there are %d partitions", mid.partitionIdx, len(c.consumers)),
+		)
+	}
+
 	return c.consumers[mid.partitionIdx].Seek(mid)
 }
 

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -575,10 +575,6 @@ func (c *consumer) Seek(msgID MessageID) error {
 	c.Lock()
 	defer c.Unlock()
 
-	if len(c.consumers) > 1 {
-		return newError(SeekFailed, "for partition topic, seek command should perform on the individual partitions")
-	}
-
 	mid, ok := c.messageID(msgID)
 	if !ok {
 		return nil

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -583,7 +583,7 @@ func (c *consumer) Seek(msgID MessageID) error {
 	if mid.partitionIdx < 0 {
 		return newError(SeekFailed, "partitionIdx is negative")
 	}
-	if mid.partitionIdx > int32(len(c.consumers)-1) {
+	if mid.partitionIdx > int32(len(c.consumers)) {
 		return newError(
 			SeekFailed,
 			fmt.Sprintf("partitionIdx is %d, but there are %d partitions", mid.partitionIdx, len(c.consumers)),


### PR DESCRIPTION
Currently, seeking on a consumer with a KeyShared subscription fails. This PR removes an unnecessary check to seek the underlying partitionConsumer.