### PR TITLE
fix: prevent rpc client panic on rpc response if `ProducerReady` is nil

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -523,7 +523,7 @@ func (c *connection) internalReceivedCommand(cmd *pb.BaseCommand, headersAndPayl
 		c.handleResponse(cmd.Success.GetRequestId(), cmd)
 
 	case pb.BaseCommand_PRODUCER_SUCCESS:
-		if !*cmd.ProducerSuccess.ProducerReady {
+		if !cmd.ProducerSuccess.GetProducerReady() {
 			request, ok := c.findPendingRequest(cmd.ProducerSuccess.GetRequestId())
 			if ok {
 				request.callback(cmd, nil)

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -138,7 +138,7 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 			// Ignoring producer not ready response.
 			// Continue to wait for the producer to create successfully
 			if res.error == nil && *res.RPCResult.Response.Type == pb.BaseCommand_PRODUCER_SUCCESS {
-				if !*res.RPCResult.Response.ProducerSuccess.ProducerReady {
+				if !res.RPCResult.Response.ProducerSuccess.GetProducerReady() {
 					timeoutCh = nil
 					break
 				}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

prevent rpc client panic on rpc response if `ProducerReady` is nil

### Modifications

use `ProducerSuccess.GetProducerReady` instead of `ProducerSuccess.ProducerReady`

**panic log**

```log
panic: runtime error: invalid memory address or nil pointer dereference

 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe997de]

 goroutine 982 [running]:

 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).internalReceivedCommand(0xc0005d0840, 0xc0010a6000, {0x0?, 0x0})

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:526 +0x1de

 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).run(0xc0005d0840)

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:420 +0x3b0

 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start.func1()

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:231 +0x65

 created by github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:227 +0x70

 panic: runtime error: invalid memory address or nil pointer dereference

 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe997de]

 
goroutine 989 [running]:

 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).internalReceivedCommand(0xc0005d1080, 0xc0004f4600, {0x0?, 0x0})

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:526 +0x1de

 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).run(0xc0005d1080)

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:420 +0x3b0

 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start.func1()

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:231 +0x65

 created by github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start

 	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.9.1-0.20230301160414-42ded0d59c46/pulsar/internal/connection.go:227 +0x70
```


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
