### PR TITLE
[Issue #897] Flush on unbatched producer panics

### DIFF
--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1705,3 +1705,29 @@ func TestProducerWithSchemaAndConsumerSchemaNotFound(t *testing.T) {
 	// should fail with error but not panic
 	assert.Error(t, err)
 }
+
+func TestProducerFlushNOP(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           newTopicName(),
+		DisableBatching: true,
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, producer)
+	defer producer.Close()
+
+	assert.NotPanics(t, func() {
+		ID, err := producer.Send(context.Background(), &ProducerMessage{
+			Payload: []byte("hello"),
+		})
+		producer.Flush()
+		assert.NoError(t, err)
+		assert.NotNil(t, ID)
+	})
+}


### PR DESCRIPTION
Fixes #897

Am not certain if this is the right place or behavior, so opening it up for comments.  It might be that it is fine to panic on a `Flush()` to a non-batching producer, provided it's explicitly documented, but probably not. It's worth noting that it worked in the past, which is how I ran into the issue in the first place, since I left an errant `Flush()` call behind in some tests after disabling batching on a producer.

Master Issue: #<xyz>

### Motivation

No one wants a panic, especially one that is undocumented.

### Modifications

nil check.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

I've included tests.

### Documentation

Since this issue would normally cause a panic, it's probably not necessary to document anything special, especially considering that a similar check is made elsewhere throughout the code. If requested, I can add a comment to the `Flush()` Godoc mentioning that it is a no-op for non-batching producers.