### PR TITLE
[Issue 923] Remove the outdated interface description of `SeekByTime`

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -264,9 +264,6 @@ type Consumer interface {
 
 	// SeekByTime resets the subscription associated with this consumer to a specific message publish time.
 	//
-	// Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the seek() on
-	// the individual partitions.
-	//
 	// @param time
 	//            the message publish time when to reposition the subscription
 	//


### PR DESCRIPTION
Fixes #923 

### Motivation

Remove the outdated interface description of `SeekByTime`. More details here #923.

### Modifications

Remove the outdated interface description of `SeekByTime`

### Verifying this change

- [x] Make sure that the change passes the CI checks.
