### PR TITLE
Fix load tls certificate

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -986,7 +986,7 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 		c.log.Debugf("getTLSConfig(): setting tlsConfig.ServerName = %+v", tlsConfig.ServerName)
 	}
 
-	if c.tlsOptions.CertFile != "" || c.tlsOptions.KeyFile != "" {
+	if c.tlsOptions.CertFile != "" && c.tlsOptions.KeyFile != "" {
 		cert, err := tls.LoadX509KeyPair(c.tlsOptions.CertFile, c.tlsOptions.KeyFile)
 		if err != nil {
 			return nil, errors.New(err.Error())

--- a/pulsar/internal/http_client.go
+++ b/pulsar/internal/http_client.go
@@ -346,7 +346,7 @@ func getDefaultTransport(tlsConfig *TLSOptions) (http.RoundTripper, error) {
 			cfg.RootCAs.AppendCertsFromPEM(rootCA)
 		}
 
-		if tlsConfig.CertFile != "" || tlsConfig.KeyFile != "" {
+		if tlsConfig.CertFile != "" && tlsConfig.KeyFile != "" {
 			cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
 			if err != nil {
 				return nil, errors.New(err.Error())


### PR DESCRIPTION
### Motivation

Fix load tls certificate.

This is an incorrect condition. The `CertFile` and `KeyFile` cannot be empty, see the following code that directly read this file:

```
func LoadX509KeyPair(certFile, keyFile string) (Certificate, error) {
	certPEMBlock, err := os.ReadFile(certFile)
	if err != nil {
		return Certificate{}, err
	}
	keyPEMBlock, err := os.ReadFile(keyFile)
	if err != nil {
		return Certificate{}, err
	}
	return X509KeyPair(certPEMBlock, keyPEMBlock)
}
```
