### PR TITLE
Migrate from the deprecated io/ioutil package

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17, 1.18, 1.19]
+        go-version: [1.16, 1.17, 1.18, 1.19]
     steps:
       - name: clean docker cache
         run: |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ CGo based library.
 
 > **Note**:
 >
-> While this library should work with Golang versions as early as 1.15, any bugs specific to versions earlier than 1.18 may not be fixed.
+> While this library should work with Golang versions as early as 1.16, any bugs specific to versions earlier than 1.18 may not be fixed.
 
 ## Status
 

--- a/integration-tests/license_test.go
+++ b/integration-tests/license_test.go
@@ -18,7 +18,6 @@
 package license_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -83,7 +82,7 @@ func TestLicense(t *testing.T) {
 
 		switch filepath.Ext(path) {
 		case ".go":
-			src, err := ioutil.ReadFile(path)
+			src, err := os.ReadFile(path)
 			if err != nil {
 				return nil
 			}
@@ -96,7 +95,7 @@ func TestLicense(t *testing.T) {
 		case ".yaml":
 			fallthrough
 		case ".conf":
-			src, err := ioutil.ReadFile(path)
+			src, err := os.ReadFile(path)
 			if err != nil {
 				return nil
 			}

--- a/oauth2/authorization_tokenretriever_test.go
+++ b/oauth2/authorization_tokenretriever_test.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -328,7 +328,7 @@ func buildResponse(statusCode int, body interface{}) *http.Response {
 	resp := &http.Response{
 		StatusCode: statusCode,
 		Header:     map[string][]string{},
-		Body:       ioutil.NopCloser(bytes.NewReader(b)),
+		Body:       io.NopCloser(bytes.NewReader(b)),
 	}
 	if strings.HasPrefix(string(b), "{") {
 		resp.Header.Add("Content-Type", "application/json")

--- a/oauth2/client_credentials_provider.go
+++ b/oauth2/client_credentials_provider.go
@@ -19,7 +19,7 @@ package oauth2
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -54,7 +54,7 @@ func (k *KeyFileProvider) GetClientCredentials() (*KeyFile, error) {
 	switch {
 	case strings.HasPrefix(k.KeyFile, FILE):
 		filename := strings.TrimPrefix(k.KeyFile, FILE)
-		keyFile, err = ioutil.ReadFile(filename)
+		keyFile, err = os.ReadFile(filename)
 	case strings.HasPrefix(k.KeyFile, DATA):
 		keyFile = []byte(strings.TrimPrefix(k.KeyFile, DATA))
 	case strings.HasPrefix(k.KeyFile, "data:"):
@@ -64,7 +64,7 @@ func (k *KeyFileProvider) GetClientCredentials() (*KeyFile, error) {
 		}
 		keyFile = url.Data
 	default:
-		keyFile, err = ioutil.ReadFile(k.KeyFile)
+		keyFile, err = os.ReadFile(k.KeyFile)
 	}
 	if err != nil {
 		return nil, err

--- a/oauth2/client_credentials_provider_test.go
+++ b/oauth2/client_credentials_provider_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -45,7 +44,7 @@ func TestNewClientCredentialsProviderFromKeyFile(t *testing.T) {
 
 	b, err := json.Marshal(keyFile)
 	require.NoError(t, err)
-	tmpFile, err := ioutil.TempFile("", "key-file")
+	tmpFile, err := os.CreateTemp("", "key-file")
 	require.NoError(t, err)
 	defer func(name string) {
 		_ = os.Remove(name)

--- a/perf/pulsar-perf-go.go
+++ b/perf/pulsar-perf-go.go
@@ -20,7 +20,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -57,7 +56,7 @@ func NewClient() (pulsar.Client, error) {
 
 	if clientArgs.TokenFile != "" {
 		// read JWT from the file
-		tokenBytes, err := ioutil.ReadFile(clientArgs.TokenFile)
+		tokenBytes, err := os.ReadFile(clientArgs.TokenFile)
 		if err != nil {
 			log.WithError(err).Errorf("failed to read Pulsar JWT from a file %s", clientArgs.TokenFile)
 			os.Exit(1)

--- a/pulsar/auth/athenz.go
+++ b/pulsar/auth/athenz.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -117,7 +117,7 @@ func (p *athenzAuthProvider) Init() error {
 		}
 		keyData = key
 	} else if uriSt.Scheme == "file" {
-		key, err := ioutil.ReadFile(uriSt.Path)
+		key, err := os.ReadFile(uriSt.Path)
 		if err != nil {
 			return err
 		}

--- a/pulsar/auth/athenz_test.go
+++ b/pulsar/auth/athenz_test.go
@@ -20,7 +20,7 @@ package auth
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -69,7 +69,7 @@ func (m *MockRoleToken) RoleTokenValue() (string, error) {
 
 func MockZmsNewTokenBuilder(domain, name string, privateKeyPEM []byte, keyVersion string) (zms.TokenBuilder, error) {
 	// assertion
-	key, err := ioutil.ReadFile(tlsClientKeyPath)
+	key, err := os.ReadFile(tlsClientKeyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/auth/basic_test.go
+++ b/pulsar/auth/basic_test.go
@@ -19,7 +19,7 @@ package auth
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -51,7 +51,7 @@ func TestNewAuthenticationBasicWithParams(t *testing.T) {
 	resp, err := client.Get(s.URL)
 	require.NoError(t, err)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, []byte("Basic YWRtaW46MTIzNDU2"), body)

--- a/pulsar/auth/oauth2_test.go
+++ b/pulsar/auth/oauth2_test.go
@@ -19,7 +19,6 @@ package auth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -64,7 +63,7 @@ func mockKeyFile(server string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	kf, err := ioutil.TempFile(pwd, "test_oauth2")
+	kf, err := os.CreateTemp(pwd, "test_oauth2")
 	if err != nil {
 		return "", err
 	}

--- a/pulsar/auth/token.go
+++ b/pulsar/auth/token.go
@@ -20,8 +20,8 @@ package auth
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -69,7 +69,7 @@ func NewAuthenticationTokenFromSupplier(tokenSupplier func() (string, error)) Pr
 func NewAuthenticationTokenFromFile(tokenFilePath string) Provider {
 	return &tokenAuthProvider{
 		tokenSupplier: func() (string, error) {
-			data, err := ioutil.ReadFile(tokenFilePath)
+			data, err := os.ReadFile(tokenFilePath)
 			if err != nil {
 				return "", err
 			}

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -189,7 +188,7 @@ func TestTLSAuthWithCertSupplier(t *testing.T) {
 }
 
 func TestTokenAuth(t *testing.T) {
-	token, err := ioutil.ReadFile(tokenFilePath)
+	token, err := os.ReadFile(tokenFilePath)
 	assert.NoError(t, err)
 
 	client, err := NewClient(ClientOptions{
@@ -212,7 +211,7 @@ func TestTokenAuthWithSupplier(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: serviceURL,
 		Authentication: NewAuthenticationTokenFromSupplier(func() (s string, err error) {
-			token, err := ioutil.ReadFile(tokenFilePath)
+			token, err := os.ReadFile(tokenFilePath)
 			if err != nil {
 				return "", err
 			}
@@ -287,7 +286,7 @@ func mockKeyFile(server string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	kf, err := ioutil.TempFile(pwd, "test_oauth2")
+	kf, err := os.CreateTemp(pwd, "test_oauth2")
 	if err != nil {
 		return "", err
 	}
@@ -838,7 +837,7 @@ func TestHTTPSAuthWithCertSupplier(t *testing.T) {
 }
 
 func TestHTTPTokenAuth(t *testing.T) {
-	token, err := ioutil.ReadFile(tokenFilePath)
+	token, err := os.ReadFile(tokenFilePath)
 	assert.NoError(t, err)
 
 	client, err := NewClient(ClientOptions{
@@ -861,7 +860,7 @@ func TestHTTPTokenAuthWithSupplier(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: webServiceURL,
 		Authentication: NewAuthenticationTokenFromSupplier(func() (s string, err error) {
-			token, err := ioutil.ReadFile(tokenFilePath)
+			token, err := os.ReadFile(tokenFilePath)
 			if err != nil {
 				return "", err
 			}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -21,9 +21,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -3422,7 +3422,7 @@ func (d *EncKeyReader) PrivateKey(keyName string, keyMeta map[string]string) (*c
 }
 
 func readKey(keyName, path string, keyMeta map[string]string) (*crypto.EncryptionKeyInfo, error) {
-	key, err := ioutil.ReadFile(path)
+	key, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/crypto/default_crypto_Key_reader.go
+++ b/pulsar/crypto/default_crypto_Key_reader.go
@@ -17,7 +17,7 @@
 
 package crypto
 
-import "io/ioutil"
+import "os"
 
 // FileKeyReader default implementation of KeyReader
 type FileKeyReader struct {
@@ -43,7 +43,7 @@ func (d *FileKeyReader) PrivateKey(keyName string, keyMeta map[string]string) (*
 }
 
 func readKey(keyName, path string, keyMeta map[string]string) (*EncryptionKeyInfo, error) {
-	key, err := ioutil.ReadFile(path)
+	key, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/helper_for_test.go
+++ b/pulsar/helper_for_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"strings"
@@ -110,7 +109,7 @@ func httpDo(method string, requestPath string, in interface{}, out interface{}) 
 	}
 
 	if out != nil {
-		outBytes, err := ioutil.ReadAll(resp.Body)
+		outBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/pulsar/internal/compression/compression_bench_test.go
+++ b/pulsar/internal/compression/compression_bench_test.go
@@ -18,7 +18,7 @@
 package compression
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -27,7 +27,7 @@ const (
 )
 
 func testCompression(b *testing.B, provider Provider) {
-	data, err := ioutil.ReadFile(dataSampleFile)
+	data, err := os.ReadFile(dataSampleFile)
 	if err != nil {
 		b.Error(err)
 	}
@@ -45,7 +45,7 @@ func testCompression(b *testing.B, provider Provider) {
 
 func testDecompression(b *testing.B, provider Provider) {
 	// Read data sample file
-	data, err := ioutil.ReadFile(dataSampleFile)
+	data, err := os.ReadFile(dataSampleFile)
 	if err != nil {
 		b.Error(err)
 	}
@@ -97,7 +97,7 @@ func BenchmarkDecompression(b *testing.B) {
 func BenchmarkCompressionParallel(b *testing.B) {
 	b.ReportAllocs()
 
-	data, err := ioutil.ReadFile(dataSampleFile)
+	data, err := os.ReadFile(dataSampleFile)
 	if err != nil {
 		b.Error(err)
 	}

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -22,9 +22,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -979,7 +979,7 @@ func (c *connection) getTLSConfig() (*tls.Config, error) {
 	}
 
 	if c.tlsOptions.TrustCertsFilePath != "" {
-		caCerts, err := ioutil.ReadFile(c.tlsOptions.TrustCertsFilePath)
+		caCerts, err := os.ReadFile(c.tlsOptions.TrustCertsFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/pulsar/internal/http_client.go
+++ b/pulsar/internal/http_client.go
@@ -23,9 +23,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -209,7 +209,7 @@ func (c *httpClient) GetWithOptions(endpoint string, obj interface{}, params map
 				return nil, err
 			}
 		} else {
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return nil, err
 			}
@@ -311,7 +311,7 @@ func safeRespClose(resp *http.Response) {
 // responseError is used to parse a response into a client error
 func responseError(resp *http.Response) error {
 	var e error
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	reason := ""
 	code := resp.StatusCode
 	if err != nil {
@@ -338,7 +338,7 @@ func getDefaultTransport(tlsConfig *TLSOptions) (http.RoundTripper, error) {
 			InsecureSkipVerify: tlsConfig.AllowInsecureConnection,
 		}
 		if len(tlsConfig.TrustCertsFilePath) > 0 {
-			rootCA, err := ioutil.ReadFile(tlsConfig.TrustCertsFilePath)
+			rootCA, err := os.ReadFile(tlsConfig.TrustCertsFilePath)
 			if err != nil {
 				return nil, err
 			}

--- a/pulsar/internal/lookup_service_test.go
+++ b/pulsar/internal/lookup_service_test.go
@@ -20,7 +20,7 @@ package internal
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 	"testing"
@@ -574,7 +574,7 @@ func mockHTTPGetLookupResult(obj interface{}) error {
 		"httpUrl": "http://broker-1:8080",
 		"httpUrlTls": ""
   	}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+	r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 	dec := json.NewDecoder(r)
 	err := dec.Decode(obj)
 	return err
@@ -584,7 +584,7 @@ func mockHTTPGetPartitionedTopicMetadataResult(obj interface{}) error {
 	jsonResponse := `{
    		"partitions": 1
   	}`
-	r := ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse)))
+	r := io.NopCloser(bytes.NewReader([]byte(jsonResponse)))
 	dec := json.NewDecoder(r)
 	err := dec.Decode(obj)
 	return err


### PR DESCRIPTION
### Motivation
The `io/ioutil` package has been deprecated in go1.16, see the [release notes](https://go.dev/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` calls with their new definitions in the `io` and `os` packages.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
