### PR TITLE
Handle nil value message correctly in table-view

### DIFF
--- a/pulsar/table_view_impl.go
+++ b/pulsar/table_view_impl.go
@@ -245,11 +245,17 @@ func (tv *TableViewImpl) handleMessage(msg Message) {
 	tv.dataMu.Lock()
 	defer tv.dataMu.Unlock()
 
-	payload := reflect.Indirect(reflect.New(tv.options.SchemaValueType)).Interface()
-	if err := msg.GetSchemaValue(&payload); err != nil {
-		tv.logger.Errorf("msg.GetSchemaValue() failed with %w; msg is %v", msg, err)
+	var payload interface{}
+	if len(msg.Payload()) == 0 {
+		delete(tv.data, msg.Key())
+	} else {
+		payload = reflect.Indirect(reflect.New(tv.options.SchemaValueType)).Interface()
+		if err := msg.GetSchemaValue(&payload); err != nil {
+			tv.logger.Errorf("msg.GetSchemaValue() failed with %w; msg is %v", msg, err)
+		}
+		tv.data[msg.Key()] = payload
 	}
-	tv.data[msg.Key()] = payload
+
 	for _, listener := range tv.listeners {
 		if err := listener(msg.Key(), payload); err != nil {
 			tv.logger.Errorf("table view listener failed for %v: %w", msg, err)

--- a/pulsar/table_view_test.go
+++ b/pulsar/table_view_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTableView(t *testing.T) {
@@ -114,21 +115,21 @@ func TestPublishNilValue(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	for tv.Size() < 1 {
-		time.Sleep(time.Second * 1)
-	}
+	require.Eventually(t, func() bool {
+		return tv.Size() == 1
+	}, 5*time.Second, 100*time.Millisecond)
 
 	assert.Equal(t, *(tv.Get("key-1").(*string)), "value-1")
 
-	// Send nil value
+	// send nil value
 	_, err = producer.Send(context.Background(), &ProducerMessage{
 		Key: "key-1",
 	})
 	assert.NoError(t, err)
 
-	for tv.Size() >= 1 {
-		time.Sleep(time.Second * 1)
-	}
+	require.Eventually(t, func() bool {
+		return tv.Size() == 0
+	}, 5*time.Second, 100*time.Millisecond)
 
 	_, err = producer.Send(context.Background(), &ProducerMessage{
 		Key:   "key-2",
@@ -136,9 +137,9 @@ func TestPublishNilValue(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	for tv.Size() < 1 {
-		time.Sleep(time.Second * 1)
-	}
+	require.Eventually(t, func() bool {
+		return tv.Size() == 1
+	}, 5*time.Second, 100*time.Millisecond)
 
 	assert.Equal(t, *(tv.Get("key-2").(*string)), "value-2")
 }


### PR DESCRIPTION
### Motivation

Currently, when we publish a nil value message([tombstones](https://en.wikipedia.org/wiki/Tombstone_(data_store))) to a compacted topic used to `TableView`, the `TableView` will store a nil value in the map, but we should remove this key since this is a tombstone.

### Modifications

* Handle nil value message correctly in table-view
* Add unit test to verify.


