### PR TITLE
[CI] Add go test flag '-v' for more clearly CI log

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -31,7 +31,7 @@ go build -o bin/pulsar-perf ./perf
 
 scripts/pulsar-test-service-start.sh
 
-go test -race -coverprofile=/tmp/coverage -timeout=20m ./...
+go test -race -coverprofile=/tmp/coverage -timeout=20m -v ./...
 go tool cover -html=/tmp/coverage -o coverage.html
 
 scripts/pulsar-test-service-stop.sh


### PR DESCRIPTION
Master Issue: #870 

### Motivation

Currently, the CI of pulsar-go-client is more and more prone to fail due to timeout. It's hard to find out which test case failed based on CI log now.

Add go test flag '-v' will make the CI log more clearly to locate which test failed or timeout.

### Modifications

Add go test flag '-v' in `run-ci.sh`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
