### PR TITLE
Fix license information for go-rate

### DIFF
--- a/distribution/LICENSE.bin.txt
+++ b/distribution/LICENSE.bin.txt
@@ -218,9 +218,6 @@ MIT License
   * github.com/kr/pretty v0.2.0 -- distribution/license/LICENSE-pretty.txt
   * github.com/sirupsen/logrus v1.4.1 -- distribution/license/LICENSE-logrus.txt
 
-GNU GENERAL PUBLIC LICENSE Version 3
-  * github.com/beefsack/go-rate v0.0.0-20180408011153-efa7637bb9b6 -- distribution/license/LICENSE-go-rate.txt
-
 BSD License
   * github.com/DataDog/zstd v1.4.6-0.20210211175136-c6db21d202f4 -- distribution/license/LICENSE-zstd.txt
   * github.com/klauspost/compress v1.9.2 -- distribution/license/LICENSE-compress.txt


### PR DESCRIPTION
This closes #952.

go-rate is licensed under GPLv3, which is not compatible with ALv2.

It has been already removed in https://github.com/apache/pulsar-client-go/pull/799 but we don't update all references.

Thank @artursouza for spotting this.