### PR TITLE
[feat]: Support auto scaled consumer receiver queue

### DIFF
--- a/perf/perf-consumer.go
+++ b/perf/perf-consumer.go
@@ -31,10 +31,11 @@ import (
 
 // ConsumeArgs define the parameters required by consume
 type ConsumeArgs struct {
-	Topic               string
-	SubscriptionName    string
-	ReceiverQueueSize   int
-	EnableBatchIndexAck bool
+	Topic                             string
+	SubscriptionName                  string
+	ReceiverQueueSize                 int
+	EnableBatchIndexAck               bool
+	EnableAutoScaledReceiverQueueSize bool
 }
 
 func newConsumerCommand() *cobra.Command {
@@ -57,6 +58,8 @@ func newConsumerCommand() *cobra.Command {
 	flags.StringVarP(&consumeArgs.SubscriptionName, "subscription", "s", "sub", "Subscription name")
 	flags.IntVarP(&consumeArgs.ReceiverQueueSize, "receiver-queue-size", "r", 1000, "Receiver queue size")
 	flags.BoolVar(&consumeArgs.EnableBatchIndexAck, "enable-batch-index-ack", false, "Whether to enable batch index ACK")
+	flags.BoolVar(&consumeArgs.EnableAutoScaledReceiverQueueSize, "enable-auto-scaled-queue-size", false,
+		"Whether to enable auto scaled receiver queue size")
 
 	return cmd
 }
@@ -76,9 +79,10 @@ func consume(consumeArgs *ConsumeArgs, stop <-chan struct{}) {
 	defer client.Close()
 
 	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
-		Topic:                          consumeArgs.Topic,
-		SubscriptionName:               consumeArgs.SubscriptionName,
-		EnableBatchIndexAcknowledgment: consumeArgs.EnableBatchIndexAck,
+		Topic:                             consumeArgs.Topic,
+		SubscriptionName:                  consumeArgs.SubscriptionName,
+		EnableBatchIndexAcknowledgment:    consumeArgs.EnableBatchIndexAck,
+		EnableAutoScaledReceiverQueueSize: consumeArgs.EnableAutoScaledReceiverQueueSize,
 	})
 
 	if err != nil {

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -160,6 +160,12 @@ type ConsumerOptions struct {
 	// Default value is `1000` messages and should be good for most use cases.
 	ReceiverQueueSize int
 
+	// EnableAutoScaledReceiverQueueSize, if enabled, the consumer receive queue will be auto-scaled
+	// by the consumer actual throughput. The ReceiverQueueSize will be the maximum size which consumer
+	// receive queue can be scaled.
+	// Default is false.
+	EnableAutoScaledReceiverQueueSize bool
+
 	// NackRedeliveryDelay specifies the delay after which to redeliver the messages that failed to be
 	// processed. Default is 1 min. (See `Consumer.Nack()`)
 	NackRedeliveryDelay time.Duration

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -399,6 +399,7 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 				consumerEventListener:       c.options.EventListener,
 				enableBatchIndexAck:         c.options.EnableBatchIndexAcknowledgment,
 				ackGroupingOptions:          c.options.AckGroupingOptions,
+				autoReceiverQueueSize:       c.options.EnableAutoScaledReceiverQueueSize,
 			}
 			cons, err := newPartitionConsumer(c, c.client, opts, c.messageCh, c.dlq, c.metrics)
 			ch <- ConsumerError{

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1321,13 +1321,12 @@ func (pc *partitionConsumer) dispatcher() {
 				} else if nextMessageInQueue == nil {
 					nextMessageInQueue = toTrackingMessageID(m[0].msgID)
 				}
+				if pc.options.autoReceiverQueueSize {
+					pc.incomingMessages.Sub(int32(len(m)))
+				}
 			}
 
 			messages = nil
-
-			if pc.options.autoReceiverQueueSize {
-				pc.incomingMessages.Store(0)
-			}
 
 			clearQueueCb(nextMessageInQueue)
 		}

--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -37,6 +37,7 @@ func TestSingleMessageIDNoAckTracker(t *testing.T) {
 		metrics:              newTestMetrics(),
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
+	pc.availablePermits = &availablePermits{pc: &pc}
 	pc.ackGroupingTracker = newAckGroupingTracker(&AckGroupingOptions{MaxSize: 0},
 		func(id MessageID) { pc.sendIndividualAck(id) }, nil)
 
@@ -75,6 +76,7 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 		metrics:              newTestMetrics(),
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
+	pc.availablePermits = &availablePermits{pc: &pc}
 	pc.ackGroupingTracker = newAckGroupingTracker(&AckGroupingOptions{MaxSize: 0},
 		func(id MessageID) { pc.sendIndividualAck(id) }, nil)
 
@@ -110,6 +112,7 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 		metrics:              newTestMetrics(),
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
+	pc.availablePermits = &availablePermits{pc: &pc}
 	pc.ackGroupingTracker = newAckGroupingTracker(&AckGroupingOptions{MaxSize: 0},
 		func(id MessageID) { pc.sendIndividualAck(id) }, nil)
 

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4030,9 +4030,6 @@ func TestConsumerWithAutoScaledQueueReceive(t *testing.T) {
 	_, err = c.Receive(context.Background())
 	assert.Nil(t, err)
 
-	// waiting for prefetched message passing from queueCh to dispatcher()
-	time.Sleep(time.Second)
-
 	// currentQueueSize should be doubled in size
 	assert.Equal(t, 2, int(pc.currentQueueSize.Load()))
 

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3988,3 +3988,89 @@ func runBatchIndexAckTest(t *testing.T, ackWithResponse bool, cumulative bool, o
 
 	client.Close()
 }
+
+func TestConsumerWithAutoScaledQueueReceive(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+
+	// create consumer
+	c, err := client.Subscribe(ConsumerOptions{
+		Topic:                             topic,
+		SubscriptionName:                  "my-sub",
+		Type:                              Exclusive,
+		ReceiverQueueSize:                 3,
+		EnableAutoScaledReceiverQueueSize: true,
+	})
+	assert.Nil(t, err)
+	pc := c.(*consumer).consumers[0]
+	assert.Equal(t, int32(1), pc.currentQueueSize.Load())
+	defer c.Close()
+
+	// create p
+	p, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer p.Close()
+
+	// send message, it will update scaleReceiverQueueHint from false to true
+	_, err = p.Send(context.Background(), &ProducerMessage{
+		Payload: []byte("hello"),
+	})
+	assert.NoError(t, err)
+
+	// this will trigger receiver queue size expanding to 2 because we have prefetched 1 message >= currentSize 1.
+	_, err = c.Receive(context.Background())
+	assert.Nil(t, err)
+
+	// waiting for prefetched message passing from queueCh to dispatcher()
+	time.Sleep(time.Second)
+
+	// currentQueueSize should be doubled in size
+	assert.Equal(t, 2, int(pc.currentQueueSize.Load()))
+
+	for i := 0; i < 5; i++ {
+		_, err = p.Send(context.Background(), &ProducerMessage{
+			Payload: []byte("hello"),
+		})
+		assert.NoError(t, err)
+
+		// waiting for prefetched message passing from queueCh to dispatcher()
+		time.Sleep(time.Second)
+
+		_, err = p.Send(context.Background(), &ProducerMessage{
+			Payload: []byte("hello"),
+		})
+		assert.NoError(t, err)
+
+		// wait all the messages has been prefetched
+		_, err = c.Receive(context.Background())
+		assert.Nil(t, err)
+		_, err = c.Receive(context.Background())
+		assert.Nil(t, err)
+		// this will not trigger receiver queue size expanding because we have prefetched 2 message < currentSize 4.
+		assert.Equal(t, int32(2), pc.currentQueueSize.Load())
+	}
+
+	for i := 0; i < 5; i++ {
+		p.SendAsync(
+			context.Background(),
+			&ProducerMessage{Payload: []byte("hello")},
+			func(id MessageID, producerMessage *ProducerMessage, err error) {
+			},
+		)
+	}
+
+	// waiting for prefetched message passing from queueCh to dispatcher()
+	time.Sleep(time.Second)
+
+	// currentQueueSize expanding to max size
+	assert.Equal(t, int32(3), pc.currentQueueSize.Load())
+}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4026,18 +4026,14 @@ func TestConsumerWithAutoScaledQueueReceive(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// waiting for prefetched message passing from queueCh to dispatcher()
-	//time.Sleep(time.Second)
-
 	// this will trigger receiver queue size expanding to 2 because we have prefetched 1 message >= currentSize 1.
 	_, err = c.Receive(context.Background())
 	assert.Nil(t, err)
 
+	// currentQueueSize should be doubled in size
 	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
 		return assert.Equal(t, 2, int(pc.currentQueueSize.Load()))
 	})
-	// currentQueueSize should be doubled in size
-	//assert.Equal(t, 2, int(pc.currentQueueSize.Load()))
 
 	for i := 0; i < 5; i++ {
 		_, err = p.Send(context.Background(), &ProducerMessage{
@@ -4076,10 +4072,4 @@ func TestConsumerWithAutoScaledQueueReceive(t *testing.T) {
 	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
 		return assert.Equal(t, 3, int(pc.currentQueueSize.Load()))
 	})
-
-	// waiting for prefetched message passing from queueCh to dispatcher()
-	//time.Sleep(time.Second)
-
-	// currentQueueSize expanding to max size
-	//assert.Equal(t, int32(3), pc.currentQueueSize.Load())
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4069,7 +4069,7 @@ func TestConsumerWithAutoScaledQueueReceive(t *testing.T) {
 		)
 	}
 
-	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
+	retryAssert(t, 3, 300, func() {}, func(t assert.TestingT) bool {
 		return assert.Equal(t, 3, int(pc.currentQueueSize.Load()))
 	})
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4026,6 +4026,9 @@ func TestConsumerWithAutoScaledQueueReceive(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	// waiting for prefetched message passing from queueCh to dispatcher()
+	time.Sleep(time.Second)
+
 	// this will trigger receiver queue size expanding to 2 because we have prefetched 1 message >= currentSize 1.
 	_, err = c.Receive(context.Background())
 	assert.Nil(t, err)

--- a/pulsar/internal/utils.go
+++ b/pulsar/internal/utils.go
@@ -85,3 +85,10 @@ func MarshalToSizedBuffer(m proto.Message, out []byte) error {
 	copy(out, b[:len(out)])
 	return nil
 }
+
+func MinInt32(lhs int32, rhs int32) int32 {
+	if lhs < rhs {
+		return lhs
+	}
+	return rhs
+}

--- a/pulsar/internal/utils.go
+++ b/pulsar/internal/utils.go
@@ -85,10 +85,3 @@ func MarshalToSizedBuffer(m proto.Message, out []byte) error {
 	copy(out, b[:len(out)])
 	return nil
 }
-
-func MinInt32(lhs int32, rhs int32) int32 {
-	if lhs < rhs {
-		return lhs
-	}
-	return rhs
-}


### PR DESCRIPTION
Master Issue: #927 

### Motivation
**Note: This is part of the work for [PIP 74](https://github.com/apache/pulsar/wiki/PIP-74%3A-Pulsar-client-memory-limits) in go client.**

The memory limit in consumer side relys on flow control. So we need to firstly support auto scaled consumer receiver queue before we implement the consumer side memory limitation.

#### Why should we support auto scaled consumer first before supporting consumer client memory limit?

The main memory consumption on the consumer side comes from the messages that the consumer prefetches from the broker. Currently, the number of prefetched messages depends on the "current available permits" which represents the messages that have been delivered to the user. When the `availablePermits` reach a certain threshold, the client will send a `Flow` request to the broker to prefetch messages. The current threshold is half of the "receiverQueueSize" (default 1000).

https://github.com/apache/pulsar-client-go/blob/352c463194916cab7772c0729c9cdac14404e8bd/pulsar/consumer_partition.go#L194-L207

If we do not support auto scaled consumer receiver queue, the `Flow` threshold will be fixed. We cannot dynamically adjust the number of prefetched messages, resulting in the inability to control consumer memory. So auto scaled consumer receiver queue needs to be supported first.

#### How does "auto scaled consumer receiver queue" work?

In consumer side, all controls related to message pulling are actually controlling the `Flow`. For example, `receiverQueueSize` controls the `Flow` by controlling the size of the receiver queue.  ReceiverQueue `queueCh` can receive more messages than `receiverQueueSize` because queueCh is a `chan []*message`.

https://github.com/apache/pulsar-client-go/blob/352c463194916cab7772c0729c9cdac14404e8bd/pulsar/consumer_partition.go#L296

If we want to control the `Flow` threshold, we should make the `queueSize` can be auto scaled. There are mainly two problems to be solved.

- Under what condition is the queue considered to need to be scaled?

When the consumption rate required by the user is greater than the configured rate, we increase the configured rate. This condition can be expressed as, before triggering a new Flow to obtain new messages, the number of messages that the current consumer has received (i.e., current available permits + current messages in `queueCh`) is greater than the current queue size. 

- When is the timing to scale receiver queue size?

In the Java client, `expectMoreIncomingMessages` is triggered by "empty reveive".

https://github.com/apache/pulsar/blob/da30b2e211d0a097abfa8d0392f1fd4b13a46328/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java#L478-L482

In the Go Client, we can not get the "empty reveive" because the `messageCh` is exposed to user to async consume. So we `expectMoreIncomingMessages` when `messageCh` is not full.

https://github.com/apache/pulsar-client-go/blob/352c463194916cab7772c0729c9cdac14404e8bd/pulsar/consumer_partition.go#L1278-L1283

More details in #927 .

### Modifications

- Add `currentQueueSize` and `scaleReceiverQueueHint` to control `Flow` rate.
- Add `AutoScaledReceiverQueueSize` option for `Consumer`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

Here is a test with pulsar-perf on local standalone server to confirm the effect of this PR.

Non-partitioned topic consumer

```
$  ./pulsar-perf produce my-test -r 1000 -s 128 -b 0 
$  ./pulsar-perf consume my-test -r 10000 --enable-auto-scaled-queue-size=true
```

| RATE  | Final receiver queue size |
| ----- | ------------------------- |
| 1     | 1                         |
| 5     | 2                         |
| 10    | 2                         |
| 100   | 8                         |
| 1000  | 64                        |
| 10000 | 1000                      |

3-partitioned topic consumer

```
$  ./pulsar-perf produce my-test-partitioned -r 1000 -s 128 -b 0 
$  ./pulsar-perf consume my-test-partitioned -r 10000 --enable-auto-scaled-queue-size=true
```

| RATE  | Final total receiver queue size | Sub-consumers receiver queue size |
| ----- | ------------------------------- | --------------------------------- |
| 1     | 4                               | 2,1,1                             |
| 10    | 8                               | 4,2,2                             |
| 100   | 16                              | 4,8,4                             |
| 1000  | 192                             | 64,64,64                          |
| 10000 | 1536                            | 512,512,512                       |
| 20000 | 3000                            | 1000,1000,1000                    |

