### PR TITLE
Only send notifications to commits@ ML

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,3 +43,11 @@ github:
     merge:   false
     # disable rebase button:
     rebase:  false
+
+
+notifications:
+  commits:      commits@pulsar.apache.org
+  issues:       commits@pulsar.apache.org
+  pullrequests: commits@pulsar.apache.org
+  discussions:  dev@pulsar.apache.org
+  jira_options: link label


### PR DESCRIPTION
### Motivation

See https://github.com/apache/pulsar-client-cpp/pull/42 for context. The goal is to decrease unnecessary notifications. If you would like to get these notifications, please subscribe to commits@ or "watch" the GitHub repo.

### Modifications

* Update the notifications to match the apache/pulsar repo.
