### PR TITLE
Upgrade the pulsar version that unit tests depend on to 2.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG GOLANG_IMAGE=golang:latest
 FROM $PULSAR_IMAGE as pulsar
 FROM $GOLANG_IMAGE
 
-RUN apt-get update && apt-get install -y openjdk-11-jre-headless ca-certificates
+RUN apt-get update && apt-get install -y openjdk-17-jre-headless ca-certificates
 
 COPY --from=pulsar /pulsar /pulsar
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 #
 
 IMAGE_NAME = pulsar-client-go-test:latest
-PULSAR_VERSION ?= 2.10.3
+PULSAR_VERSION ?= 2.11.0
 PULSAR_IMAGE = apachepulsar/pulsar:$(PULSAR_VERSION)
 GO_VERSION ?= 1.18
 GOLANG_IMAGE = golang:$(GO_VERSION)

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -319,9 +319,6 @@ func TestConsumerKeyShared(t *testing.T) {
 		}
 	}
 
-	assert.NotEqual(t, 0, receivedConsumer1)
-	assert.NotEqual(t, 0, receivedConsumer2)
-
 	t.Logf("TestConsumerKeyShared received messages consumer1: %d consumser2: %d\n",
 		receivedConsumer1, receivedConsumer2)
 	assert.Equal(t, 100, receivedConsumer1+receivedConsumer2)
@@ -2580,8 +2577,6 @@ func TestKeyBasedBatchProducerConsumerKeyShared(t *testing.T) {
 		}
 	}
 
-	assert.NotEqual(t, 0, receivedConsumer1)
-	assert.NotEqual(t, 0, receivedConsumer2)
 	assert.Equal(t, len(consumer1Keys)*MsgBatchCount, receivedConsumer1)
 	assert.Equal(t, len(consumer2Keys)*MsgBatchCount, receivedConsumer2)
 
@@ -2763,9 +2758,6 @@ func TestConsumerKeySharedWithOrderingKey(t *testing.T) {
 			consumer2.Ack(cm.Message)
 		}
 	}
-
-	assert.NotEqual(t, 0, receivedConsumer1)
-	assert.NotEqual(t, 0, receivedConsumer2)
 
 	t.Logf(
 		"TestConsumerKeySharedWithOrderingKey received messages consumer1: %d consumser2: %d\n",

--- a/pulsar/internal/lookup_service.go
+++ b/pulsar/internal/lookup_service.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 
@@ -257,7 +258,13 @@ func (ls *lookupService) GetTopicsOfNamespace(namespace string, mode GetTopicsOf
 		return []string{}, errors.New(res.Response.GetError().String())
 	}
 
-	return res.Response.GetTopicsOfNamespaceResponse.GetTopics(), nil
+	var topics []string
+	for _, topic := range res.Response.GetTopicsOfNamespaceResponse.GetTopics() {
+		if !strings.Contains(topic, "__change_events") {
+			topics = append(topics, topic)
+		}
+	}
+	return topics, nil
 }
 
 func (ls *lookupService) Close() {}


### PR DESCRIPTION
### Motivation
Pulsar 2.11.0 has been [released](https://github.com/apache/pulsar/releases/tag/v2.11.0). Upgrade the versions that unit tests depend on so that they are compatible with the latest versions and support new features.


### Modifications
- Upgrade the pulsar version that unit tests depend on to 2.11.0.
- The `GetTopicsOfNamespace` method filters system topics. (This is the break change for broker v2.11.0, which has started an [email discussion](https://lists.apache.org/thread/qhm0zbfw0wfd1m5vj977w002qmkr5lt9). Temporarily fix it on the client side first)
- Fix incorrect HTTP requests. (Because in v2.11.0 will [validate bad requests](https://github.com/apache/pulsar/pull/16577))
- Remove key_shared subscribe consumer unit test-related assert(that every consumer will receive the message), Because consistent hashing is [enabled by default in v2.11.0](https://github.com/apache/pulsar/pull/13352), in scenarios where the number of keys is small, all messages may be sent to the same consumer.

### Verifying this change
- All tests passed.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (upgrade)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
