### PR TITLE
[Issue 453] Add NewMessageID() method.

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3342,7 +3342,7 @@ func TestAckWithMessageID(t *testing.T) {
 	assert.Nil(t, err)
 
 	id := message.ID()
-	newId := NewMessageID(id.LedgerID(), id.EntryID(), id.BatchIdx(), id.PartitionIdx())
-	err = consumer.AckID(newId)
+	newID := NewMessageID(id.LedgerID(), id.EntryID(), id.BatchIdx(), id.PartitionIdx())
+	err = consumer.AckID(newID)
 	assert.Nil(t, err)
 }

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -161,6 +161,11 @@ func DeserializeMessageID(data []byte) (MessageID, error) {
 	return deserializeMessageID(data)
 }
 
+// NewMessageID Custom Create MessageID
+func NewMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32) MessageID {
+	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx)
+}
+
 // EarliestMessageID returns a messageID that points to the earliest message available in a topic
 func EarliestMessageID() MessageID {
 	return earliestMessageID


### PR DESCRIPTION
Fixes #453 

### Motivation

Sometimes we need to deal with some messages manually.

```go
pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"

	msgID := &pb.MessageIdData{
		LedgerId:             proto.Uint64(699),
		EntryId:              proto.Uint64(11),
		Partition:            proto.Int32(0),
		BatchIndex:           proto.Int32(0),
	}
	bytes, _ := proto.Marshal(msgID)
	id, _ := pulsar.DeserializeMessageID(bytes)
	err = consumer.AckID(id)
```
Here is the nonsensical serialization and deserialization code, also `pb` is an internal package and cannot be accessed externally.


### Modifications

Add the `NewMessageID()` method.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

