### PR TITLE
Fix batched messages not ACKed correctly when batch index ACK is disabled

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -499,6 +499,8 @@ func (pc *partitionConsumer) ackID(msgID MessageID, withResponse bool) error {
 	trackingID := toTrackingMessageID(msgID)
 
 	if trackingID != nil && trackingID.ack() {
+		// All messages in the same batch have been acknowledged, we only need to acknowledge the
+		// MessageID that represents the entry that stores the whole batch
 		trackingID = &trackingMessageID{
 			messageID: &messageID{
 				ledgerID: trackingID.ledgerID,

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -499,8 +499,12 @@ func (pc *partitionConsumer) ackID(msgID MessageID, withResponse bool) error {
 	trackingID := toTrackingMessageID(msgID)
 
 	if trackingID != nil && trackingID.ack() {
-		trackingID.batchIdx = -1
-		trackingID.batchSize = 0
+		trackingID = &trackingMessageID{
+			messageID: &messageID{
+				ledgerID: trackingID.ledgerID,
+				entryID:  trackingID.entryID,
+			},
+		}
 		pc.metrics.AcksCounter.Inc()
 		pc.metrics.ProcessingTime.Observe(float64(time.Now().UnixNano()-trackingID.receivedTime.UnixNano()) / 1.0e9)
 	} else if !pc.options.enableBatchIndexAck {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/993

### Motivation

When batch index ACK is disabled, if N messages in a batch are acknowledged, currently only the batched message ID of the last message will be acknowledged. This behavior is wrong because we need to acknowledge the whole batch.

### Modifications

- Create a new trackingMessageID that has no batch index and size fields for this case
- Add `TestConsumerBatchIndexAckDisabled` to cover this case