### PR TITLE
feat: add BackoffPolicy to `reader` and improve test case

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3286,20 +3286,20 @@ func TestConsumerWithBackoffPolicy(t *testing.T) {
 	// 1 s
 	startTime := time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 2 s
 	startTime = time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 4 s
 	startTime = time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 4 s
 	startTime = time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 }

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1094,22 +1094,22 @@ func TestProducerWithBackoffPolicy(t *testing.T) {
 	// 1 s
 	startTime := time.Now()
 	partitionProducerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 2 s
 	startTime = time.Now()
 	partitionProducerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 4 s
 	startTime = time.Now()
 	partitionProducerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 4 s
 	startTime = time.Now()
 	partitionProducerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 }
 
 func TestSendContextExpired(t *testing.T) {

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1072,6 +1072,46 @@ func TestSendTimeout(t *testing.T) {
 	makeHTTPCall(t, http.MethodDelete, quotaURL, "")
 }
 
+func TestProducerWithBackoffPolicy(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	topicName := newTopicName()
+
+	backoff := newTestBackoffPolicy(1*time.Second, 4*time.Second)
+	_producer, err := client.CreateProducer(ProducerOptions{
+		Topic:         topicName,
+		SendTimeout:   2 * time.Second,
+		BackoffPolicy: backoff,
+	})
+	assert.Nil(t, err)
+	defer _producer.Close()
+
+	partitionProducerImp := _producer.(*producer).producers[0].(*partitionProducer)
+	// 1 s
+	startTime := time.Now()
+	partitionProducerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+
+	// 2 s
+	startTime = time.Now()
+	partitionProducerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+
+	// 4 s
+	startTime = time.Now()
+	partitionProducerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+
+	// 4 s
+	startTime = time.Now()
+	partitionProducerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+}
+
 func TestSendContextExpired(t *testing.T) {
 	quotaURL := adminURL + "/admin/v2/namespaces/public/default/backlogQuota"
 	quotaFmt := `{"limit": "%d", "policy": "producer_request_hold"}`

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -19,8 +19,9 @@ package pulsar
 
 import (
 	"context"
-	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar/internal"
 )
 
 // ReaderMessage packages Reader and Message as a struct to use.

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"time"
 )
 
@@ -86,6 +87,10 @@ type ReaderOptions struct {
 
 	// Schema represents the schema implementation.
 	Schema Schema
+
+	// BackoffPolicy parameterize the following options in the reconnection logic to
+	// allow users to customize the reconnection logic (minBackoff, maxBackoff and jitterPercentage)
+	BackoffPolicy internal.BackoffPolicy
 }
 
 // Reader can be used to scan through all the messages currently available in a topic.

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -106,6 +106,7 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 		replicateSubscriptionState: false,
 		decryption:                 options.Decryption,
 		schema:                     options.Schema,
+		backoffPolicy:              options.BackoffPolicy,
 	}
 
 	reader := &reader{

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -20,7 +20,6 @@ package pulsar
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"testing"
 	"time"
 
@@ -803,8 +802,8 @@ func (b *testBackoffPolicy) Next() time.Duration {
 	return b.curBackoff
 }
 
-func (b *testBackoffPolicy) Check(startTime time.Time) bool {
-	log.Warn(time.Now().Sub(startTime), b.curBackoff)
+func (b *testBackoffPolicy) IsExpectedIntervalFrom(startTime time.Time) bool {
+	// Approximately equal to expected interval
 	if time.Now().Sub(startTime) < b.curBackoff-time.Second {
 		return false
 	}
@@ -834,20 +833,20 @@ func TestReaderWithBackoffPolicy(t *testing.T) {
 	// 1 s
 	startTime := time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 2 s
 	startTime = time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 4 s
 	startTime = time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 
 	// 4 s
 	startTime = time.Now()
 	partitionConsumerImp.reconnectToBroker()
-	assert.True(t, backoff.Check(startTime))
+	assert.True(t, backoff.IsExpectedIntervalFrom(startTime))
 }

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"context"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"testing"
 	"time"
 
@@ -774,4 +775,79 @@ func TestReaderWithSchema(t *testing.T) {
 	err = msg.GetSchemaValue(&res)
 	assert.Nil(t, err)
 	assert.Equal(t, *res, value)
+}
+
+func newTestBackoffPolicy(minBackoff, maxBackoff time.Duration) *testBackoffPolicy {
+	return &testBackoffPolicy{
+		curBackoff: 0,
+		minBackoff: minBackoff,
+		maxBackoff: maxBackoff,
+	}
+}
+
+type testBackoffPolicy struct {
+	curBackoff, minBackoff, maxBackoff time.Duration
+	retryTime                          int
+}
+
+func (b *testBackoffPolicy) Next() time.Duration {
+	// Double the delay each time
+	b.curBackoff += b.curBackoff
+	if b.curBackoff.Nanoseconds() < b.minBackoff.Nanoseconds() {
+		b.curBackoff = b.minBackoff
+	} else if b.curBackoff.Nanoseconds() > b.maxBackoff.Nanoseconds() {
+		b.curBackoff = b.maxBackoff
+	}
+	b.retryTime++
+
+	return b.curBackoff
+}
+
+func (b *testBackoffPolicy) Check(startTime time.Time) bool {
+	log.Warn(time.Now().Sub(startTime), b.curBackoff)
+	if time.Now().Sub(startTime) < b.curBackoff-time.Second {
+		return false
+	}
+	if time.Now().Sub(startTime) > b.curBackoff+time.Second {
+		return false
+	}
+	return true
+}
+
+func TestReaderWithBackoffPolicy(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	backoff := newTestBackoffPolicy(1*time.Second, 4*time.Second)
+	_reader, err := client.CreateReader(ReaderOptions{
+		Topic:          "my-topic",
+		StartMessageID: LatestMessageID(),
+		BackoffPolicy:  backoff,
+	})
+	assert.NotNil(t, _reader)
+	assert.Nil(t, err)
+
+	partitionConsumerImp := _reader.(*reader).pc
+	// 1 s
+	startTime := time.Now()
+	partitionConsumerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+
+	// 2 s
+	startTime = time.Now()
+	partitionConsumerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+
+	// 4 s
+	startTime = time.Now()
+	partitionConsumerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
+
+	// 4 s
+	startTime = time.Now()
+	partitionConsumerImp.reconnectToBroker()
+	assert.True(t, backoff.Check(startTime))
 }

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -804,10 +804,10 @@ func (b *testBackoffPolicy) Next() time.Duration {
 
 func (b *testBackoffPolicy) IsExpectedIntervalFrom(startTime time.Time) bool {
 	// Approximately equal to expected interval
-	if time.Now().Sub(startTime) < b.curBackoff-time.Second {
+	if time.Since(startTime) < b.curBackoff-time.Second {
 		return false
 	}
-	if time.Now().Sub(startTime) > b.curBackoff+time.Second {
+	if time.Since(startTime) > b.curBackoff+time.Second {
 		return false
 	}
 	return true


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #872



### Modifications

Add `BackoffPolicy` for `ReaderOptions` and add tests for `BackoffPolicy`.

Because `Reader` uses `partitionConsumer`, just adding a field in `ReaderOptions` is enough.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change has added tests.

### Does this pull request potentially affect one of the following parts:

  - **The public API: (yes)**
  - The default values of configurations: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
