### PR TITLE
Add TLS transport config

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -105,6 +105,12 @@ type ClientOptions struct {
 	// Example: `Authentication: NewAuthenticationTLS("my-cert.pem", "my-key.pem")`
 	Authentication
 
+	// Set the path to the TLS key file
+	TLSKeyFilePath string
+
+	// Set the path to the TLS certificate file
+	TLSCertificateFile string
+
 	// Set the path to the trusted TLS certificate file
 	TLSTrustCertsFilePath string
 

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -71,6 +71,8 @@ func newClient(options ClientOptions) (Client, error) {
 	case "pulsar+ssl", "https":
 		tlsConfig = &internal.TLSOptions{
 			AllowInsecureConnection: options.TLSAllowInsecureConnection,
+			KeyFile:                 options.TLSKeyFilePath,
+			CertFile:                options.TLSCertificateFile,
 			TrustCertsFilePath:      options.TLSTrustCertsFilePath,
 			ValidateHostname:        options.TLSValidateHostname,
 		}

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1067,7 +1067,7 @@ func TestHTTPSBasicAuth(t *testing.T) {
 	client.Close()
 }
 
-func testTlsTransportWithBasicAuth(t *testing.T, url string) {
+func testTLSTransportWithBasicAuth(t *testing.T, url string) {
 	t.Helper()
 
 	basicAuth, err := NewAuthenticationBasic("admin", "123456")
@@ -1094,10 +1094,10 @@ func testTlsTransportWithBasicAuth(t *testing.T, url string) {
 	client.Close()
 }
 
-func TestServiceUrlTlsWithTlsTransportWithBasicAuth(t *testing.T) {
-	testTlsTransportWithBasicAuth(t, serviceURLTLS)
+func TestServiceUrlTLSWithTLSTransportWithBasicAuth(t *testing.T) {
+	testTLSTransportWithBasicAuth(t, serviceURLTLS)
 }
 
-func TestWebServiceUrlTlsWithTlsTransportWithBasicAuth(t *testing.T) {
-	testTlsTransportWithBasicAuth(t, webServiceURLTLS)
+func TestWebServiceUrlTLSWithTLSTransportWithBasicAuth(t *testing.T) {
+	testTLSTransportWithBasicAuth(t, webServiceURLTLS)
 }

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1066,3 +1066,38 @@ func TestHTTPSBasicAuth(t *testing.T) {
 
 	client.Close()
 }
+
+func testTlsTransportWithBasicAuth(t *testing.T, url string) {
+	t.Helper()
+
+	basicAuth, err := NewAuthenticationBasic("admin", "123456")
+	require.NoError(t, err)
+	require.NotNil(t, basicAuth)
+
+	client, err := NewClient(ClientOptions{
+		URL:                   url,
+		TLSCertificateFile:    tlsClientCertPath,
+		TLSKeyFilePath:        tlsClientKeyPath,
+		TLSTrustCertsFilePath: caCertsPath,
+		Authentication:        basicAuth,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic: newTopicName(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, producer)
+
+	client.Close()
+}
+
+func TestServiceUrlTlsWithTlsTransportWithBasicAuth(t *testing.T) {
+	testTlsTransportWithBasicAuth(t, serviceURLTLS)
+}
+
+func TestWebServiceUrlTlsWithTlsTransportWithBasicAuth(t *testing.T) {
+	testTlsTransportWithBasicAuth(t, webServiceURLTLS)
+}

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -47,6 +47,8 @@ const (
 )
 
 type TLSOptions struct {
+	KeyFile                 string
+	CertFile                string
 	TrustCertsFilePath      string
 	AllowInsecureConnection bool
 	ValidateHostname        bool
@@ -980,6 +982,14 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 
 	if c.tlsOptions.ValidateHostname {
 		tlsConfig.ServerName = c.physicalAddr.Hostname()
+	}
+
+	if c.tlsOptions.CertFile != "" || c.tlsOptions.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(c.tlsOptions.CertFile, c.tlsOptions.KeyFile)
+		if err != nil {
+			return nil, errors.New(err.Error())
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	cert, err := c.auth.GetTLSCertificate()

--- a/pulsar/internal/http_client.go
+++ b/pulsar/internal/http_client.go
@@ -345,6 +345,14 @@ func getDefaultTransport(tlsConfig *TLSOptions) (http.RoundTripper, error) {
 			cfg.RootCAs = x509.NewCertPool()
 			cfg.RootCAs.AppendCertsFromPEM(rootCA)
 		}
+
+		if tlsConfig.CertFile != "" || tlsConfig.KeyFile != "" {
+			cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
+			if err != nil {
+				return nil, errors.New(err.Error())
+			}
+			cfg.Certificates = []tls.Certificate{cert}
+		}
 		transport.TLSClientConfig = cfg
 	}
 	transport.MaxIdleConnsPerHost = 10


### PR DESCRIPTION
### Motivation

Add a TLS transport config for the client.

In the old version, we can only use the TLS authentication to config the TLS transport, so we cannot use the other authentication, which is confusing, so we need to add a TLS transport config for the client, which would resolve the issue I mentioned.

When using this config with the TLS authentication, the TLS authentication config is preferred.
