### PR TITLE
[issue 840][client] batchReceive support for consumer

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -78,6 +78,23 @@ type DLQPolicy struct {
 	RetryLetterTopic string
 }
 
+type BatchReceivePolicy struct {
+	/**
+	 * maxNumMessages specifies max number of messages for a single batch receive, 0 or negative means no limit.
+	 */
+	maxNumMessages int
+
+	/**
+	 * maxNumBytes specifies max bytes of messages for a single batch receive, 0 or negative means no limit.
+	 */
+	maxNumBytes int64
+
+	/**
+	 * timeout for waiting for enough messages(enough number or enough bytes).
+	 */
+	timeout time.Duration
+}
+
 // ConsumerOptions is used to configure and create instances of Consumer.
 type ConsumerOptions struct {
 	// Topic specifies the topic this consumer will subscribe on.
@@ -192,6 +209,9 @@ type ConsumerOptions struct {
 	// error information of the Ack method only contains errors that may occur in the Go SDK's own processing.
 	// Default: false
 	AckWithResponse bool
+
+	// BatchReceivePolicy is the config of consumer's batch receive behavior
+	BatchReceivePolicy *BatchReceivePolicy
 }
 
 // Consumer is an interface that abstracts behavior of Pulsar's consumer
@@ -205,6 +225,9 @@ type Consumer interface {
 	// Receive a single message.
 	// This calls blocks until a message is available.
 	Receive(context.Context) (Message, error)
+
+	// BatchReceive receive many messages by BatchReceivePolicy
+	BatchReceive(context.Context) (*Messages, error)
 
 	// Chan returns a channel to consume messages from
 	Chan() <-chan ConsumerMessage

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -49,7 +49,7 @@ type multiTopicConsumer struct {
 }
 
 func newMultiTopicConsumer(client *client, options ConsumerOptions, topics []string,
-	messageCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter) (Consumer, error) {
+	messageCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter) (*multiTopicConsumer, error) {
 	mtc := &multiTopicConsumer{
 		client:       client,
 		options:      options,
@@ -128,7 +128,7 @@ func (c *multiTopicConsumer) AckID(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return errors.New("invalid message id type in multi_consumer")
+		return errors.New("invalid message id type in consumer")
 	}
 
 	if mid.consumer == nil {

--- a/pulsar/consumer_multitopic_test.go
+++ b/pulsar/consumer_multitopic_test.go
@@ -18,9 +18,11 @@
 package pulsar
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -83,4 +85,103 @@ func TestMultiTopicConsumerReceive(t *testing.T) {
 		}
 	}
 	assert.Equal(t, receivedTopic1, receivedTopic2)
+}
+
+func TestMultiTopicConsumerBatchReceive(t *testing.T) {
+	topic1 := newTopicName()
+	topic2 := newTopicName()
+
+	client, err := NewClient(ClientOptions{
+		URL: "pulsar://localhost:6650",
+	})
+	assert.Nil(t, err)
+	testTopics := []string{topic1, topic2}
+	commonOpt := ConsumerOptions{
+		Topics:                      testTopics,
+		SubscriptionName:            "multi-topic-sub",
+		Type:                        Exclusive,
+		SubscriptionInitialPosition: SubscriptionPositionEarliest,
+	}
+
+	// total 10 messages, 50 byte
+	for _, topic := range testTopics {
+		producer, err := client.CreateProducer(ProducerOptions{
+			Topic: topic,
+		})
+		assert.Nil(t, err)
+		for i := 0; i < 5; i++ {
+			msg := &ProducerMessage{
+				Payload: []byte("12345"),
+			}
+			_, err := producer.Send(context.Background(), msg)
+			assert.Nil(t, err)
+		}
+	}
+
+	//test for maxNumMessages
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 6,
+		maxNumBytes:    999,
+		timeout:        10 * time.Second,
+	}
+	_consumer, err := client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer1 := _consumer.(*multiTopicConsumer)
+	messages, err := consumer1.BatchReceive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 6, messages.Size())
+	consumer1.Close()
+
+	//test for maxNumBytes
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 999,
+		maxNumBytes:    14,
+		timeout:        10 * time.Second,
+	}
+	_consumer, err = client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer2 := _consumer.(*multiTopicConsumer)
+	messages, err = consumer2.BatchReceive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 2, messages.Size())
+	consumer2.Close()
+
+	//test for maxNumBytes and maxNumMessages
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 3,
+		maxNumBytes:    24,
+		timeout:        10 * time.Second,
+	}
+	_consumer, err = client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer3 := _consumer.(*multiTopicConsumer)
+	messages, err = consumer3.BatchReceive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 3, messages.Size())
+	consumer3.Close()
+
+	// test for timeout
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 999,
+		maxNumBytes:    999,
+		timeout:        3 * time.Second,
+	}
+	_consumer, err = client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer4 := _consumer.(*multiTopicConsumer)
+
+	ch := make(chan struct{})
+	go func() {
+		messages, err = consumer4.BatchReceive(context.Background())
+		ch <- struct{}{}
+	}()
+	timer := time.NewTimer(4 * time.Second)
+	select {
+	case <-timer.C:
+		assert.Fail(t, "BatchReceivePolicy.timeout failed: should stop after 3 seconds")
+	case <-ch:
+		assert.Nil(t, err)
+		assert.Equal(t, 10, messages.Size())
+	}
+	consumer4.Close()
 }

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -18,8 +18,6 @@
 package pulsar
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -37,73 +35,36 @@ const (
 )
 
 type regexConsumer struct {
-	client *client
-	dlq    *dlqRouter
-	rlq    *retryRouter
-
-	options ConsumerOptions
-
-	messageCh chan ConsumerMessage
+	*multiTopicConsumer
 
 	namespace string
 	pattern   *regexp.Regexp
 
 	consumersLock sync.Mutex
-	consumers     map[string]Consumer
 	subscribeCh   chan []string
 	unsubscribeCh chan []string
-
-	closeOnce sync.Once
-	closeCh   chan struct{}
-
-	ticker *time.Ticker
-
-	log log.Logger
-
-	consumerName string
+	ticker        *time.Ticker
 }
 
-func newRegexConsumer(c *client, opts ConsumerOptions, tn *internal.TopicName, pattern *regexp.Regexp,
-	msgCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter) (Consumer, error) {
-	rc := &regexConsumer{
-		client:    c,
-		dlq:       dlq,
-		rlq:       rlq,
-		options:   opts,
-		messageCh: msgCh,
-
-		namespace: tn.Namespace,
-		pattern:   pattern,
-
-		consumers:     make(map[string]Consumer),
-		subscribeCh:   make(chan []string, 1),
-		unsubscribeCh: make(chan []string, 1),
-
-		closeCh: make(chan struct{}),
-
-		log:          c.log.SubLogger(log.Fields{"topic": tn.Name}),
-		consumerName: opts.Name,
+func newRegexConsumer(client *client, opts ConsumerOptions, tn *internal.TopicName, pattern *regexp.Regexp,
+	msgCh chan ConsumerMessage, dlq *dlqRouter, rlq *retryRouter) (*regexConsumer, error) {
+	topics, err := topics(client, tn.Namespace, pattern)
+	if err != nil {
+		return nil, err
 	}
-
-	topics, err := rc.topics()
+	mtc, err := newMultiTopicConsumer(client, opts, topics, msgCh, dlq, rlq)
 	if err != nil {
 		return nil, err
 	}
 
-	var errs error
-	for ce := range subscriber(c, topics, opts, msgCh, dlq, rlq) {
-		if ce.err != nil {
-			errs = pkgerrors.Wrapf(ce.err, "unable to subscribe to topic=%s", ce.topic)
-		} else {
-			rc.consumers[ce.topic] = ce.consumer
-		}
-	}
+	rc := &regexConsumer{
+		multiTopicConsumer: mtc,
 
-	if errs != nil {
-		for _, c := range rc.consumers {
-			c.Close()
-		}
-		return nil, errs
+		namespace: tn.Namespace,
+		pattern:   pattern,
+
+		subscribeCh:   make(chan []string, 1),
+		unsubscribeCh: make(chan []string, 1),
 	}
 
 	// set up timer
@@ -116,10 +77,6 @@ func newRegexConsumer(c *client, opts ConsumerOptions, tn *internal.TopicName, p
 	go rc.monitor()
 
 	return rc, nil
-}
-
-func (c *regexConsumer) Subscription() string {
-	return c.options.SubscriptionName
 }
 
 func (c *regexConsumer) Unsubscribe() error {
@@ -137,85 +94,8 @@ func (c *regexConsumer) Unsubscribe() error {
 	return errs
 }
 
-func (c *regexConsumer) Receive(ctx context.Context) (message Message, err error) {
-	for {
-		select {
-		case <-c.closeCh:
-			return nil, newError(ConsumerClosed, "consumer closed")
-		case cm, ok := <-c.messageCh:
-			if !ok {
-				return nil, newError(ConsumerClosed, "consumer closed")
-			}
-			return cm.Message, nil
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
-}
-
-// Chan return the messages chan to user
-func (c *regexConsumer) Chan() <-chan ConsumerMessage {
-	return c.messageCh
-}
-
-// Ack the consumption of a single message
-func (c *regexConsumer) Ack(msg Message) error {
-	return c.AckID(msg.ID())
-}
-
 func (c *regexConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 	c.log.Warnf("regexp consumer not support ReconsumeLater yet.")
-}
-
-// AckID the consumption of a single message, identified by its MessageID
-func (c *regexConsumer) AckID(msgID MessageID) error {
-	mid, ok := toTrackingMessageID(msgID)
-	if !ok {
-		c.log.Warnf("invalid message id type %T", msgID)
-		return errors.New("invalid message id type")
-	}
-
-	if mid.consumer == nil {
-		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
-		return errors.New("consumer is nil in consumer_regex")
-	}
-
-	return mid.Ack()
-}
-
-func (c *regexConsumer) Nack(msg Message) {
-	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
-		msgID := msg.ID()
-		mid, ok := toTrackingMessageID(msgID)
-		if !ok {
-			c.log.Warnf("invalid message id type %T", msgID)
-			return
-		}
-
-		if mid.consumer == nil {
-			c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
-			return
-		}
-		mid.NackByMsg(msg)
-		return
-	}
-
-	c.NackID(msg.ID())
-}
-
-func (c *regexConsumer) NackID(msgID MessageID) {
-	mid, ok := toTrackingMessageID(msgID)
-	if !ok {
-		c.log.Warnf("invalid message id type %T", msgID)
-		return
-	}
-
-	if mid.consumer == nil {
-		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
-		return
-	}
-
-	mid.Nack()
 }
 
 func (c *regexConsumer) Close() {
@@ -246,11 +126,6 @@ func (c *regexConsumer) Seek(msgID MessageID) error {
 
 func (c *regexConsumer) SeekByTime(time time.Time) error {
 	return newError(SeekFailed, "seek command not allowed for regex consumer")
-}
-
-// Name returns the name of consumer.
-func (c *regexConsumer) Name() string {
-	return c.consumerName
 }
 
 func (c *regexConsumer) closed() bool {
@@ -285,7 +160,7 @@ func (c *regexConsumer) monitor() {
 }
 
 func (c *regexConsumer) discover() {
-	topics, err := c.topics()
+	topics, err := topics(c.client, c.namespace, c.pattern)
 	if err != nil {
 		c.log.WithError(err).Errorf("Failed to discover topics")
 		return
@@ -360,13 +235,13 @@ func (c *regexConsumer) unsubscribe(topics []string) {
 	}
 }
 
-func (c *regexConsumer) topics() ([]string, error) {
-	topics, err := c.client.lookupService.GetTopicsOfNamespace(c.namespace, internal.Persistent)
+func topics(client *client, namespace string, pattern *regexp.Regexp) ([]string, error) {
+	topics, err := client.lookupService.GetTopicsOfNamespace(namespace, internal.Persistent)
 	if err != nil {
 		return nil, err
 	}
 
-	filtered := filterTopics(topics, c.pattern)
+	filtered := filterTopics(topics, pattern)
 	return filtered, nil
 }
 
@@ -376,6 +251,7 @@ type consumerError struct {
 	consumer Consumer
 }
 
+// create consumers for all partitions of topics
 func subscriber(c *client, topics []string, opts ConsumerOptions, ch chan ConsumerMessage,
 	dlq *dlqRouter, rlq *retryRouter) <-chan consumerError {
 	consumerErrorCh := make(chan consumerError, len(topics))

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -156,13 +156,11 @@ func runRegexConsumerDiscoverPatternAll(t *testing.T, c Client, namespace string
 
 	dlq, _ := newDlqRouter(c.(*client), nil, log.DefaultNopLogger())
 	rlq, _ := newRetryRouter(c.(*client), nil, false, log.DefaultNopLogger())
-	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
+	rc, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer consumer.Close()
-
-	rc := consumer.(*regexConsumer)
+	defer rc.Close()
 
 	// trigger discovery
 	rc.discover()
@@ -194,13 +192,11 @@ func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string
 
 	dlq, _ := newDlqRouter(c.(*client), nil, log.DefaultNopLogger())
 	rlq, _ := newRetryRouter(c.(*client), nil, false, log.DefaultNopLogger())
-	consumer, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
+	rc, err := newRegexConsumer(c.(*client), opts, tn, pattern, make(chan ConsumerMessage, 1), dlq, rlq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer consumer.Close()
-
-	rc := consumer.(*regexConsumer)
+	defer rc.Close()
 
 	// trigger discovery
 	rc.discover()

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -364,3 +364,103 @@ func cloneConsumers(rc *regexConsumer) map[string]Consumer {
 	}
 	return consumers
 }
+
+func TestRegexTopicConsumerBatchReceive(t *testing.T) {
+	randomPrefix := generateRandomName()
+	topic1 := randomPrefix + "-1"
+	topic2 := randomPrefix + "-2"
+	testTopics := []string{topic1, topic2}
+
+	client, err := NewClient(ClientOptions{
+		URL: "pulsar://localhost:6650",
+	})
+	assert.Nil(t, err)
+	commonOpt := ConsumerOptions{
+		TopicsPattern:               randomPrefix + "-.*",
+		SubscriptionName:            "regex-topic-sub",
+		Type:                        Exclusive,
+		SubscriptionInitialPosition: SubscriptionPositionEarliest,
+	}
+
+	// total 10 messages, 50 byte
+	for _, topic := range testTopics {
+		producer, err := client.CreateProducer(ProducerOptions{
+			Topic: topic,
+		})
+		assert.Nil(t, err)
+		for i := 0; i < 5; i++ {
+			msg := &ProducerMessage{
+				Payload: []byte("12345"),
+			}
+			_, err := producer.Send(context.Background(), msg)
+			assert.Nil(t, err)
+		}
+	}
+
+	//test for maxNumMessages
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 6,
+		maxNumBytes:    999,
+		timeout:        10 * time.Second,
+	}
+	_consumer, err := client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer1 := _consumer.(*regexConsumer)
+	messages, err := consumer1.BatchReceive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 6, messages.Size())
+	consumer1.Close()
+
+	//test for maxNumBytes
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 999,
+		maxNumBytes:    14,
+		timeout:        10 * time.Second,
+	}
+	_consumer, err = client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer2 := _consumer.(*regexConsumer)
+	messages, err = consumer2.BatchReceive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 2, messages.Size())
+	consumer2.Close()
+
+	//test for maxNumBytes and maxNumMessages
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 3,
+		maxNumBytes:    24,
+		timeout:        10 * time.Second,
+	}
+	_consumer, err = client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer3 := _consumer.(*regexConsumer)
+	messages, err = consumer3.BatchReceive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 3, messages.Size())
+	consumer3.Close()
+
+	// test for timeout
+	commonOpt.BatchReceivePolicy = &BatchReceivePolicy{
+		maxNumMessages: 999,
+		maxNumBytes:    999,
+		timeout:        3 * time.Second,
+	}
+	_consumer, err = client.Subscribe(commonOpt)
+	assert.Nil(t, err)
+	consumer4 := _consumer.(*regexConsumer)
+
+	ch := make(chan struct{})
+	go func() {
+		messages, err = consumer4.BatchReceive(context.Background())
+		ch <- struct{}{}
+	}()
+	timer := time.NewTimer(4 * time.Second)
+	select {
+	case <-timer.C:
+		assert.Fail(t, "BatchReceivePolicy.timeout failed: should stop after 3 seconds")
+	case <-ch:
+		assert.Nil(t, err)
+		assert.Equal(t, 10, messages.Size())
+	}
+	consumer4.Close()
+}

--- a/pulsar/helper_for_test.go
+++ b/pulsar/helper_for_test.go
@@ -171,7 +171,7 @@ func retryAssert(t assert.TestingT, times int, milliseconds int, update func(), 
 	for i := 0; i < times; i++ {
 		time.Sleep(time.Duration(milliseconds) * time.Millisecond)
 		update()
-		if assert(nil) {
+		if assert(t) {
 			break
 		}
 	}

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -60,6 +60,10 @@ func (c *mockConsumer) Receive(ctx context.Context) (message pulsar.Message, err
 	return nil, nil
 }
 
+func (c *mockConsumer) BatchReceive(ctx context.Context) (*pulsar.Messages, error) {
+	return nil, nil
+}
+
 func (c *mockConsumer) Chan() <-chan pulsar.ConsumerMessage {
 	return nil
 }


### PR DESCRIPTION
Note: this pr is a draft, waiting #848 to be merged.

Master Issue: #840

### Motivation

Add `batchReceive` method for consumers

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
