### PR TITLE
Fix marshalling time.Time{} to uint64

### DIFF
--- a/pulsar/internal/utils.go
+++ b/pulsar/internal/utils.go
@@ -28,6 +28,10 @@ import (
 
 // TimestampMillis return a time unix nano.
 func TimestampMillis(t time.Time) uint64 {
+	// calling UnixNano on the zero Time is undefined
+	if t.IsZero() {
+		return 0
+	}
 	return uint64(t.UnixNano()) / uint64(time.Millisecond)
 }
 

--- a/pulsar/internal/utils_test.go
+++ b/pulsar/internal/utils_test.go
@@ -55,3 +55,8 @@ func TestParseRelativeTimeInSeconds(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, time.Duration(10)*time.Hour*24*7*365, timestamp)
 }
+
+func TestTimestampMillis(t *testing.T) {
+	assert.Equal(t, uint64(0), TimestampMillis(time.Time{}))
+	assert.Equal(t, uint64(7), TimestampMillis(time.UnixMilli(7)))
+}

--- a/pulsar/internal/utils_test.go
+++ b/pulsar/internal/utils_test.go
@@ -58,5 +58,5 @@ func TestParseRelativeTimeInSeconds(t *testing.T) {
 
 func TestTimestampMillis(t *testing.T) {
 	assert.Equal(t, uint64(0), TimestampMillis(time.Time{}))
-	assert.Equal(t, uint64(7), TimestampMillis(time.UnixMilli(7)))
+	assert.Equal(t, uint64(7), TimestampMillis(time.Unix(0, 7*int64(time.Millisecond))))
 }


### PR DESCRIPTION
Signed-off-by: Ayman Khalil <ayman.khalil@datastax.com>

### Motivation

When producing messages via the go client, if the user doesn't assign an explicit `EventTime` to the message, the following `uint64` will end up on the wire:
`11651379494838`

This is because [TimestampMillis](https://github.com/aymkhalil/pulsar-client-go/blob/7fbfbaac9532efd3dbab7f768daca045a86d9966/pulsar/internal/utils.go#L30) calls UnixNano, but [UnixNano](https://pkg.go.dev/time#Time.UnixNano) on the zero Time is undefined.

[This](https://go.dev/play/p/mDPKyxFCKLL) code mimic what happens when TimestampMillis is called on the Zero value

Please note that go consumers (like this[ ](https://github.com/apache/pulsar-client-go/blob/a013ff0b7353fab87a7eb7599377bb06b46eb7b7/pulsar/consumer_test.go#L624)test) will NOT notice this issue, because this is handled correctly when [unmarshalling](https://github.com/apache/pulsar-client-go/blob/649d992f26349835d7dc1e7632d60e399bd4eaa5/pulsar/internal/pulsar_proto/PulsarApi.pb.go#L1634) on the consumer side

To reproduce the issue, simple send a message via the go client:

```go
             msg := pulsar.ProducerMessage{
			Value: &myType{
             ....
			},
			EventTime: time.Time{}, // or just leave it out
		}
	    _, err = producer.Send(ctx, &msg)

```

and consume via puslar admin, java client, sink, etc:
```java
 CompletableFuture.supplyAsync(() -> {
            Message rm = null;
            try {
                rm = consumer.receive();
                consumer.acknowledge(rm);
                System.out.println(rm.getEventTime()); // prints 11651379494838 (always)

            } catch (PulsarClientException e) {
                ...
            }
            ...
        });
```

### Modifications
*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as https://github.com/apache/pulsar-client-go/blob/a013ff0b7353fab87a7eb7599377bb06b46eb7b7/pulsar/consumer_test.go#L593. Also added simple unit test to verify `time.Time{}` marshals to `0`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: ( no )
  - The default values of configurations: (no)
  - The wire protocol: (yes) : The wire will have 0 instead of 11651379494838 for unset EventTime values. This behavior is noticed only by non-go consumers.

### Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
