### PR TITLE
[feat] Support memory limit for producer.

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -144,6 +144,10 @@ type ClientOptions struct {
 	MetricsRegisterer prometheus.Registerer
 
 	EnableTransaction bool
+
+	// Limit of client memory usage (in byte). The 64M default can guarantee a high producer throughput.
+	// Config less than 0 indicates off memory limit.
+	MemoryLimitBytes int64
 }
 
 // Client represents a pulsar client

--- a/pulsar/error.go
+++ b/pulsar/error.go
@@ -110,6 +110,9 @@ const (
 	InvalidStatus
 	// TransactionError means this is a transaction related error
 	TransactionError
+
+	// ClientMemoryBufferIsFull client limit buffer is full
+	ClientMemoryBufferIsFull
 )
 
 // Error implement error interface, composed of two parts: msg and result.
@@ -216,6 +219,8 @@ func getResultStr(r Result) string {
 		return "ProducerClosed"
 	case SchemaFailure:
 		return "SchemaFailure"
+	case ClientMemoryBufferIsFull:
+		return "ClientMemoryBufferIsFull"
 	default:
 		return fmt.Sprintf("Result(%d)", r)
 	}

--- a/pulsar/internal/channel_cond.go
+++ b/pulsar/internal/channel_cond.go
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+type ChCond struct {
+	L sync.Locker
+	n unsafe.Pointer
+}
+
+func NewCond(l sync.Locker) *ChCond {
+	c := &ChCond{L: l}
+	n := make(chan struct{})
+	c.n = unsafe.Pointer(&n)
+	return c
+}
+
+// Wait for Broadcast calls. Similar to regular sync.Cond
+func (c *ChCond) Wait() {
+	n := c.notifyChan()
+	c.L.Unlock()
+	<-n
+	c.L.Lock()
+}
+
+// WaitWithContext Same as Wait() call, but the end condition can also be controlled through the context.
+func (c *ChCond) WaitWithContext(ctx context.Context) bool {
+	n := c.notifyChan()
+	c.L.Unlock()
+	defer c.L.Lock()
+	select {
+	case <-n:
+		return true
+	case <-ctx.Done():
+		return false
+	default:
+		return true
+	}
+}
+
+// Broadcast wakes all goroutines waiting on c.
+// It is not required for the caller to hold c.L during the call.
+func (c *ChCond) Broadcast() {
+	n := make(chan struct{})
+	ptrOld := atomic.SwapPointer(&c.n, unsafe.Pointer(&n))
+	close(*(*chan struct{})(ptrOld))
+}
+
+func (c *ChCond) notifyChan() <-chan struct{} {
+	ptr := atomic.LoadPointer(&c.n)
+	return *((*chan struct{})(ptr))
+}

--- a/pulsar/internal/channel_cond.go
+++ b/pulsar/internal/channel_cond.go
@@ -26,13 +26,15 @@ import (
 
 type chCond struct {
 	L sync.Locker
-	n unsafe.Pointer
+	// The pointer to the channel, the channel pointed to may change,
+	// because we will use the channel's close mechanism to implement broadcast notifications.
+	notifyChanPointer unsafe.Pointer
 }
 
 func newCond(l sync.Locker) *chCond {
 	c := &chCond{L: l}
 	n := make(chan struct{})
-	c.n = unsafe.Pointer(&n)
+	c.notifyChanPointer = unsafe.Pointer(&n)
 	return c
 }
 
@@ -63,11 +65,12 @@ func (c *chCond) waitWithContext(ctx context.Context) bool {
 // It is not required for the caller to hold c.L during the call.
 func (c *chCond) broadcast() {
 	n := make(chan struct{})
-	ptrOld := atomic.SwapPointer(&c.n, unsafe.Pointer(&n))
+	ptrOld := atomic.SwapPointer(&c.notifyChanPointer, unsafe.Pointer(&n))
+	// close old channels to trigger broadcast.
 	close(*(*chan struct{})(ptrOld))
 }
 
 func (c *chCond) notifyChan() <-chan struct{} {
-	ptr := atomic.LoadPointer(&c.n)
+	ptr := atomic.LoadPointer(&c.notifyChanPointer)
 	return *((*chan struct{})(ptr))
 }

--- a/pulsar/internal/channel_cond_test.go
+++ b/pulsar/internal/channel_cond_test.go
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestChCond(t *testing.T) {
+	cond := NewCond(&sync.Mutex{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		cond.L.Lock()
+		cond.Wait()
+		cond.L.Unlock()
+		wg.Done()
+	}()
+	time.Sleep(10 * time.Millisecond)
+	cond.Broadcast()
+	wg.Wait()
+}
+
+func TestChCondWithContext(t *testing.T) {
+	cond := NewCond(&sync.Mutex{})
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	go func() {
+		cond.L.Lock()
+		cond.WaitWithContext(ctx)
+		cond.L.Unlock()
+		wg.Done()
+	}()
+	cancel()
+	wg.Wait()
+}

--- a/pulsar/internal/channel_cond_test.go
+++ b/pulsar/internal/channel_cond_test.go
@@ -25,28 +25,28 @@ import (
 )
 
 func TestChCond(t *testing.T) {
-	cond := NewCond(&sync.Mutex{})
+	cond := newCond(&sync.Mutex{})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		cond.L.Lock()
-		cond.Wait()
+		cond.wait()
 		cond.L.Unlock()
 		wg.Done()
 	}()
 	time.Sleep(10 * time.Millisecond)
-	cond.Broadcast()
+	cond.broadcast()
 	wg.Wait()
 }
 
 func TestChCondWithContext(t *testing.T) {
-	cond := NewCond(&sync.Mutex{})
+	cond := newCond(&sync.Mutex{})
 	wg := sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
 	go func() {
 		cond.L.Lock()
-		cond.WaitWithContext(ctx)
+		cond.waitWithContext(ctx)
 		cond.L.Unlock()
 		wg.Done()
 	}()

--- a/pulsar/internal/memory_limit_controller.go
+++ b/pulsar/internal/memory_limit_controller.go
@@ -35,14 +35,14 @@ type MemoryLimitController interface {
 
 type memoryLimitController struct {
 	limit        int64
-	chCond       ChCond
+	chCond       *ChCond
 	currentUsage int64
 }
 
 func NewMemoryLimitController(limit int64) MemoryLimitController {
 	mlc := &memoryLimitController{
 		limit:  limit,
-		chCond: *NewCond(&sync.Mutex{}),
+		chCond: NewCond(&sync.Mutex{}),
 	}
 	return mlc
 }

--- a/pulsar/internal/memory_limit_controller.go
+++ b/pulsar/internal/memory_limit_controller.go
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+type MemoryLimitController interface {
+	ReserveMemory(ctx context.Context, size int64) bool
+	TryReserveMemory(size int64) bool
+	ForceReserveMemory(size int64)
+	ReleaseMemory(size int64)
+	CurrentUsage() int64
+	CurrentUsagePercent() float64
+	IsMemoryLimited() bool
+}
+
+type memoryLimitController struct {
+	limit        int64
+	chCond       ChCond
+	currentUsage int64
+}
+
+func NewMemoryLimitController(limit int64) MemoryLimitController {
+	mlc := &memoryLimitController{
+		limit:  limit,
+		chCond: *NewCond(&sync.Mutex{}),
+	}
+	return mlc
+}
+
+func (m *memoryLimitController) ReserveMemory(ctx context.Context, size int64) bool {
+	if !m.TryReserveMemory(size) {
+		m.chCond.L.Lock()
+		defer m.chCond.L.Unlock()
+
+		for !m.TryReserveMemory(size) {
+			if !m.chCond.WaitWithContext(ctx) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (m *memoryLimitController) TryReserveMemory(size int64) bool {
+	for {
+		current := atomic.LoadInt64(&m.currentUsage)
+		newUsage := current + size
+
+		// This condition means we allowed one request to go over the limit.
+		if m.IsMemoryLimited() && current > m.limit {
+			return false
+		}
+
+		if atomic.CompareAndSwapInt64(&m.currentUsage, current, newUsage) {
+			return true
+		}
+	}
+}
+
+func (m *memoryLimitController) ForceReserveMemory(size int64) {
+	atomic.AddInt64(&m.currentUsage, size)
+}
+
+func (m *memoryLimitController) ReleaseMemory(size int64) {
+	newUsage := atomic.AddInt64(&m.currentUsage, -size)
+	if newUsage+size > m.limit && newUsage <= m.limit {
+		m.chCond.Broadcast()
+	}
+}
+
+func (m *memoryLimitController) CurrentUsage() int64 {
+	return atomic.LoadInt64(&m.currentUsage)
+}
+
+func (m *memoryLimitController) CurrentUsagePercent() float64 {
+	return float64(atomic.LoadInt64(&m.currentUsage)) / float64(m.limit)
+}
+
+func (m *memoryLimitController) IsMemoryLimited() bool {
+	return m.limit > 0
+}

--- a/pulsar/internal/memory_limit_controller_test.go
+++ b/pulsar/internal/memory_limit_controller_test.go
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimit(t *testing.T) {
+
+	mlc := NewMemoryLimitController(100)
+
+	for i := 0; i < 101; i++ {
+		assert.True(t, mlc.TryReserveMemory(1))
+	}
+
+	assert.False(t, mlc.TryReserveMemory(1))
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+	assert.Equal(t, 1.01, mlc.CurrentUsagePercent())
+
+	mlc.ReleaseMemory(1)
+	assert.Equal(t, int64(100), mlc.CurrentUsage())
+	assert.Equal(t, 1.0, mlc.CurrentUsagePercent())
+
+	assert.True(t, mlc.TryReserveMemory(1))
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+
+	mlc.ForceReserveMemory(99)
+	assert.False(t, mlc.TryReserveMemory(1))
+	assert.Equal(t, int64(200), mlc.CurrentUsage())
+	assert.Equal(t, 2.0, mlc.CurrentUsagePercent())
+
+	mlc.ReleaseMemory(50)
+	assert.False(t, mlc.TryReserveMemory(1))
+	assert.Equal(t, int64(150), mlc.CurrentUsage())
+	assert.Equal(t, 1.5, mlc.CurrentUsagePercent())
+}
+
+func TestDisableLimit(t *testing.T) {
+	mlc := NewMemoryLimitController(-1)
+	assert.True(t, mlc.TryReserveMemory(1000000))
+	assert.True(t, mlc.ReserveMemory(context.Background(), 1000000))
+	mlc.ReleaseMemory(1000000)
+	assert.Equal(t, int64(1000000), mlc.CurrentUsage())
+}
+
+func TestMultiGoroutineTryReserveMem(t *testing.T) {
+	mlc := NewMemoryLimitController(10000)
+
+	// Multi goroutine try reserve memory.
+	wg := sync.WaitGroup{}
+
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for i := 0; i < 1000; i++ {
+				assert.True(t, mlc.TryReserveMemory(1))
+			}
+			wg.Done()
+		}()
+	}
+	assert.True(t, mlc.TryReserveMemory(1))
+	wg.Wait()
+	assert.False(t, mlc.TryReserveMemory(1))
+	assert.Equal(t, int64(10001), mlc.CurrentUsage())
+	assert.Equal(t, 1.0001, mlc.CurrentUsagePercent())
+}
+
+func TestReserveWithContext(t *testing.T) {
+	mlc := NewMemoryLimitController(100)
+	assert.True(t, mlc.TryReserveMemory(101))
+	gorNum := 10
+
+	// Reserve ctx timeout
+	waitGroup := sync.WaitGroup{}
+	waitGroup.Add(gorNum)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	for i := 0; i < gorNum; i++ {
+		go func() {
+			assert.False(t, mlc.ReserveMemory(ctx, 1))
+			waitGroup.Done()
+		}()
+	}
+	waitGroup.Wait()
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+
+	// Reserve ctx cancel
+	waitGroup.Add(gorNum)
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	for i := 0; i < gorNum; i++ {
+		go func() {
+			assert.False(t, mlc.ReserveMemory(cancelCtx, 1))
+			waitGroup.Done()
+		}()
+	}
+	cancel()
+	waitGroup.Wait()
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+}
+
+func TestBlocking(t *testing.T) {
+	mlc := NewMemoryLimitController(100)
+	assert.True(t, mlc.TryReserveMemory(101))
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+	assert.Equal(t, 1.01, mlc.CurrentUsagePercent())
+
+	gorNum := 10
+	chs := make([]chan int, gorNum)
+	for i := 0; i < gorNum; i++ {
+		chs[i] = make(chan int, 1)
+		go reserveMemory(mlc, chs[i])
+	}
+
+	// The threads are blocked since the quota is full
+	for i := 0; i < gorNum; i++ {
+		assert.False(t, awaitCh(chs[i]))
+	}
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+
+	mlc.ReleaseMemory(int64(gorNum))
+	for i := 0; i < gorNum; i++ {
+		assert.True(t, awaitCh(chs[i]))
+	}
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+}
+
+func TestStepRelease(t *testing.T) {
+	mlc := NewMemoryLimitController(100)
+	assert.True(t, mlc.TryReserveMemory(101))
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+	assert.Equal(t, 1.01, mlc.CurrentUsagePercent())
+
+	gorNum := 10
+	ch := make(chan int, 1)
+	for i := 0; i < gorNum; i++ {
+		go reserveMemory(mlc, ch)
+	}
+
+	// The threads are blocked since the quota is full
+	assert.False(t, awaitCh(ch))
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+
+	for i := 0; i < gorNum; i++ {
+		mlc.ReleaseMemory(1)
+		assert.True(t, awaitCh(ch))
+		assert.False(t, awaitCh(ch))
+	}
+	assert.Equal(t, int64(101), mlc.CurrentUsage())
+}
+
+func reserveMemory(mlc MemoryLimitController, ch chan int) {
+	mlc.ReserveMemory(context.Background(), 1)
+	ch <- 1
+}
+
+func awaitCh(ch chan int) bool {
+	select {
+	case <-ch:
+		return true
+	case <-time.After(100 * time.Millisecond):
+		return false
+	}
+}

--- a/pulsar/internal/memory_limit_controller_test.go
+++ b/pulsar/internal/memory_limit_controller_test.go
@@ -36,11 +36,11 @@ func TestLimit(t *testing.T) {
 
 	assert.False(t, mlc.TryReserveMemory(1))
 	assert.Equal(t, int64(101), mlc.CurrentUsage())
-	assert.Equal(t, 1.01, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 1.01, mlc.CurrentUsagePercent(), 0.000001)
 
 	mlc.ReleaseMemory(1)
 	assert.Equal(t, int64(100), mlc.CurrentUsage())
-	assert.Equal(t, 1.0, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 1.0, mlc.CurrentUsagePercent(), 0.000001)
 
 	assert.True(t, mlc.TryReserveMemory(1))
 	assert.Equal(t, int64(101), mlc.CurrentUsage())
@@ -48,12 +48,12 @@ func TestLimit(t *testing.T) {
 	mlc.ForceReserveMemory(99)
 	assert.False(t, mlc.TryReserveMemory(1))
 	assert.Equal(t, int64(200), mlc.CurrentUsage())
-	assert.Equal(t, 2.0, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 2.0, mlc.CurrentUsagePercent(), 0.000001)
 
 	mlc.ReleaseMemory(50)
 	assert.False(t, mlc.TryReserveMemory(1))
 	assert.Equal(t, int64(150), mlc.CurrentUsage())
-	assert.Equal(t, 1.5, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 1.5, mlc.CurrentUsagePercent(), 0.000001)
 }
 
 func TestDisableLimit(t *testing.T) {
@@ -83,7 +83,7 @@ func TestMultiGoroutineTryReserveMem(t *testing.T) {
 	wg.Wait()
 	assert.False(t, mlc.TryReserveMemory(1))
 	assert.Equal(t, int64(10001), mlc.CurrentUsage())
-	assert.Equal(t, 1.0001, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 1.0001, mlc.CurrentUsagePercent(), 0.000001)
 }
 
 func TestReserveWithContext(t *testing.T) {
@@ -123,7 +123,7 @@ func TestBlocking(t *testing.T) {
 	mlc := NewMemoryLimitController(100)
 	assert.True(t, mlc.TryReserveMemory(101))
 	assert.Equal(t, int64(101), mlc.CurrentUsage())
-	assert.Equal(t, 1.01, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 1.01, mlc.CurrentUsagePercent(), 0.000001)
 
 	gorNum := 10
 	chs := make([]chan int, gorNum)
@@ -149,7 +149,7 @@ func TestStepRelease(t *testing.T) {
 	mlc := NewMemoryLimitController(100)
 	assert.True(t, mlc.TryReserveMemory(101))
 	assert.Equal(t, int64(101), mlc.CurrentUsage())
-	assert.Equal(t, 1.01, mlc.CurrentUsagePercent())
+	assert.InDelta(t, 1.01, mlc.CurrentUsagePercent(), 0.000001)
 
 	gorNum := 10
 	ch := make(chan int, 1)

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1836,8 +1836,10 @@ func TestMemLimitRejectProducerMessages(t *testing.T) {
 	assert.ErrorContains(t, err, getResultStr(ClientMemoryBufferIsFull))
 
 	// flush pending msg
-	producer1.Flush()
-	producer2.Flush()
+	err = producer1.Flush()
+	assert.NoError(t, err)
+	err = producer2.Flush()
+	assert.NoError(t, err)
 	assert.Equal(t, int64(0), c.(*client).memLimit.CurrentUsage())
 
 	_, err = producer1.Send(context.Background(), &ProducerMessage{
@@ -1894,7 +1896,8 @@ func TestMemLimitContextCancel(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	producer.Flush()
+	err = producer.Flush()
+	assert.NoError(t, err)
 	assert.Equal(t, int64(0), c.(*client).memLimit.CurrentUsage())
 
 	_, err = producer.Send(context.Background(), &ProducerMessage{

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1779,3 +1779,126 @@ func TestWaitForExclusiveProducer(t *testing.T) {
 	producer1.Close()
 	wg.Wait()
 }
+
+func TestMemLimitRejectProducerMessages(t *testing.T) {
+
+	c, err := NewClient(ClientOptions{
+		URL:              serviceURL,
+		MemoryLimitBytes: 100 * 1024,
+	})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	topicName := newTopicName()
+	producer1, _ := c.CreateProducer(ProducerOptions{
+		Topic:                   topicName,
+		DisableBlockIfQueueFull: true,
+		DisableBatching:         false,
+		BatchingMaxPublishDelay: 100 * time.Second,
+		SendTimeout:             2 * time.Second,
+	})
+
+	producer2, _ := c.CreateProducer(ProducerOptions{
+		Topic:                   topicName,
+		DisableBlockIfQueueFull: true,
+		DisableBatching:         false,
+		BatchingMaxPublishDelay: 100 * time.Second,
+		SendTimeout:             2 * time.Second,
+	})
+
+	n := 101
+	for i := 0; i < n/2; i++ {
+		producer1.SendAsync(context.Background(), &ProducerMessage{
+			Payload: make([]byte, 1024),
+		}, func(id MessageID, message *ProducerMessage, e error) {})
+
+		producer2.SendAsync(context.Background(), &ProducerMessage{
+			Payload: make([]byte, 1024),
+		}, func(id MessageID, message *ProducerMessage, e error) {})
+	}
+	// Last message in order to reach the limit
+	producer1.SendAsync(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	}, func(id MessageID, message *ProducerMessage, e error) {})
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int64(n*1024), c.(*client).memLimit.CurrentUsage())
+
+	_, err = producer1.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, getResultStr(ClientMemoryBufferIsFull))
+
+	_, err = producer2.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, getResultStr(ClientMemoryBufferIsFull))
+
+	// flush pending msg
+	producer1.Flush()
+	producer2.Flush()
+	assert.Equal(t, int64(0), c.(*client).memLimit.CurrentUsage())
+
+	_, err = producer1.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	assert.NoError(t, err)
+	_, err = producer2.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	assert.NoError(t, err)
+}
+
+func TestMemLimitContextCancel(t *testing.T) {
+
+	c, err := NewClient(ClientOptions{
+		URL:              serviceURL,
+		MemoryLimitBytes: 100 * 1024,
+	})
+	assert.NoError(t, err)
+	defer c.Close()
+
+	topicName := newTopicName()
+	producer, _ := c.CreateProducer(ProducerOptions{
+		Topic:                   topicName,
+		DisableBlockIfQueueFull: false,
+		DisableBatching:         false,
+		BatchingMaxPublishDelay: 100 * time.Second,
+		SendTimeout:             2 * time.Second,
+	})
+
+	n := 101
+	ctx, cancel := context.WithCancel(context.Background())
+	for i := 0; i < n; i++ {
+		producer.SendAsync(ctx, &ProducerMessage{
+			Payload: make([]byte, 1024),
+		}, func(id MessageID, message *ProducerMessage, e error) {})
+	}
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int64(n*1024), c.(*client).memLimit.CurrentUsage())
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		producer.SendAsync(ctx, &ProducerMessage{
+			Payload: make([]byte, 1024),
+		}, func(id MessageID, message *ProducerMessage, e error) {
+			assert.Error(t, e)
+			assert.ErrorContains(t, e, getResultStr(TimeoutError))
+			wg.Done()
+		})
+	}()
+
+	// cancel pending msg
+	cancel()
+	wg.Wait()
+
+	producer.Flush()
+	assert.Equal(t, int64(0), c.(*client).memLimit.CurrentUsage())
+
+	_, err = producer.Send(context.Background(), &ProducerMessage{
+		Payload: make([]byte, 1024),
+	})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Master Issue: #927 

### Motivation

#927 

### Modifications

- Added `channel_cond` class to enhance `sync.cond` to support wait that can accept context.
- Added the `memory_limit_controller` class.
- Producer adds memory limit relate logic.


### Verifying this change
- Added `channel_cond_test` to cover `channel_cond`
- Added `memory_limit_controller_test` to cover `mem_mory_limit_controller`
- Added `TestMemLimitRejectProducerMessages` and `TestMemLimitContextCancel ` to cover producer relate logic.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  
