### PR TITLE
Fix flaky Key_Shared subscription related tests

### DIFF
--- a/integration-tests/conf/standalone.conf
+++ b/integration-tests/conf/standalone.conf
@@ -313,3 +313,5 @@ systemTopicEnabled=true
 # The schema compatibility strategy is used for system topics.
 # Available values: ALWAYS_INCOMPATIBLE, ALWAYS_COMPATIBLE, BACKWARD, FORWARD, FULL, BACKWARD_TRANSITIVE, FORWARD_TRANSITIVE, FULL_TRANSITIVE
 systemTopicSchemaCompatibilityStrategy=ALWAYS_COMPATIBLE
+
+subscriptionKeySharedUseConsistentHashing=false


### PR DESCRIPTION
### Motivation

After https://github.com/apache/pulsar-client-go/pull/953, the Pulsar version was upgraded from 2.8.3 to 2.10.3. However, [PIP-119](https://github.com/apache/pulsar/pull/13352) changed the default value of `subscriptionKeySharedUseConsistentHashing` to true, which leads to the flakiness of Key_Shared subscription related tests.

Example: https://github.com/apache/pulsar-client-go/actions/runs/4291098473/jobs/7475868787

### Modifications

Configure `subscriptionKeySharedUseConsistentHashing` with `false`.