### PR TITLE
[perf]: More precise producer rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.uber.org/atomic v1.7.0
 	golang.org/x/mod v0.5.1
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/protobuf v1.26.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,7 @@ golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -107,7 +107,8 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 	ch := make(chan float64)
 
-	rateLimiter := rate.NewLimiter(rate.Limit(produceArgs.Rate), produceArgs.Rate)
+	limit := rate.Every(time.Duration(float64(time.Second) / float64(produceArgs.Rate)))
+	rateLimiter := rate.NewLimiter(limit, produceArgs.Rate)
 
 	go func(stopCh <-chan struct{}) {
 		for {

--- a/perf/perf-producer.go
+++ b/perf/perf-producer.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/bmizerany/perks/quantile"
 	"github.com/spf13/cobra"
 
@@ -104,16 +106,8 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 	payload := make([]byte, produceArgs.MessageSize)
 
 	ch := make(chan float64)
-	rateLimitCh := make(chan time.Time, produceArgs.Rate)
-	go func(rateLimit int, interval time.Duration) {
-		if rateLimit <= 0 { // 0 as no limit enforced
-			return
-		}
-		for {
-			oldest := <-rateLimitCh
-			time.Sleep(interval - time.Since(oldest))
-		}
-	}(produceArgs.Rate, time.Second)
+
+	rateLimiter := rate.NewLimiter(rate.Limit(produceArgs.Rate), produceArgs.Rate)
 
 	go func(stopCh <-chan struct{}) {
 		for {
@@ -125,7 +119,7 @@ func produce(produceArgs *ProduceArgs, stop <-chan struct{}) {
 
 			start := time.Now()
 			if produceArgs.Rate > 0 {
-				rateLimitCh <- start
+				_ = rateLimiter.Wait(context.TODO())
 			}
 
 			producer.SendAsync(ctx, &pulsar.ProducerMessage{


### PR DESCRIPTION
### Motivation

Currently, when the rate of the producer is set relatively small, the actual production rate is not accurate.

For example.

```
$ ./pulsar-perf-old produce my-test-r1 -r 1

INFO[17:20:12.524] Stats - Publish rate:    2.9 msg/s -    0.0 Mbps - 
                                Latency ms: 50%   3.8 -95% 1004.0 - 99% 1004.3 - 99.9% 1004.3 - max 1005.2 
INFO[17:20:22.523] Stats - Publish rate:    3.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50%   3.8 -95% 1004.0 - 99% 1004.2 - 99.9% 1004.2 - max 1004.9 
INFO[17:20:32.523] Stats - Publish rate:    3.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50%   3.9 -95% 1004.0 - 99% 1004.0 - 99.9% 1004.0 - max 1004.1 

$ ./pulsar-perf-old produce my-test-r1 -r 5

INFO[17:27:33.597] Stats - Publish rate:    6.9 msg/s -    0.1 Mbps - 
                                Latency ms: 50%   4.0 -95% 1004.1 - 99% 1005.0 - 99.9% 1005.0 - max 1019.0 
INFO[17:27:43.596] Stats - Publish rate:    7.0 msg/s -    0.1 Mbps - 
                                Latency ms: 50%   4.7 -95% 1004.9 - 99% 1006.0 - 99.9% 1006.0 - max 1006.3 
INFO[17:27:53.596] Stats - Publish rate:    7.0 msg/s -    0.1 Mbps - 
                                Latency ms: 50%   4.0 -95% 1004.0 - 99% 1004.9 - 99.9% 1004.9 - max 1005.5 
INFO[17:28:03.588] Stats - Publish rate:    7.0 msg/s -    0.1 Mbps - 
                                Latency ms: 50%   5.0 -95% 1005.1 - 99% 1008.1 - 99.9% 1008.1 - max 1015.5
```

After modify the rate limiter, the result can be improved as that.

```
$ ./pulsar-perf produce my-test-r1 -r 1

INFO[17:22:45.971] Stats - Publish rate:    1.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 1004.4 -95% 1005.1 - 99% 1005.1 - 99.9% 1005.1 - max 1006.2 
INFO[17:22:55.971] Stats - Publish rate:    1.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 1004.2 -95% 1007.4 - 99% 1007.4 - 99.9% 1007.4 - max 1008.0 
INFO[17:23:05.971] Stats - Publish rate:    1.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 1003.4 -95% 1004.7 - 99% 1004.7 - 99.9% 1004.7 - max 1008.1 
INFO[17:23:15.971] Stats - Publish rate:    1.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 1003.5 -95% 1004.3 - 99% 1004.3 - 99.9% 1004.3 - max 1004.6 

$ ./pulsar-perf produce my-test-r1 -r 5

INFO[17:29:07.675] Stats - Publish rate:    5.4 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 203.5 -95% 204.6 - 99% 206.3 - 99.9% 206.3 - max  207.3 
INFO[17:29:17.675] Stats - Publish rate:    5.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 203.8 -95% 205.5 - 99% 206.2 - 99.9% 206.2 - max  206.3 
INFO[17:29:27.675] Stats - Publish rate:    5.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 203.7 -95% 204.7 - 99% 207.4 - 99.9% 207.4 - max  220.8 
INFO[17:29:37.675] Stats - Publish rate:    5.0 msg/s -    0.0 Mbps - 
                                Latency ms: 50% 203.6 -95% 204.3 - 99% 204.4 - 99.9% 204.4 - max  204.5 
```

### Modifications

- Use the "golang.org/x/time/rate" as producer limiter.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
