### PR TITLE
[Issue 183] [Feat] Support cumulative acknowledge

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -231,13 +231,13 @@ type Consumer interface {
 	// AckID the consumption of a single message, identified by its MessageID
 	AckID(MessageID) error
 
-	// CumulativeAck the reception of all the messages in the stream up to (and including)
+	// AckCumulative the reception of all the messages in the stream up to (and including)
 	// the provided message.
-	CumulativeAck(msg Message) error
+	AckCumulative(msg Message) error
 
-	// CumulativeAckID the reception of all the messages in the stream up to (and including)
+	// AckIDCumulative the reception of all the messages in the stream up to (and including)
 	// the provided message, identified by its MessageID
-	CumulativeAckID(msgID MessageID) error
+	AckIDCumulative(msgID MessageID) error
 
 	// ReconsumeLater mark a message for redelivery after custom delay
 	ReconsumeLater(msg Message, delay time.Duration)

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -231,6 +231,14 @@ type Consumer interface {
 	// AckID the consumption of a single message, identified by its MessageID
 	AckID(MessageID) error
 
+	// CumulativeAck the reception of all the messages in the stream up to (and including)
+	// the provided message.
+	CumulativeAck(msg Message) error
+
+	// CumulativeAckID the reception of all the messages in the stream up to (and including)
+	// the provided message, identified by its MessageID
+	CumulativeAckID(msgID MessageID) error
+
 	// ReconsumeLater mark a message for redelivery after custom delay
 	ReconsumeLater(msg Message, delay time.Duration)
 

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -38,8 +38,8 @@ type acker interface {
 	// AckID does not handle errors returned by the Broker side, so no need to wait for doneCh to finish.
 	AckID(id MessageID) error
 	AckIDWithResponse(id MessageID) error
-	CumulativeAckID(msgID MessageID) error
-	CumulativeAckIDWithResponse(msgID MessageID) error
+	AckIDCumulative(msgID MessageID) error
+	AckIDWithResponseCumulative(msgID MessageID) error
 	NackID(id MessageID)
 	NackMsg(msg Message)
 }
@@ -479,24 +479,24 @@ func (c *consumer) AckID(msgID MessageID) error {
 	return c.consumers[msgID.PartitionIdx()].AckID(msgID)
 }
 
-// CumulativeAck the reception of all the messages in the stream up to (and including)
+// AckCumulative the reception of all the messages in the stream up to (and including)
 // the provided message, identified by its MessageID
-func (c *consumer) CumulativeAck(msg Message) error {
-	return c.CumulativeAckID(msg.ID())
+func (c *consumer) AckCumulative(msg Message) error {
+	return c.AckIDCumulative(msg.ID())
 }
 
-// CumulativeAckID the reception of all the messages in the stream up to (and including)
+// AckIDCumulative the reception of all the messages in the stream up to (and including)
 // the provided message, identified by its MessageID
-func (c *consumer) CumulativeAckID(msgID MessageID) error {
+func (c *consumer) AckIDCumulative(msgID MessageID) error {
 	if err := c.checkMsgIDPartition(msgID); err != nil {
 		return err
 	}
 
 	if c.options.AckWithResponse {
-		return c.consumers[msgID.PartitionIdx()].CumulativeAckIDWithResponse(msgID)
+		return c.consumers[msgID.PartitionIdx()].AckIDWithResponseCumulative(msgID)
 	}
 
-	return c.consumers[msgID.PartitionIdx()].CumulativeAckID(msgID)
+	return c.consumers[msgID.PartitionIdx()].AckIDCumulative(msgID)
 }
 
 // ReconsumeLater mark a message for redelivery after custom delay

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -38,6 +38,8 @@ type acker interface {
 	// AckID does not handle errors returned by the Broker side, so no need to wait for doneCh to finish.
 	AckID(id MessageID) error
 	AckIDWithResponse(id MessageID) error
+	CumulativeAckID(msgID MessageID) error
+	CumulativeAckIDWithResponse(msgID MessageID) error
 	NackID(id MessageID)
 	NackMsg(msg Message)
 }
@@ -475,6 +477,26 @@ func (c *consumer) AckID(msgID MessageID) error {
 	}
 
 	return c.consumers[msgID.PartitionIdx()].AckID(msgID)
+}
+
+// CumulativeAck the reception of all the messages in the stream up to (and including)
+// the provided message, identified by its MessageID
+func (c *consumer) CumulativeAck(msg Message) error {
+	return c.CumulativeAckID(msg.ID())
+}
+
+// CumulativeAckID the reception of all the messages in the stream up to (and including)
+// the provided message, identified by its MessageID
+func (c *consumer) CumulativeAckID(msgID MessageID) error {
+	if err := c.checkMsgIDPartition(msgID); err != nil {
+		return err
+	}
+
+	if c.options.AckWithResponse {
+		return c.consumers[msgID.PartitionIdx()].CumulativeAckIDWithResponse(msgID)
+	}
+
+	return c.consumers[msgID.PartitionIdx()].CumulativeAckID(msgID)
 }
 
 // ReconsumeLater mark a message for redelivery after custom delay

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -143,6 +143,33 @@ func (c *multiTopicConsumer) AckID(msgID MessageID) error {
 	return mid.consumer.AckID(msgID)
 }
 
+// CumulativeAck the reception of all the messages in the stream up to (and including)
+// the provided message
+func (c *multiTopicConsumer) CumulativeAck(msg Message) error {
+	return c.CumulativeAckID(msg.ID())
+}
+
+// CumulativeAckID the reception of all the messages in the stream up to (and including)
+// the provided message, identified by its MessageID
+func (c *multiTopicConsumer) CumulativeAckID(msgID MessageID) error {
+	mid, ok := toTrackingMessageID(msgID)
+	if !ok {
+		c.log.Warnf("invalid message id type %T", msgID)
+		return errors.New("invalid message id type in multi_consumer")
+	}
+
+	if mid.consumer == nil {
+		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
+		return errors.New("unable to ack message because consumer is nil")
+	}
+
+	if c.options.AckWithResponse {
+		return mid.consumer.CumulativeAckIDWithResponse(msgID)
+	}
+
+	return mid.consumer.CumulativeAckID(msgID)
+}
+
 func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 	names, err := validateTopicNames(msg.Topic())
 	if err != nil {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -143,15 +143,15 @@ func (c *multiTopicConsumer) AckID(msgID MessageID) error {
 	return mid.consumer.AckID(msgID)
 }
 
-// CumulativeAck the reception of all the messages in the stream up to (and including)
+// AckCumulative the reception of all the messages in the stream up to (and including)
 // the provided message
-func (c *multiTopicConsumer) CumulativeAck(msg Message) error {
-	return c.CumulativeAckID(msg.ID())
+func (c *multiTopicConsumer) AckCumulative(msg Message) error {
+	return c.AckIDCumulative(msg.ID())
 }
 
-// CumulativeAckID the reception of all the messages in the stream up to (and including)
+// AckIDCumulative the reception of all the messages in the stream up to (and including)
 // the provided message, identified by its MessageID
-func (c *multiTopicConsumer) CumulativeAckID(msgID MessageID) error {
+func (c *multiTopicConsumer) AckIDCumulative(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
@@ -164,10 +164,10 @@ func (c *multiTopicConsumer) CumulativeAckID(msgID MessageID) error {
 	}
 
 	if c.options.AckWithResponse {
-		return mid.consumer.CumulativeAckIDWithResponse(msgID)
+		return mid.consumer.AckIDWithResponseCumulative(msgID)
 	}
 
-	return mid.consumer.CumulativeAckID(msgID)
+	return mid.consumer.AckIDCumulative(msgID)
 }
 
 func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -479,15 +479,15 @@ func (pc *partitionConsumer) AckID(msgID MessageID) error {
 	return nil
 }
 
-func (pc *partitionConsumer) CumulativeAckID(msgID MessageID) error {
-	return pc.internalCumulativeAckID(msgID, false)
+func (pc *partitionConsumer) AckIDCumulative(msgID MessageID) error {
+	return pc.internalAckIDCumulative(msgID, false)
 }
 
-func (pc *partitionConsumer) CumulativeAckIDWithResponse(msgID MessageID) error {
-	return pc.internalCumulativeAckID(msgID, true)
+func (pc *partitionConsumer) AckIDWithResponseCumulative(msgID MessageID) error {
+	return pc.internalAckIDCumulative(msgID, true)
 }
 
-func (pc *partitionConsumer) internalCumulativeAckID(msgID MessageID, withResponse bool) error {
+func (pc *partitionConsumer) internalAckIDCumulative(msgID MessageID, withResponse bool) error {
 	if state := pc.getConsumerState(); state == consumerClosed || state == consumerClosing {
 		pc.log.WithField("state", state).Error("Failed to ack by closing or closed consumer")
 		return errors.New("consumer state is closed")

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -187,15 +187,15 @@ func (c *regexConsumer) AckID(msgID MessageID) error {
 	return mid.consumer.AckID(msgID)
 }
 
-// CumulativeAck the reception of all the messages in the stream up to (and including)
+// AckCumulative the reception of all the messages in the stream up to (and including)
 // the provided message.
-func (c *regexConsumer) CumulativeAck(msg Message) error {
-	return c.CumulativeAckID(msg.ID())
+func (c *regexConsumer) AckCumulative(msg Message) error {
+	return c.AckIDCumulative(msg.ID())
 }
 
-// CumulativeAckID the reception of all the messages in the stream up to (and including)
+// AckIDCumulative the reception of all the messages in the stream up to (and including)
 // the provided message, identified by its MessageID
-func (c *regexConsumer) CumulativeAckID(msgID MessageID) error {
+func (c *regexConsumer) AckIDCumulative(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
@@ -208,10 +208,10 @@ func (c *regexConsumer) CumulativeAckID(msgID MessageID) error {
 	}
 
 	if c.options.AckWithResponse {
-		return mid.consumer.CumulativeAckIDWithResponse(msgID)
+		return mid.consumer.AckIDWithResponseCumulative(msgID)
 	}
 
-	return mid.consumer.CumulativeAckID(msgID)
+	return mid.consumer.AckIDCumulative(msgID)
 }
 
 func (c *regexConsumer) Nack(msg Message) {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -42,7 +42,7 @@ import (
 
 var (
 	adminURL  = "http://localhost:8080"
-	lookupURL = "pulsar://10.238.18.160:6650"
+	lookupURL = "pulsar://localhost:6650"
 )
 
 func TestProducerConsumer(t *testing.T) {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -775,7 +775,7 @@ func TestConsumerNoBatchCumulativeAck(t *testing.T) {
 
 		if i == N/2-1 {
 			// cumulative acks the first half of messages
-			consumer.CumulativeAck(msg)
+			consumer.AckCumulative(msg)
 		}
 	}
 
@@ -862,7 +862,7 @@ func TestConsumerBatchCumulativeAck(t *testing.T) {
 
 		if i == N-1 {
 			// cumulative acks the first half of messages
-			consumer.CumulativeAck(msg)
+			consumer.AckCumulative(msg)
 		}
 	}
 
@@ -1601,7 +1601,7 @@ func TestCumulativeAckWithResponse(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	err = consumer.CumulativeAck(msg)
+	err = consumer.AckCumulative(msg)
 	assert.Nil(t, err)
 }
 

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -105,6 +106,25 @@ func (id trackingMessageID) ack() bool {
 		return id.tracker.ack(int(id.batchIdx))
 	}
 	return true
+}
+
+func (id trackingMessageID) ackCumulative() bool {
+	if id.tracker != nil && id.batchIdx > -1 {
+		return id.tracker.ackCumulative(int(id.batchIdx))
+	}
+	return true
+}
+
+func (id trackingMessageID) prev() trackingMessageID {
+	return trackingMessageID{
+		messageID: messageID{
+			ledgerID:     id.ledgerID,
+			entryID:      id.entryID - 1,
+			partitionIdx: id.partitionIdx,
+		},
+		tracker:  id.tracker,
+		consumer: id.consumer,
+	}
 }
 
 func (id messageID) isEntryIDValid() bool {
@@ -367,8 +387,9 @@ func newAckTracker(size int) *ackTracker {
 
 type ackTracker struct {
 	sync.Mutex
-	size     int
-	batchIDs *big.Int
+	size           int
+	batchIDs       *big.Int
+	prevBatchAcked uint32
 }
 
 func (t *ackTracker) ack(batchID int) bool {
@@ -379,6 +400,25 @@ func (t *ackTracker) ack(batchID int) bool {
 	defer t.Unlock()
 	t.batchIDs = t.batchIDs.SetBit(t.batchIDs, batchID, 0)
 	return len(t.batchIDs.Bits()) == 0
+}
+
+func (t *ackTracker) ackCumulative(batchID int) bool {
+	if batchID < 0 {
+		return true
+	}
+	mask := big.NewInt(-1)
+	t.Lock()
+	defer t.Unlock()
+	t.batchIDs.And(t.batchIDs, mask.Lsh(mask, uint(batchID+1)))
+	return len(t.batchIDs.Bits()) == 0
+}
+
+func (t *ackTracker) hasPrevBatchAcked() bool {
+	return atomic.LoadUint32(&t.prevBatchAcked) == 1
+}
+
+func (t *ackTracker) setPrevBatchAcked() {
+	atomic.StoreUint32(&t.prevBatchAcked, 1)
 }
 
 func (t *ackTracker) completed() bool {

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -81,6 +81,17 @@ func TestAckTracker(t *testing.T) {
 	}
 	assert.Equal(t, true, tracker.completed())
 
+	tracker = newAckTracker(1000)
+	for i := 0; i < 1000; i++ {
+		if i < 999 {
+			assert.False(t, tracker.ackCumulative(i))
+			assert.False(t, tracker.completed())
+		} else {
+			assert.True(t, tracker.ackCumulative(i))
+			assert.True(t, tracker.completed())
+		}
+	}
+
 	// test large number 1000 cumulative
 	tracker = newAckTracker(1000)
 

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -80,6 +80,12 @@ func TestAckTracker(t *testing.T) {
 
 	}
 	assert.Equal(t, true, tracker.completed())
+
+	// test large number 1000 cumulative
+	tracker = newAckTracker(1000)
+
+	assert.Equal(t, true, tracker.ackCumulative(999))
+	assert.Equal(t, true, tracker.completed())
 }
 
 func TestAckingMessageIDBatchOne(t *testing.T) {

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -72,6 +72,14 @@ func (c *mockConsumer) AckID(msgID pulsar.MessageID) error {
 	return nil
 }
 
+func (c *mockConsumer) CumulativeAck(msg pulsar.Message) error {
+	return nil
+}
+
+func (c *mockConsumer) CumulativeAckID(msgID pulsar.MessageID) error {
+	return nil
+}
+
 func (c *mockConsumer) ReconsumeLater(msg pulsar.Message, delay time.Duration) {}
 
 func (c *mockConsumer) Nack(msg pulsar.Message) {}

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -72,11 +72,11 @@ func (c *mockConsumer) AckID(msgID pulsar.MessageID) error {
 	return nil
 }
 
-func (c *mockConsumer) CumulativeAck(msg pulsar.Message) error {
+func (c *mockConsumer) AckCumulative(msg pulsar.Message) error {
 	return nil
 }
 
-func (c *mockConsumer) CumulativeAckID(msgID pulsar.MessageID) error {
+func (c *mockConsumer) AckIDCumulative(msgID pulsar.MessageID) error {
 	return nil
 }
 


### PR DESCRIPTION
Master Issue: #183 

### Motivation

Cumulative acknowledgement is a useful feature. Users can use this feature to ack messages in the stream up to (and including) provided message. 

Issue #183 shows more details.

### Modifications

- Add two api `AckCumulative` and `AckIDCumulative` for `Consumer`.

``` golang

// AckCumulative the reception of all the messages in the stream up to (and including)
// the provided message.
AckCumulative(msg Message) error

// AckIDCumulative the reception of all the messages in the stream up to (and including)
// the provided message, identified by its MessageID
AckIDCumulative(msgID MessageID) error

```

- Add the `AckCumulative` and `AckIDCumulative` implementation for `consumer`, `multiTopicConsumer`, `regexConsumer` and `mockConsumer`.

- Add the unit test `TestConsumerNoBatchCumulativeAck` `TestConsumerBatchCumulativeAck` `TestCumulativeAckWithResponse` for cumulative ack in `consumer_test.go`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - The public API: yes
