### PR TITLE
Optimize batch index ACK performance

### DIFF
--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -38,7 +38,7 @@ func TestSingleMessageIDNoAckTracker(t *testing.T) {
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
 	pc.ackGroupingTracker = newAckGroupingTracker(&AckGroupingOptions{MaxSize: 0},
-		func(id MessageID) { pc.sendIndividualAck(id) }, nil)
+		func(id MessageID) { pc.sendIndividualAck(id) }, nil, nil)
 
 	headersAndPayload := internal.NewBufferWrapper(rawCompatSingleMessage)
 	if err := pc.MessageReceived(nil, headersAndPayload); err != nil {
@@ -76,7 +76,7 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
 	pc.ackGroupingTracker = newAckGroupingTracker(&AckGroupingOptions{MaxSize: 0},
-		func(id MessageID) { pc.sendIndividualAck(id) }, nil)
+		func(id MessageID) { pc.sendIndividualAck(id) }, nil, nil)
 
 	headersAndPayload := internal.NewBufferWrapper(rawBatchMessage1)
 	if err := pc.MessageReceived(nil, headersAndPayload); err != nil {
@@ -111,7 +111,7 @@ func TestBatchMessageIDWithAckTracker(t *testing.T) {
 		decryptor:            crypto.NewNoopDecryptor(),
 	}
 	pc.ackGroupingTracker = newAckGroupingTracker(&AckGroupingOptions{MaxSize: 0},
-		func(id MessageID) { pc.sendIndividualAck(id) }, nil)
+		func(id MessageID) { pc.sendIndividualAck(id) }, nil, nil)
 
 	headersAndPayload := internal.NewBufferWrapper(rawBatchMessage10)
 	if err := pc.MessageReceived(nil, headersAndPayload); err != nil {

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -212,11 +212,3 @@ func messageIDCompare(lhs MessageID, rhs MessageID) int {
 	}
 	return 0
 }
-
-func messageIDHash(id MessageID) int64 {
-	return id.LedgerID() + 31*id.EntryID()
-}
-
-func messageIDIsBatch(id MessageID) bool {
-	return id.BatchIdx() >= 0 && id.BatchSize() > 0
-}


### PR DESCRIPTION
### Motivation

Currently, when `EnableBatchIndexAck` is true, the ACK performance is very poor. There are two main reasons:
1. Acknowledgment by list is not supported. It means that even N MessageIDs are grouped, there are still N ACK requests to send.
2. The implementation of ACK grouping tracker is wrong. Give a batch that has N messages, when batch index ACK is enabled, each MessageID is cached. However, after all these N MessageIDs arrived, the current implementation does not clear them.

### Modifications
- Add a `func(id []*pb.MessageIdData)` to the ACK grouping tracker. When flushing individual ACKs, construct the slice and wrap the slice to `CommandAck` directly.
- Refactor the implementation of the ACK grouping tracker to have these two data structures:
  - `pendingAcks`: Cache the non-batched MessageIDs
  - `pendingBatchAcks`: Cache the batched MessageIDs, once all messages in a batch have been added, remove them from it and add the non-batched MessageID to `pendingAcks`
- Add `TestBatchIndexAckAllMessages` to verify the new behavior.

After this change, the ACK order cannot be guaranteed, sort the acknowledged MessageIDs in the `ack_grouping_tracker_test.go`.