### PR TITLE
[feat] Support consumer client memory limit

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -30,12 +30,13 @@ import (
 )
 
 const (
-	defaultConnectionTimeout = 10 * time.Second
-	defaultOperationTimeout  = 30 * time.Second
-	defaultKeepAliveInterval = 30 * time.Second
-	defaultMemoryLimitBytes  = 64 * 1024 * 1024
-	defaultConnMaxIdleTime   = 180 * time.Second
-	minConnMaxIdleTime       = 60 * time.Second
+	defaultConnectionTimeout           = 10 * time.Second
+	defaultOperationTimeout            = 30 * time.Second
+	defaultKeepAliveInterval           = 30 * time.Second
+	defaultMemoryLimitBytes            = 64 * 1024 * 1024
+	defaultMemoryLimitTriggerThreshold = 0.95
+	defaultConnMaxIdleTime             = 180 * time.Second
+	minConnMaxIdleTime                 = 60 * time.Second
 )
 
 type client struct {
@@ -158,7 +159,7 @@ func newClient(options ClientOptions) (Client, error) {
 			maxConnectionsPerHost, logger, metrics, connectionMaxIdleTime),
 		log:      logger,
 		metrics:  metrics,
-		memLimit: internal.NewMemoryLimitController(memLimitBytes),
+		memLimit: internal.NewMemoryLimitController(memLimitBytes, defaultMemoryLimitTriggerThreshold),
 	}
 	serviceNameResolver := internal.NewPulsarServiceNameResolver(url)
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -79,7 +79,6 @@ const (
 const (
 	initialReceiverQueueSize           = 1
 	receiverQueueExpansionMemThreshold = 0.75
-	receiverQueueShrinkMemThreshold    = 0.95
 )
 
 const (
@@ -335,7 +334,7 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 	}
 	if pc.options.autoReceiverQueueSize {
 		pc.currentQueueSize.Store(initialReceiverQueueSize)
-		pc.client.memLimit.RegisterTrigger(receiverQueueShrinkMemThreshold, pc.shrinkReceiverQueueSize)
+		pc.client.memLimit.RegisterTrigger(pc.shrinkReceiverQueueSize)
 	} else {
 		pc.currentQueueSize.Store(int32(pc.options.receiverQueueSize))
 	}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4113,3 +4113,126 @@ func TestConsumerBatchIndexAckDisabled(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("done"), message.Payload())
 }
+
+func TestConsumerMemoryLimit(t *testing.T) {
+	// Create client 1 without memory limit
+	cli1, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer cli1.Close()
+
+	// Create client 1 with memory limit
+	cli2, err := NewClient(ClientOptions{
+		URL:              lookupURL,
+		MemoryLimitBytes: 10 * 1024,
+	})
+
+	assert.Nil(t, err)
+	defer cli2.Close()
+
+	topic := newTopicName()
+
+	// Use client 1 to create producer p1
+	p1, err := cli1.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer p1.Close()
+
+	// Use mem-limited client 2 to create consumer c1
+	c1, err := cli2.Subscribe(ConsumerOptions{
+		Topic:                             topic,
+		SubscriptionName:                  "my-sub-1",
+		Type:                              Exclusive,
+		EnableAutoScaledReceiverQueueSize: true,
+	})
+	assert.Nil(t, err)
+	defer c1.Close()
+	pc1 := c1.(*consumer).consumers[0]
+
+	// Fill up the messageCh of c1
+	for i := 0; i < 10; i++ {
+		p1.SendAsync(
+			context.Background(),
+			&ProducerMessage{Payload: createTestMessagePayload(1)},
+			func(id MessageID, producerMessage *ProducerMessage, err error) {
+			},
+		)
+	}
+
+	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
+		return assert.Equal(t, 10, len(pc1.messageCh))
+	})
+
+	// Get current receiver queue size of c1
+	prevQueueSize := pc1.currentQueueSize.Load()
+
+	// Make the client 1 exceed the memory limit
+	_, err = p1.Send(context.Background(), &ProducerMessage{
+		Payload: createTestMessagePayload(10*1024 + 1),
+	})
+	assert.NoError(t, err)
+
+	// c1 should shrink it's receiver queue size
+	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
+		return assert.Equal(t, prevQueueSize/2, pc1.currentQueueSize.Load())
+	})
+
+	// Use mem-limited client 2 to create consumer c2
+	c2, err := cli2.Subscribe(ConsumerOptions{
+		Topic:                             topic,
+		SubscriptionName:                  "my-sub-2",
+		Type:                              Exclusive,
+		SubscriptionInitialPosition:       SubscriptionPositionEarliest,
+		EnableAutoScaledReceiverQueueSize: true,
+	})
+	assert.Nil(t, err)
+	defer c2.Close()
+	pc2 := c2.(*consumer).consumers[0]
+
+	// Try to induce c2 receiver queue size expansion
+	for i := 0; i < 10; i++ {
+		p1.SendAsync(
+			context.Background(),
+			&ProducerMessage{Payload: createTestMessagePayload(1)},
+			func(id MessageID, producerMessage *ProducerMessage, err error) {
+			},
+		)
+	}
+
+	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
+		return assert.Equal(t, 10, len(pc1.messageCh))
+	})
+
+	// c2 receiver queue size should not expansion because client 1 has exceeded the memory limit
+	assert.Equal(t, 1, int(pc2.currentQueueSize.Load()))
+
+	// Use mem-limited client 2 to create producer p2
+	p2, err := cli2.CreateProducer(ProducerOptions{
+		Topic:                   topic,
+		DisableBatching:         false,
+		DisableBlockIfQueueFull: true,
+	})
+	assert.Nil(t, err)
+	defer p2.Close()
+
+	var pErr error
+	p1.SendAsync(
+		context.Background(),
+		&ProducerMessage{Payload: createTestMessagePayload(1)},
+		func(id MessageID, producerMessage *ProducerMessage, err error) {
+			pErr = err
+		},
+	)
+
+	// Producer can't send message
+	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
+		if pErr != nil {
+			return assert.Equal(t, true, errors.Is(pErr, errMemoryBufferIsFull))
+		}
+		return false
+	})
+}

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4219,20 +4219,9 @@ func TestConsumerMemoryLimit(t *testing.T) {
 	assert.Nil(t, err)
 	defer p2.Close()
 
-	var pErr error
-	p1.SendAsync(
-		context.Background(),
-		&ProducerMessage{Payload: createTestMessagePayload(1)},
-		func(id MessageID, producerMessage *ProducerMessage, err error) {
-			pErr = err
-		},
-	)
-
-	// Producer can't send message
-	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
-		if pErr != nil {
-			return assert.Equal(t, true, errors.Is(pErr, errMemoryBufferIsFull))
-		}
-		return false
+	_, err = p2.Send(context.Background(), &ProducerMessage{
+		Payload: createTestMessagePayload(1),
 	})
+	// Producer can't send message
+	assert.Equal(t, true, errors.Is(err, errMemoryBufferIsFull))
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4237,6 +4237,16 @@ func TestConsumerMemoryLimit(t *testing.T) {
 		}
 	}
 
+	// Fill up the messageCh of c1 and c2
+	for i := 0; i < 10; i++ {
+		p1.SendAsync(
+			context.Background(),
+			&ProducerMessage{Payload: createTestMessagePayload(1)},
+			func(id MessageID, producerMessage *ProducerMessage, err error) {
+			},
+		)
+	}
+
 	pc1.currentQueueSize.Store(8)
 	pc2.currentQueueSize.Store(8)
 

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4274,7 +4274,7 @@ func TestMultiConsumerMemoryLimit(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	defer c2.Close()
-	pc2 := c1.(*consumer).consumers[0]
+	pc2 := c2.(*consumer).consumers[0]
 
 	// Fill up the messageCh of c1 nad c2
 	for i := 0; i < 10; i++ {

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -382,6 +382,10 @@ func (msg *message) BrokerPublishTime() *time.Time {
 	return msg.brokerPublishTime
 }
 
+func (msg *message) size() int {
+	return len(msg.payLoad)
+}
+
 func newAckTracker(size uint) *ackTracker {
 	batchIDs := bitset.New(size)
 	for i := uint(0); i < size; i++ {

--- a/pulsar/internal/memory_limit_controller.go
+++ b/pulsar/internal/memory_limit_controller.go
@@ -56,8 +56,9 @@ func (t *thresholdTrigger) canTryRunning() bool {
 func (t *thresholdTrigger) setRunning(isRunning bool) {
 	if isRunning {
 		atomic.StoreInt32(&t.triggerRunning, 1)
+	} else {
+		atomic.StoreInt32(&t.triggerRunning, 0)
 	}
-	atomic.StoreInt32(&t.triggerRunning, 0)
 }
 
 // NewMemoryLimitController threshold valid range is (0, 1.0)

--- a/pulsar/internal/memory_limit_controller_test.go
+++ b/pulsar/internal/memory_limit_controller_test.go
@@ -171,7 +171,7 @@ func TestStepRelease(t *testing.T) {
 }
 
 func TestRegisterTrigger(t *testing.T) {
-	mlc := NewMemoryLimitController(100, 1.0)
+	mlc := NewMemoryLimitController(100, 0.95)
 	triggeredResult1 := false
 	triggeredResult2 := false
 	finishCh := make(chan struct{}, 2)
@@ -196,12 +196,12 @@ func TestRegisterTrigger(t *testing.T) {
 
 	mlc.TryReserveMemory(45)
 	timer.Reset(time.Millisecond * 100)
-	select {
-	case <-finishCh:
-		assert.True(t, triggeredResult1)
-		assert.True(t, triggeredResult2)
-	case <-timer.C:
-		assert.Error(t, fmt.Errorf("trigger timeout"))
+	for triggeredResult2 && triggeredResult1 {
+		select {
+		case <-finishCh:
+		case <-timer.C:
+			assert.Error(t, fmt.Errorf("trigger timeout"))
+		}
 	}
 
 	triggeredResult2 = false


### PR DESCRIPTION
Master Issue: #927 

### Motivation

This is part of the work for [PIP 74](https://github.com/apache/pulsar/wiki/PIP-74%3A-Pulsar-client-memory-limits) in go client.

More details in https://github.com/apache/pulsar-client-go/issues/927 .

### Modifications

- Consumer adds memory limit relate logic.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **GoDocs** / not documented)
