### PR TITLE
[fix][ci]The cluster standalone is created twice

### DIFF
--- a/integration-tests/conf/standalone.conf
+++ b/integration-tests/conf/standalone.conf
@@ -38,9 +38,6 @@ bindAddress=0.0.0.0
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
 advertisedAddress=localhost
 
-# Name of the cluster to which this broker belongs to
-clusterName=standalone
-
 # Zookeeper session timeout in milliseconds
 zooKeeperSessionTimeoutMillis=30000
 


### PR DESCRIPTION
### Motivation
The cluster 'standalone' is created twice. Because the cluster is created in `PulsarStandalone` first, the creation in `scripts/pulsar-test-service-stop.sh` will be failed.
Code in the master branch:
*  Create in `PulsarStandalone` if it does not exist.
    ```java
        final List<String> clusters = admin.clusters().getClusters();
        if (!clusters.contains(cluster)) {
            admin.clusters().createCluster(cluster, ClusterData.builder()
                    .serviceUrl(broker.getWebServiceAddress())
                    .serviceUrlTls(broker.getWebServiceAddressTls())
                    .brokerServiceUrl(broker.getBrokerServiceUrl())
                    .brokerServiceUrlTls(broker.getBrokerServiceUrlTls())
                    .build());
            }
     ````

* Create in `scripts/pulsar-test-service-stop.sh`
https://github.com/apache/pulsar-client-go/blob/93a5a765b9ff9d756d0adc5d2de30f31e4cbf29f/scripts/pulsar-test-service-start.sh#L54-L60

Failed job: https://github.com/apache/pulsar-client-go/actions/runs/4170721803/jobs/7219958508

### Modifications

Delete the configuration of cluster `standalone` in standalone.conf.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
