### PR TITLE
Fix ack grouping tracker is duplicate method will be blocked.

### DIFF
--- a/pulsar/ack_grouping_tracker_test.go
+++ b/pulsar/ack_grouping_tracker_test.go
@@ -195,3 +195,15 @@ func TestTimedTrackerIsDuplicate(t *testing.T) {
 	assert.False(t, tracker.isDuplicate(&messageID{batchIdx: 1, batchSize: 3}))
 	assert.False(t, tracker.isDuplicate(&messageID{batchIdx: 2, batchSize: 3}))
 }
+
+func TestDuplicateAfterClose(t *testing.T) {
+	var acker mockAcker
+	tracker := newAckGroupingTracker(&AckGroupingOptions{MaxSize: 3, MaxTime: 0},
+		func(id MessageID) { acker.ack(id) }, func(id MessageID) { acker.ackCumulative(id) })
+
+	tracker.add(&messageID{ledgerID: 1})
+	assert.True(t, tracker.isDuplicate(&messageID{ledgerID: 1}))
+
+	tracker.close()
+	assert.False(t, tracker.isDuplicate(&messageID{ledgerID: 1}))
+}


### PR DESCRIPTION
Master Issue: #979

### Motivation

The root cause is `internalReceivedCommand` will be blocked by `timedAckGroupingTracker.isDuplicate`. 

https://github.com/apache/pulsar-client-go/blob/75d2df3b7d1d1d04fb660a1b6c11ede1d2f161bf/pulsar/internal/connection.go#L421-L422

```
1 @ 0x104ff6204 0x104fc232c 0x104fc1ed8 0x1054894dc 0x105497934 0x10541fa60 0x10541e430 0x10541d3bc 0x10541c114 0x105027874
# 0x1054894db github.com/apache/pulsar-client-go/pulsar.(*timedAckGroupingTracker).isDuplicate+0x3b  /Users/shibaodi/GolandProjects/pulsar-client-go/pulsar/ack_grouping_tracker.go:281
# 0x105497933 github.com/apache/pulsar-client-go/pulsar.(*partitionConsumer).MessageReceived+0xd63  /Users/shibaodi/GolandProjects/pulsar-client-go/pulsar/consumer_partition.go:1007
# 0x10541fa5f github.com/apache/pulsar-client-go/pulsar/internal.(*connection).handleMessage+0xdf  /Users/shibaodi/GolandProjects/pulsar-client-go/pulsar/internal/connection.go:757
# 0x10541e42f github.com/apache/pulsar-client-go/pulsar/internal.(*connection).internalReceivedCommand+0x28f /Users/shibaodi/GolandProjects/pulsar-client-go/pulsar/internal/connection.go:588
# 0x10541d3bb github.com/apache/pulsar-client-go/pulsar/internal.(*connection).run+0x30b   /Users/shibaodi/GolandProjects/pulsar-client-go/pulsar/internal/connection.go:423
# 0x10541c113 github.com/apache/pulsar-client-go/pulsar/internal.(*connection).start.func1+0x53  /Users/shibaodi/GolandProjects/pulsar-client-go/pulsar/internal/connection.go:233

```

Then, the subsequent commands under this `connection` cannot be processed, resulting in a timeout.

**Failed logs**
```
time="2023-03-02T06:34:19Z" level=info msg="Closing consumer=2" consumerID=2 name=rtvmw subscription=sub-2 topic="persistent://public/default/my-topic-70957754"
time="2023-03-02T06:34:49Z" level=warning msg="Failed to close consumer" consumerID=2 error="request timed out" name=rtvmw subscription=sub-2 topic="persistent://public/default/my-topic-70957754"
time="2023-03-02T06:34:49Z" level=info msg="close consumer, exit reconnect" consumerID=2 name=rtvmw subscription=sub-2 topic="persistent://public/default/my-topic-70957754"
    consumer_test.go:1026: 
        	Error Trace:	/pulsar/pulsar-client-go/pulsar/consumer_test.go:1026
        	Error:      	Expected nil, but got: &errors.errorString{s:"request timed out"}
        	Test:       	TestConsumerBatchCumulativeAck
```

#957 introduced the `AckGroupingTracker`. If a consumer calls close, it will closed `AckGroupingTracker`, This exits the loop.

https://github.com/apache/pulsar-client-go/blob/ebc025e37ccb9ad2d2da2603736a1f97ac904ca0/pulsar/ack_grouping_tracker.go#L116-L118

This will course in never getting `duplicateResultCh` messages and be blocked here.

https://github.com/apache/pulsar-client-go/blob/7d257b01b1216e0009495a4aaf83b1716ba458a9/pulsar/ack_grouping_tracker.go#L282


In this test, when called `c1.close() or c2.close()`, there may be `message cmd` pushed over and eventually blocked by the `isDuplicate` method.

https://github.com/apache/pulsar-client-go/blob/42ded0d59c46fd3fdaad45f045f7e8bf091131a5/pulsar/consumer_test.go#L1002-L1018

### Modifications
- Use `sync.mutex` instead of `select channel` to refactor `AckGroupingTracker`.

### Verifying this change

- Add `TestDuplicateAfterClose ` to cover it.

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
