### PR TITLE
[Issue 918] [Refactor] Remove the `clearMessageQueuesCh` in `partitionConsumer.dispatcher()`

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -132,6 +132,11 @@ type ConsumerOptions struct {
 	// Default is false
 	RetryEnable bool
 
+	// StartMessageIDInclusive, if true, the consumer will start at including the given position
+	// of any reset operation like `Consumer.Seek()`.
+	// Default is `false` and the reader will start from the "next" message
+	StartMessageIDInclusive bool
+
 	// MessageChannel sets a `MessageChannel` for the consumer
 	// When a message is received, it will be pushed to the channel for consumption
 	MessageChannel chan ConsumerMessage

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -364,6 +364,7 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 				subProperties:               subProperties,
 				replicateSubscriptionState:  c.options.ReplicateSubscriptionState,
 				startMessageID:              trackingMessageID{},
+				startMessageIDInclusive:     c.options.StartMessageIDInclusive,
 				subscriptionMode:            durable,
 				readCompacted:               c.options.ReadCompacted,
 				interceptors:                c.options.Interceptors,


### PR DESCRIPTION
Master Issue: #918 

### Motivation

The two chanel `clearMessageQueuesCh` and `clearQueueCb` just need to keep one.

For more details please check #918.

### Modifications

- Remove the `clearMessageQueuesCh` in `partitionConsumer.dispatcher()`
- Modify the `clearQueueCb` in `partitionConsumer.dispatcher()`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
