### PR TITLE
[fix] Fix data race in checkAndCleanIdleConnections

### DIFF
--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -154,7 +154,8 @@ func (p *connectionPool) checkAndCleanIdleConnections(maxIdleTime time.Duration)
 			p.Lock()
 			for k, c := range p.connections {
 				if c.CheckIdle(maxIdleTime) {
-					c.log.Debugf("Closed connection due to inactivity.")
+					p.log.Debugf("Closed connection from pool due to inactivity. logical_addr=%+v physical_addr=%+v",
+						c.logicalAddr, c.physicalAddr)
 					delete(p.connections, k)
 					c.Close()
 				}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #978


### Motivation

From the data race log of the issue:
```
2023-03-07T02:05:50.0096902Z WARNING: DATA RACE
2023-03-07T02:05:50.0097176Z Read at 0x00c0003bb298 by goroutine 111:
2023-03-07T02:05:50.0097767Z   github.com/apache/pulsar-client-go/pulsar/internal.(*connectionPool).checkAndCleanIdleConnections()
2023-03-07T02:05:50.0098468Z       /pulsar/pulsar-client-go/pulsar/internal/connection_pool.go:157 +0x24d
2023-03-07T02:05:50.0099058Z   github.com/apache/pulsar-client-go/pulsar/internal.StartCleanConnectionsTask.func1()
2023-03-07T02:05:50.0099727Z       /pulsar/pulsar-client-go/pulsar/internal/helper.go:25 +0x47
2023-03-07T02:05:50.0099934Z 
2023-03-07T02:05:50.0100066Z Previous write at 0x00c0003bb298 by goroutine 69:
2023-03-07T02:05:50.0100537Z   github.com/apache/pulsar-client-go/pulsar/internal.(*connection).connect()
2023-03-07T02:05:50.0101126Z       /pulsar/pulsar-client-go/pulsar/internal/connection.go:277 +0x5d2
2023-03-07T02:05:50.0101649Z   github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start.func1()
2023-03-07T02:05:50.0102222Z       /pulsar/pulsar-client-go/pulsar/internal/connection.go:230 +0x34

```

We can see that the read access of c.log here:
https://github.com/apache/pulsar-client-go/blob/c5956779f078176b6f915892dd47d9cbdb0d0fea/pulsar/internal/connection_pool.go#L157

is conflict with the write access of c.log here:

https://github.com/apache/pulsar-client-go/blob/c5956779f078176b6f915892dd47d9cbdb0d0fea/pulsar/internal/connection.go#L277

This caused the data race.

### Modifications

* Using p.log to avoid accessing the c.log

### Verifying this change


This change is already covered by existing tests

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
