### PR TITLE
[Issue 873] Fix flaky test TestRLQMultiTopics() and TestRLQSpecifiedPartitionTopic()

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1549,15 +1549,6 @@ func TestRLQSpecifiedPartitionTopic(t *testing.T) {
 	assert.Nil(t, err)
 	defer rlqConsumer.Close()
 
-	// subscribe DLQ Topic
-	dlqConsumer, err := client.Subscribe(ConsumerOptions{
-		Topic:                       subName + "-DLQ",
-		SubscriptionName:            subName,
-		SubscriptionInitialPosition: SubscriptionPositionEarliest,
-	})
-	assert.Nil(t, err)
-	defer dlqConsumer.Close()
-
 	// create producer
 	producer, err := client.CreateProducer(ProducerOptions{Topic: normalTopic})
 	assert.Nil(t, err)
@@ -1585,6 +1576,15 @@ func TestRLQSpecifiedPartitionTopic(t *testing.T) {
 	msg, err := rlqConsumer.Receive(rlqCtx)
 	assert.Error(t, err)
 	assert.Nil(t, msg)
+
+	// subscribe DLQ Topic
+	dlqConsumer, err := client.Subscribe(ConsumerOptions{
+		Topic:                       subName + "-DLQ",
+		SubscriptionName:            subName,
+		SubscriptionInitialPosition: SubscriptionPositionEarliest,
+	})
+	assert.Nil(t, err)
+	defer dlqConsumer.Close()
 
 	// 3. Create consumer on the DLQ topic to verify the routing
 	dlqReceived := 0
@@ -3263,4 +3263,10 @@ func TestAvailablePermitsLeak(t *testing.T) {
 	cancel3()
 	assert.NotEqual(t, true, errors.Is(err, context.DeadlineExceeded),
 		"This means the resource is exhausted. consumer.Receive() will block forever.")
+}
+
+func TestCI(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		TestAvailablePermitsLeak(t)
+	}
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1481,7 +1481,6 @@ func TestRLQMultiTopics(t *testing.T) {
 		SubscriptionName:            subName,
 		SubscriptionInitialPosition: SubscriptionPositionEarliest,
 	})
-
 	assert.Nil(t, err)
 	defer dlqConsumer.Close()
 

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1440,15 +1440,6 @@ func TestRLQMultiTopics(t *testing.T) {
 	assert.Nil(t, err)
 	defer rlqConsumer.Close()
 
-	// subscribe DLQ Topic
-	dlqConsumer, err := client.Subscribe(ConsumerOptions{
-		Topic:                       subName + "-DLQ",
-		SubscriptionName:            subName,
-		SubscriptionInitialPosition: SubscriptionPositionEarliest,
-	})
-	assert.Nil(t, err)
-	defer dlqConsumer.Close()
-
 	// create multi producers
 	producer01, err := client.CreateProducer(ProducerOptions{Topic: topic01})
 	assert.Nil(t, err)
@@ -1482,6 +1473,15 @@ func TestRLQMultiTopics(t *testing.T) {
 	msg, err := rlqConsumer.Receive(rlqCtx)
 	assert.Error(t, err)
 	assert.Nil(t, msg)
+
+	// subscribe DLQ Topic
+	dlqConsumer, err := client.Subscribe(ConsumerOptions{
+		Topic:                       subName + "-DLQ",
+		SubscriptionName:            subName,
+		SubscriptionInitialPosition: SubscriptionPositionEarliest,
+	})
+	assert.Nil(t, err)
+	defer dlqConsumer.Close()
 
 	// 3. Create consumer on the DLQ topic to verify the routing
 	dlqReceived := 0

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -41,7 +41,7 @@ import (
 
 var (
 	adminURL  = "http://localhost:8080"
-	lookupURL = "pulsar://localhost:6650"
+	lookupURL = "pulsar://10.105.7.225:6650"
 )
 
 func TestProducerConsumer(t *testing.T) {
@@ -3262,10 +3262,4 @@ func TestAvailablePermitsLeak(t *testing.T) {
 	cancel3()
 	assert.NotEqual(t, true, errors.Is(err, context.DeadlineExceeded),
 		"This means the resource is exhausted. consumer.Receive() will block forever.")
-}
-
-func TestCI(t *testing.T) {
-	for i := 0; i < 50; i++ {
-		TestAvailablePermitsLeak(t)
-	}
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1421,7 +1421,8 @@ func TestRLQMultiTopics(t *testing.T) {
 	subName := fmt.Sprintf("sub01-%d", time.Now().Unix())
 	maxRedeliveries := 2
 	N := 100
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
 
 	client, err := NewClient(ClientOptions{URL: lookupURL})
 	assert.Nil(t, err)

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1481,6 +1481,7 @@ func TestRLQMultiTopics(t *testing.T) {
 		SubscriptionName:            subName,
 		SubscriptionInitialPosition: SubscriptionPositionEarliest,
 	})
+
 	assert.Nil(t, err)
 	defer dlqConsumer.Close()
 


### PR DESCRIPTION
Fixes #873 

### Motivation

The TestRLQMultiTopics() and TestRLQSpecifiedPartitionTopic() have a very high chance of failing (stuck forever). The purpose of this PR is to fix the stuck problem to save CI cost and find out why it often failed.

In my environment, run the TestRLQMultiTopics() 50 times in a row, the stuck will definitely occur (usually occurs in the tenth). Strangely after changing the location of the DLQ subscription statement, the problem never reappeared.

Did I miss something?

### Modifications

The subcription of DLQ consumer has been moved from before RLQ consumer to after RLQ consumer. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

