### PR TITLE
OAuth2 KeyFileProvider - Use the `DATA` constant as prefix

### DIFF
--- a/oauth2/client_credentials_provider.go
+++ b/oauth2/client_credentials_provider.go
@@ -55,7 +55,7 @@ func (k *KeyFileProvider) GetClientCredentials() (*KeyFile, error) {
 	case strings.HasPrefix(k.KeyFile, FILE):
 		filename := strings.TrimPrefix(k.KeyFile, FILE)
 		keyFile, err = ioutil.ReadFile(filename)
-	case strings.HasPrefix(k.KeyFile, "data://"):
+	case strings.HasPrefix(k.KeyFile, DATA):
 		keyFile = []byte(strings.TrimPrefix(k.KeyFile, DATA))
 	default:
 		keyFile, err = ioutil.ReadFile(k.KeyFile)


### PR DESCRIPTION
### Motivation

- Code cleanup.

### Modifications

- A minor change to use the constant instead of a repeated string.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
- [x] This change is already covered by existing tests: `TestNewAuthenticationOAuth2WithParams` in `pulsar/internal/auth/oauth2_test.go`.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? - **No.**
