### PR TITLE
[improve][ci] add -failfast flag to improve test process

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -31,7 +31,7 @@ go build -o bin/pulsar-perf ./perf
 
 scripts/pulsar-test-service-start.sh
 
-go test -race -coverprofile=/tmp/coverage -timeout=20m -v ./...
+go test -race -failfast -coverprofile=/tmp/coverage -timeout=20m -v ./...
 go tool cover -html=/tmp/coverage -o coverage.html
 
 scripts/pulsar-test-service-stop.sh


### PR DESCRIPTION
Even if one test case failed, all other tests will still run anyway. Add `failfast` can stop other test cases if any test failed.

FYI: https://stackoverflow.com/questions/32046192/stop-on-first-test-failure-with-go-test