### PR TITLE
[refactor]: Refactor the toTrackingMessageID()

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -538,6 +538,10 @@ func (c *consumer) ReconsumeLaterWithCustomProperties(msg Message, customPropert
 	}
 
 	msgID := c.messageID(msg.ID())
+	if msgID == nil {
+		return
+	}
+
 	props := make(map[string]string)
 	for k, v := range msg.Properties() {
 		props[k] = v
@@ -589,6 +593,10 @@ func (c *consumer) Nack(msg Message) {
 	}
 	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
 		mid := c.messageID(msg.ID())
+		if mid == nil {
+			return
+		}
+
 		if mid.consumer != nil {
 			mid.consumer.NackID(msg.ID())
 			return

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -531,10 +531,13 @@ func (c *consumer) ReconsumeLaterWithCustomProperties(msg Message, customPropert
 	if delay < 0 {
 		delay = 0
 	}
-	msgID := c.messageID(msg.ID())
-	if msgID == nil {
+
+	if !checkMessageIDType(msg.ID()) {
+		c.log.Warnf("invalid message id type %T", msg.ID())
 		return
 	}
+
+	msgID := c.messageID(msg.ID())
 	props := make(map[string]string)
 	for k, v := range msg.Properties() {
 		props[k] = v
@@ -580,12 +583,12 @@ func (c *consumer) ReconsumeLaterWithCustomProperties(msg Message, customPropert
 }
 
 func (c *consumer) Nack(msg Message) {
+	if !checkMessageIDType(msg.ID()) {
+		c.log.Warnf("invalid message id type %T", msg.ID())
+		return
+	}
 	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
 		mid := c.messageID(msg.ID())
-		if mid == nil {
-			return
-		}
-
 		if mid.consumer != nil {
 			mid.consumer.NackID(msg.ID())
 			return
@@ -745,10 +748,6 @@ func toProtoInitialPosition(p SubscriptionInitialPosition) pb.CommandSubscribe_I
 
 func (c *consumer) messageID(msgID MessageID) *trackingMessageID {
 	mid := toTrackingMessageID(msgID)
-	if mid == nil {
-		c.log.Warnf("invalid message id type %T", msgID)
-		return nil
-	}
 
 	partition := int(mid.partitionIdx)
 	// did we receive a valid partition index?

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -125,11 +125,11 @@ func (c *multiTopicConsumer) Ack(msg Message) error {
 
 // AckID the consumption of a single message, identified by its MessageID
 func (c *multiTopicConsumer) AckID(msgID MessageID) error {
-	mid := toTrackingMessageID(msgID)
-	if mid == nil {
+	if !checkMessageIDType(msgID) {
 		c.log.Warnf("invalid message id type %T", msgID)
 		return errors.New("invalid message id type in multi_consumer")
 	}
+	mid := toTrackingMessageID(msgID)
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
@@ -152,11 +152,11 @@ func (c *multiTopicConsumer) AckCumulative(msg Message) error {
 // AckIDCumulative the reception of all the messages in the stream up to (and including)
 // the provided message, identified by its MessageID
 func (c *multiTopicConsumer) AckIDCumulative(msgID MessageID) error {
-	mid := toTrackingMessageID(msgID)
-	if mid == nil {
+	if !checkMessageIDType(msgID) {
 		c.log.Warnf("invalid message id type %T", msgID)
 		return errors.New("invalid message id type in multi_consumer")
 	}
+	mid := toTrackingMessageID(msgID)
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
@@ -203,11 +203,11 @@ func (c *multiTopicConsumer) ReconsumeLaterWithCustomProperties(msg Message, cus
 func (c *multiTopicConsumer) Nack(msg Message) {
 	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
 		msgID := msg.ID()
-		mid := toTrackingMessageID(msgID)
-		if mid == nil {
+		if !checkMessageIDType(msgID) {
 			c.log.Warnf("invalid message id type %T", msgID)
 			return
 		}
+		mid := toTrackingMessageID(msgID)
 
 		if mid.consumer == nil {
 			c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
@@ -221,11 +221,11 @@ func (c *multiTopicConsumer) Nack(msg Message) {
 }
 
 func (c *multiTopicConsumer) NackID(msgID MessageID) {
-	mid := toTrackingMessageID(msgID)
-	if mid == nil {
+	if !checkMessageIDType(msgID) {
 		c.log.Warnf("invalid message id type %T", msgID)
 		return
 	}
+	mid := toTrackingMessageID(msgID)
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -174,11 +174,12 @@ func (c *regexConsumer) ReconsumeLaterWithCustomProperties(msg Message, customPr
 
 // AckID the consumption of a single message, identified by its MessageID
 func (c *regexConsumer) AckID(msgID MessageID) error {
-	mid := toTrackingMessageID(msgID)
-	if mid == nil {
+	if !checkMessageIDType(msgID) {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return errors.New("invalid message id type")
+		return fmt.Errorf("invalid message id type %T", msgID)
 	}
+
+	mid := toTrackingMessageID(msgID)
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
@@ -201,11 +202,12 @@ func (c *regexConsumer) AckCumulative(msg Message) error {
 // AckIDCumulative the reception of all the messages in the stream up to (and including)
 // the provided message, identified by its MessageID
 func (c *regexConsumer) AckIDCumulative(msgID MessageID) error {
-	mid := toTrackingMessageID(msgID)
-	if mid == nil {
+	if !checkMessageIDType(msgID) {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return errors.New("invalid message id type")
+		return fmt.Errorf("invalid message id type %T", msgID)
 	}
+
+	mid := toTrackingMessageID(msgID)
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
@@ -222,11 +224,11 @@ func (c *regexConsumer) AckIDCumulative(msgID MessageID) error {
 func (c *regexConsumer) Nack(msg Message) {
 	if c.options.EnableDefaultNackBackoffPolicy || c.options.NackBackoffPolicy != nil {
 		msgID := msg.ID()
-		mid := toTrackingMessageID(msgID)
-		if mid == nil {
+		if !checkMessageIDType(msgID) {
 			c.log.Warnf("invalid message id type %T", msgID)
 			return
 		}
+		mid := toTrackingMessageID(msgID)
 
 		if mid.consumer == nil {
 			c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)
@@ -240,11 +242,12 @@ func (c *regexConsumer) Nack(msg Message) {
 }
 
 func (c *regexConsumer) NackID(msgID MessageID) {
-	mid := toTrackingMessageID(msgID)
-	if mid == nil {
+	if !checkMessageIDType(msgID) {
 		c.log.Warnf("invalid message id type %T", msgID)
 		return
 	}
+
+	mid := toTrackingMessageID(msgID)
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to nack messageID=%+v can not determine topic", msgID)


### PR DESCRIPTION
### Motivation

`toTrackingMessageID()` is a function that is widely used in `consumer` implementation. It can convert an interface type  `MessageID` into an struct type `trackingMessageID`. In addition, the second return value also plays a role in checking the `MessageID` type. In other words, it indicates that `MessageID` **cannot** be a user-defined type. From the perspective of code readability, `toTrackingMessageID()` should not do both.

**Note**: After #968 , `toTrackingMessageID()` returns only a pointer now. The role of original `ok` is replaced by nil pointer  now. However, the main content discussed in this PR has not changed.

For example.

https://github.com/apache/pulsar-client-go/blob/e2ea255052e8a527091791ef368851d885ee2d45/pulsar/consumer_regex.go#L176-L181

This example is the correct usage. The `ok` returned by `toTrackingMessageID()` is used to reject user-defined `MessageID`.

https://github.com/apache/pulsar-client-go/blob/e2ea255052e8a527091791ef368851d885ee2d45/pulsar/consumer_partition.go#L470-L473

This example is a bit vague. The actual effect here is the same as the previous example. But it return an error `failed to convert trackingMessageID` which is confusing. 

https://github.com/apache/pulsar-client-go/blob/e2ea255052e8a527091791ef368851d885ee2d45/pulsar/consumer_partition.go#L1816-L1820

In this case. We just want to convert `MessageID` into `trackingMessageID`. We do not care what it really is because it's not possible an invalid `MessageID` implementation.

So, original `toTrackingMessageID()` needs to require a careful look to use it correctly. I think it would be better to split it into two different method. `toTrackingMessageID()` just do the struct conversion, which it's more clearly. And when the new messageID type is added, we can just modify the `checkMessageIDType`.

### Modifications

- Refactor the `toTrackingMessageID()`
- Add the `checkMessageIDType()` to check whether `MessageID` is user-defined.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? no
