### PR TITLE
[Issue 899] Fix the compression broken when batching is disabled

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -574,6 +574,12 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		compressedPayload = p.compressionProvider.Compress(nil, uncompressedPayload)
 		compressedSize = len(compressedPayload)
 		checkSize = compressedSize
+
+		// set the compress type in msgMetaData
+		compressionType := pb.CompressionType(p.options.CompressionType)
+		if compressionType != pb.CompressionType_NONE {
+			mm.Compression = &compressionType
+		}
 	} else {
 		// final check for batching message is in serializeMessage
 		// this is a double check


### PR DESCRIPTION
Fixes #899 

### Motivation

`MessageMetadata.Compression` is missed to be set when batching is disabled in #805. This pr aims to fix it.

### Modifications

Set the `MessageMetadata.Compression` when batching is disabled and add test code.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


