### PR TITLE
[feature] Support batch index ACK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/99designs/keyring v1.2.1
 	github.com/AthenZ/athenz v1.10.39
 	github.com/DataDog/zstd v1.5.0
+	github.com/bits-and-blooms/bitset v1.4.0
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b
 	github.com/davecgh/go-spew v1.1.1
 	github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bits-and-blooms/bitset v1.4.0 h1:+YZ8ePm+He2pU3dZlIZiOeAKfrBkXi1lSrXJ/Xzgbu8=
+github.com/bits-and-blooms/bitset v1.4.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=

--- a/integration-tests/conf/standalone.conf
+++ b/integration-tests/conf/standalone.conf
@@ -292,3 +292,5 @@ globalZookeeperServers=
 
 # Deprecated. Use brokerDeleteInactiveTopicsFrequencySeconds
 brokerServicePurgeInactiveFrequencyInSeconds=60
+
+acknowledgmentAtBatchIndexLevelEnabled=true

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -211,6 +211,10 @@ type ConsumerOptions struct {
 	// AutoAckIncompleteChunk sets whether consumer auto acknowledges incomplete chunked message when it should
 	// be removed (e.g.the chunked message pending queue is full). (default: false)
 	AutoAckIncompleteChunk bool
+
+	// Enable or disable batch index acknowledgment. To enable this feature, ensure batch index acknowledgment
+	// is enabled on the broker side. (default: false)
+	EnableBatchIndexAcknowledgment bool
 }
 
 // Consumer is an interface that abstracts behavior of Pulsar's consumer

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -397,6 +397,7 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 				expireTimeOfIncompleteChunk: c.options.ExpireTimeOfIncompleteChunk,
 				autoAckIncompleteChunk:      c.options.AutoAckIncompleteChunk,
 				consumerEventListener:       c.options.EventListener,
+				enableBatchIndexAck:         c.options.EnableBatchIndexAcknowledgment,
 			}
 			cons, err := newPartitionConsumer(c, c.client, opts, c.messageCh, c.dlq, c.metrics)
 			ch <- ConsumerError{

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3841,7 +3841,142 @@ func TestAckWithMessageID(t *testing.T) {
 	assert.Nil(t, err)
 
 	id := message.ID()
-	newID := NewMessageID(id.LedgerID(), id.EntryID(), id.BatchIdx(), id.PartitionIdx())
+	newID := NewMessageID(id.LedgerID(), id.EntryID(), id.BatchIdx(), id.PartitionIdx(), 0)
 	err = consumer.AckID(newID)
 	assert.Nil(t, err)
+}
+
+func TestBatchIndexAck(t *testing.T) {
+	tests := []struct {
+		AckWithResponse bool
+		Cumulative      bool
+	}{
+		{
+			AckWithResponse: true,
+			Cumulative:      true,
+		},
+		{
+			AckWithResponse: true,
+			Cumulative:      false,
+		},
+		{
+			AckWithResponse: false,
+			Cumulative:      true,
+		},
+		{
+			AckWithResponse: false,
+			Cumulative:      false,
+		},
+	}
+	for _, params := range tests {
+		t.Run(fmt.Sprintf("TestBatchIndexAck_WithResponse_%v_Cumulative_%v",
+			params.AckWithResponse, params.Cumulative),
+			func(t *testing.T) {
+				runBatchIndexAckTest(t, params.AckWithResponse, params.Cumulative)
+			})
+	}
+}
+
+func runBatchIndexAckTest(t *testing.T, ackWithResponse bool, cumulative bool) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+
+	topic := newTopicName()
+	createConsumer := func() Consumer {
+		consumer, err := client.Subscribe(ConsumerOptions{
+			Topic:                          topic,
+			SubscriptionName:               "my-sub",
+			AckWithResponse:                ackWithResponse,
+			EnableBatchIndexAcknowledgment: true,
+		})
+		assert.Nil(t, err)
+		return consumer
+	}
+
+	consumer := createConsumer()
+
+	duration, err := time.ParseDuration("1h")
+	assert.Nil(t, err)
+
+	const BatchingMaxSize int = 2 * 5
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:                   topic,
+		DisableBatching:         false,
+		BatchingMaxMessages:     uint(BatchingMaxSize),
+		BatchingMaxSize:         uint(1024 * 1024 * 10),
+		BatchingMaxPublishDelay: duration,
+	})
+	assert.Nil(t, err)
+	for i := 0; i < BatchingMaxSize; i++ {
+		producer.SendAsync(context.Background(), &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("msg-%d", i)),
+		}, func(id MessageID, producerMessage *ProducerMessage, err error) {
+			assert.Nil(t, err)
+			log.Printf("Sent to %v:%d:%d", id, id.BatchIdx(), id.BatchSize())
+		})
+	}
+	assert.Nil(t, producer.Flush())
+
+	msgIds := make([]MessageID, BatchingMaxSize)
+	for i := 0; i < BatchingMaxSize; i++ {
+		message, err := consumer.Receive(context.Background())
+		assert.Nil(t, err)
+		msgIds[i] = message.ID()
+		log.Printf("Received %v from %v:%d:%d", string(message.Payload()), message.ID(),
+			message.ID().BatchIdx(), message.ID().BatchSize())
+	}
+
+	// Acknowledge half of the messages
+	if cumulative {
+		msgID := msgIds[BatchingMaxSize/2-1]
+		consumer.AckIDCumulative(msgID)
+		log.Printf("Acknowledge %v:%d cumulatively\n", msgID, msgID.BatchIdx())
+	} else {
+		for i := 0; i < BatchingMaxSize; i++ {
+			msgID := msgIds[i]
+			if i%2 == 0 {
+				consumer.AckID(msgID)
+				log.Printf("Acknowledge %v:%d\n", msgID, msgID.BatchIdx())
+			}
+		}
+	}
+	consumer.Close()
+	consumer = createConsumer()
+
+	for i := 0; i < BatchingMaxSize/2; i++ {
+		message, err := consumer.Receive(context.Background())
+		assert.Nil(t, err)
+		log.Printf("Received %v from %v:%d:%d", string(message.Payload()), message.ID(),
+			message.ID().BatchIdx(), message.ID().BatchSize())
+		index := i*2 + 1
+		if cumulative {
+			index = i + BatchingMaxSize/2
+		}
+		assert.Equal(t, []byte(fmt.Sprintf("msg-%d", index)), message.Payload())
+		assert.Equal(t, msgIds[index].BatchIdx(), message.ID().BatchIdx())
+		// We should not acknowledge message.ID() here because message.ID() shares a different
+		// tracker with msgIds
+		if !cumulative {
+			msgID := msgIds[index]
+			consumer.AckID(msgID)
+			log.Printf("Acknowledge %v:%d\n", msgID, msgID.BatchIdx())
+		}
+	}
+	if cumulative {
+		msgID := msgIds[BatchingMaxSize-1]
+		consumer.AckIDCumulative(msgID)
+		log.Printf("Acknowledge %v:%d cumulatively\n", msgID, msgID.BatchIdx())
+	}
+	consumer.Close()
+	consumer = createConsumer()
+	_, err = producer.Send(context.Background(), &ProducerMessage{Payload: []byte("end-marker")})
+	assert.Nil(t, err)
+	msg, err := consumer.Receive(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, "end-marker", string(msg.Payload()))
+
+	client.Close()
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3841,7 +3841,7 @@ func TestAckWithMessageID(t *testing.T) {
 	assert.Nil(t, err)
 
 	id := message.ID()
-	newID := NewMessageID(id.LedgerID(), id.EntryID(), id.BatchIdx(), id.PartitionIdx(), 0)
+	newID := NewMessageID(id.LedgerID(), id.EntryID(), id.BatchIdx(), id.PartitionIdx())
 	err = consumer.AckID(newID)
 	assert.Nil(t, err)
 }

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMessageId(t *testing.T) {
-	id := newMessageID(1, 2, 3, 4)
+	id := newMessageID(1, 2, 3, 4, 5)
 	bytes := id.Serialize()
 
 	id2, err := DeserializeMessageID(bytes)
@@ -35,6 +35,7 @@ func TestMessageId(t *testing.T) {
 	assert.Equal(t, int64(2), id2.(messageID).entryID)
 	assert.Equal(t, int32(3), id2.(messageID).batchIdx)
 	assert.Equal(t, int32(4), id2.(messageID).partitionIdx)
+	assert.Equal(t, int32(5), id2.(messageID).batchSize)
 
 	id, err = DeserializeMessageID(nil)
 	assert.Error(t, err)
@@ -47,11 +48,12 @@ func TestMessageId(t *testing.T) {
 
 func TestMessageIdGetFuncs(t *testing.T) {
 	// test LedgerId,EntryId,BatchIdx,PartitionIdx
-	id := newMessageID(1, 2, 3, 4)
+	id := newMessageID(1, 2, 3, 4, 5)
 	assert.Equal(t, int64(1), id.LedgerID())
 	assert.Equal(t, int64(2), id.EntryID())
 	assert.Equal(t, int32(3), id.BatchIdx())
 	assert.Equal(t, int32(4), id.PartitionIdx())
+	assert.Equal(t, int32(5), id.BatchSize())
 }
 
 func TestAckTracker(t *testing.T) {
@@ -101,7 +103,7 @@ func TestAckTracker(t *testing.T) {
 
 func TestAckingMessageIDBatchOne(t *testing.T) {
 	tracker := newAckTracker(1)
-	msgID := newTrackingMessageID(1, 1, 0, 0, tracker)
+	msgID := newTrackingMessageID(1, 1, 0, 0, 0, tracker)
 	assert.Equal(t, true, msgID.ack())
 	assert.Equal(t, true, tracker.completed())
 }
@@ -109,8 +111,8 @@ func TestAckingMessageIDBatchOne(t *testing.T) {
 func TestAckingMessageIDBatchTwo(t *testing.T) {
 	tracker := newAckTracker(2)
 	ids := []trackingMessageID{
-		newTrackingMessageID(1, 1, 0, 0, tracker),
-		newTrackingMessageID(1, 1, 1, 0, tracker),
+		newTrackingMessageID(1, 1, 0, 0, 0, tracker),
+		newTrackingMessageID(1, 1, 1, 0, 0, tracker),
 	}
 
 	assert.Equal(t, false, ids[0].ack())
@@ -120,8 +122,8 @@ func TestAckingMessageIDBatchTwo(t *testing.T) {
 	// try reverse order
 	tracker = newAckTracker(2)
 	ids = []trackingMessageID{
-		newTrackingMessageID(1, 1, 0, 0, tracker),
-		newTrackingMessageID(1, 1, 1, 0, tracker),
+		newTrackingMessageID(1, 1, 0, 0, 0, tracker),
+		newTrackingMessageID(1, 1, 1, 0, 0, tracker),
 	}
 	assert.Equal(t, false, ids[1].ack())
 	assert.Equal(t, true, ids[0].ack())

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -154,6 +154,9 @@ type MessageID interface {
 
 	// PartitionIdx returns the message partitionIdx
 	PartitionIdx() int32
+
+	// BatchSize returns 0 or the batch size, which must be greater than BatchIdx()
+	BatchSize() int32
 }
 
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation
@@ -162,8 +165,8 @@ func DeserializeMessageID(data []byte) (MessageID, error) {
 }
 
 // NewMessageID Custom Create MessageID
-func NewMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32) MessageID {
-	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx)
+func NewMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32, batchSize int32) MessageID {
+	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx, batchSize)
 }
 
 // EarliestMessageID returns a messageID that points to the earliest message available in a topic

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -165,8 +165,8 @@ func DeserializeMessageID(data []byte) (MessageID, error) {
 }
 
 // NewMessageID Custom Create MessageID
-func NewMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32, batchSize int32) MessageID {
-	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx, batchSize)
+func NewMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32) MessageID {
+	return newMessageID(ledgerID, entryID, batchIdx, partitionIdx, 0)
 }
 
 // EarliestMessageID returns a messageID that points to the earliest message available in a topic

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -426,6 +426,10 @@ func (id *myMessageID) BatchIdx() int32 {
 	return id.BatchIdx()
 }
 
+func (id *myMessageID) BatchSize() int32 {
+	return id.BatchSize()
+}
+
 func (id *myMessageID) PartitionIdx() int32 {
 	return id.PartitionIdx()
 }


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/894

### Modifications

Add an `EnableBatchIndexAcknowledgment` to specify whether batch index ACK is enabled. Since this feature requires the conversion between a bit set and its underlying long array, which is similar to Java's `BitSet`, this commit introduces github.com/bits-and-blooms/bitset dependency to replace the `big.Int` based implementation of the bit set.

Add a `BatchSize()` method to `MessageId` to indicate the size of the `ack_set` field. When the batch index ACK happens, convert the `[]uint64` to the `[]int64` as the `ack_set` field in `CommandAck`. When receiving messages, convert the `ack_set` field in `CommandMessage` to filter the acknowledged single messages.

Remove the duplicated code in `AckID` and `AckIDWithResponse`.

### Verifications

`TestBatchIndexAck` is added to cover the case whether `AckWithResponse` is enabled and both individual and cumulative ACK.