### PR TITLE
fix cnx headersAndPayload nil panic

### DIFF
--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -43,7 +43,7 @@ func newConnectionReader(cnx *connection) *connectionReader {
 func (r *connectionReader) readFromConnection() {
 	for {
 		cmd, headersAndPayload, err := r.readSingleCommand()
-		if err != nil {
+		if err != nil || headersAndPayload == nil {
 			if !r.cnx.closed() {
 				r.cnx.log.WithError(err).Infof("Error reading from connection")
 				r.cnx.Close()


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/900

Motivation
- avoid headersAndPayload nil cause panic

Modifications

- check headersAndPayload is nil.