### PR TITLE
[fix]: Fix panic caused by retryAssert()

### DIFF
--- a/pulsar/helper_for_test.go
+++ b/pulsar/helper_for_test.go
@@ -177,9 +177,14 @@ func retryAssert(t assert.TestingT, times int, milliseconds int, update func(), 
 	for i := 0; i < times; i++ {
 		time.Sleep(time.Duration(milliseconds) * time.Millisecond)
 		update()
-		if assert(nil) {
+		if assert(fakeAssertT{}) {
 			break
 		}
 	}
 	assert(t)
+}
+
+type fakeAssertT struct{}
+
+func (fa fakeAssertT) Errorf(format string, args ...interface{}) {
 }


### PR DESCRIPTION
### Motivation

retryAssert() will cause panic when assert failed.

For example.

```
func TestRetryAssert(t *testing.T) {
	retryAssert(t, 5, 200, func() {}, func(t assert.TestingT) bool {
		return assert.Equal(t, 1, 12)
	})
}
```

Result.

```
=== RUN   TestRetryAssert
--- FAIL: TestRetryAssert (0.20s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1047ffe40]
```

This is because when assert failed, t.Errorf() will be invoked. However, retryAssert passed a nil value.

https://github.com/apache/pulsar-client-go/blob/04ad521e6d061768ff02ac9bf024932d45b2bd94/pulsar/helper_for_test.go#L180

### Modifications

- Fix retryAssert() to avoid panic()

### Verifying this change

- [x] Make sure that the change passes the CI checks.
