### PR TITLE
Fix golangci-lint verify failed.

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

CI starts failing: https://github.com/apache/pulsar-client-go/actions/runs/4101318705/jobs/7072982772

It looks like a golang-lint 1.51.x [issue](https://github.com/golangci/golangci-lint/releases/tag/v1.51.1)

### Modifications
- Fixed golang-lint@1.50.1 version


