### PR TITLE
returning errors back to the client. 

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -74,9 +74,9 @@ func NewAuthenticationAthenz(authParams map[string]string) Authentication {
 }
 
 // NewAuthenticationOAuth2 Creates OAuth2 Authentication provider
-func NewAuthenticationOAuth2(authParams map[string]string) Authentication {
-	oauth, _ := auth.NewAuthenticationOAuth2WithParams(authParams)
-	return oauth
+func NewAuthenticationOAuth2(authParams map[string]string) (Authentication, error) {
+	oauth, err := auth.NewAuthenticationOAuth2WithParams(authParams)
+	return oauth, err
 }
 
 // NewAuthenticationBasic Creates Basic Authentication provider


### PR DESCRIPTION

### Motivation
When using the pulsar go client with oauth2, setting up the auth with the function NewAuthenticationOAuth2 doesn't return an error. In case of errors in the authentication flow nothing happens and the user/developer can only assume that the authentication went well.

It turns out there is a pretty decent error handling in the entire flow, but for unknown reasons this error is discarded right before the connection is returned to the client.

### Modifications

Instead of just discarding the error, it is now returned. Note that  the function now returns two parameters instead of just one and should be handled accordingly.
Refer to the changelog of the file `pulsar/client.go` to see the actual changes.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Documentation
  - Does this pull request introduce a new feature? no