### PR TITLE
[feature] Message payload processor PIP-96

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -242,6 +242,12 @@ type ConsumerOptions struct {
 	// NOTE: This option does not work if AckWithResponse is true
 	//	because there are only synchronous APIs for acknowledgment
 	AckGroupingOptions *AckGroupingOptions
+
+	// Process the message if it is not nil. If it's nil, the messages will be
+	// considered to be in pulsar's format. If they are in different format, the client
+	// may produce errors when processing.
+	// See PIP-96 https://github.com/apache/pulsar/wiki/PIP-96%3A-Message-payload-processor-for-Pulsar-client
+	MessagePayloadProcessor MessagePayloadProcessor
 }
 
 // Consumer is an interface that abstracts behavior of Pulsar's consumer

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -400,6 +400,7 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 				enableBatchIndexAck:         c.options.EnableBatchIndexAcknowledgment,
 				ackGroupingOptions:          c.options.AckGroupingOptions,
 				autoReceiverQueueSize:       c.options.EnableAutoScaledReceiverQueueSize,
+				messagePayloadProcessor:     c.options.MessagePayloadProcessor,
 			}
 			cons, err := newPartitionConsumer(c, c.client, opts, c.messageCh, c.dlq, c.metrics)
 			ch <- ConsumerError{
@@ -565,7 +566,7 @@ func (c *consumer) ReconsumeLaterWithCustomProperties(msg Message, customPropert
 
 	consumerMsg := ConsumerMessage{
 		Consumer: c,
-		Message: &message{
+		Message: &MessageImpl{
 			payLoad:    msg.Payload(),
 			properties: props,
 			msgID:      msgID,

--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -30,7 +30,7 @@ import (
 func TestSingleMessageIDNoAckTracker(t *testing.T) {
 	eventsCh := make(chan interface{}, 1)
 	pc := partitionConsumer{
-		queueCh:              make(chan []*message, 1),
+		queueCh:              make(chan []*MessageImpl, 1),
 		eventsCh:             eventsCh,
 		compressionProviders: sync.Map{},
 		options:              &partitionConsumerOpts{},
@@ -69,7 +69,7 @@ func newTestMetrics() *internal.LeveledMetrics {
 func TestBatchMessageIDNoAckTracker(t *testing.T) {
 	eventsCh := make(chan interface{}, 1)
 	pc := partitionConsumer{
-		queueCh:              make(chan []*message, 1),
+		queueCh:              make(chan []*MessageImpl, 1),
 		eventsCh:             eventsCh,
 		compressionProviders: sync.Map{},
 		options:              &partitionConsumerOpts{},
@@ -105,7 +105,7 @@ func TestBatchMessageIDNoAckTracker(t *testing.T) {
 func TestBatchMessageIDWithAckTracker(t *testing.T) {
 	eventsCh := make(chan interface{}, 1)
 	pc := partitionConsumer{
-		queueCh:              make(chan []*message, 1),
+		queueCh:              make(chan []*MessageImpl, 1),
 		eventsCh:             eventsCh,
 		compressionProviders: sync.Map{},
 		options:              &partitionConsumerOpts{},

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -63,7 +63,7 @@ func (r *dlqRouter) shouldSendToDlq(cm *ConsumerMessage) bool {
 		return false
 	}
 
-	msg := cm.Message.(*message)
+	msg := cm.Message.(*MessageImpl)
 	r.log.WithField("count", msg.redeliveryCount).
 		WithField("max", r.policy.MaxDeliveries).
 		WithField("msgId", msg.msgID).
@@ -90,7 +90,7 @@ func (r *dlqRouter) run() {
 		case cm := <-r.messageCh:
 			r.log.WithField("msgID", cm.ID()).Debug("Got message for DLQ")
 			producer := r.getProducer(cm.Consumer.(*consumer).options.Schema)
-			msg := cm.Message.(*message)
+			msg := cm.Message.(*MessageImpl)
 			msgID := msg.ID()
 
 			// properties associated with original message

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -58,6 +58,13 @@ func NewMessageReader(headersAndPayload Buffer) *MessageReader {
 	}
 }
 
+func NewBatchMessageReader(headersAndPayload Buffer) *MessageReader {
+	return &MessageReader{
+		buffer:  headersAndPayload,
+		batched: true,
+	}
+}
+
 func NewMessageReaderFromArray(headersAndPayload []byte) *MessageReader {
 	return NewMessageReader(NewBufferWrapper(headersAndPayload))
 }
@@ -78,47 +85,39 @@ type MessageReader struct {
 	batched bool
 }
 
-// ReadChecksum
-func (r *MessageReader) readChecksum() (uint32, error) {
-	if r.buffer.ReadableBytes() < 6 {
-		return 0, errors.New("missing message header")
+// VerifyChecksum verify checksum only if first two bytes matches with magic number
+// following same approach as Java pluser client
+func (r *MessageReader) VerifyChecksumIfExists() (bool, error) {
+	if r.buffer.ReadableBytes() < 2 {
+		return false, errors.New("missing message header")
 	}
 	// reader magic number
-	magicNumber := r.buffer.ReadUint16()
+	magicNumber := binary.BigEndian.Uint16(r.buffer.Get(r.buffer.ReaderIndex(), 2))
 	if magicNumber != magicCrc32c {
-		return 0, ErrCorruptedMessage
+		// if checksum is not available, validation return true and nil error
+		return true, nil
 	}
+	r.buffer.Skip(2)
 	checksum := r.buffer.ReadUint32()
-	return checksum, nil
+	computedChecksum := Crc32cCheckSum(r.buffer.ReadableSlice())
+	if checksum != computedChecksum {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (r *MessageReader) ReadMessageMetadata() (*pb.MessageMetadata, error) {
-	// Wire format
+	// Wire format of pulsar entry format
 	// [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA]
-
-	// read checksum
-	checksum, err := r.readChecksum()
-	if err != nil {
-		return nil, err
-	}
-
-	// validate checksum
-	computedChecksum := Crc32cCheckSum(r.buffer.ReadableSlice())
-	if checksum != computedChecksum {
-		return nil, fmt.Errorf("checksum mismatch received: 0x%x computed: 0x%x", checksum, computedChecksum)
-	}
-
 	size := r.buffer.ReadUint32()
 	data := r.buffer.Read(size)
 	var meta pb.MessageMetadata
 	if err := proto.Unmarshal(data, &meta); err != nil {
 		return nil, ErrCorruptedMessage
 	}
-
 	if meta.NumMessagesInBatch != nil {
 		r.batched = true
 	}
-
 	return &meta, nil
 }
 

--- a/pulsar/internal/commands_test.go
+++ b/pulsar/internal/commands_test.go
@@ -18,6 +18,7 @@
 package internal
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,10 @@ func TestConvertStringMap(t *testing.T) {
 func TestReadMessageMetadata(t *testing.T) {
 	// read old style message (not batched)
 	reader := NewMessageReaderFromArray(rawCompatSingleMessage)
+	ok, err := reader.VerifyChecksumIfExists()
+	if !ok || err != nil {
+		t.Fatal(errors.New("checksum validation failed"))
+	}
 	meta, err := reader.ReadMessageMetadata()
 	if err != nil {
 		t.Fatal(err)
@@ -55,6 +60,10 @@ func TestReadMessageMetadata(t *testing.T) {
 
 	// read message with batch of 1
 	reader = NewMessageReaderFromArray(rawBatchMessage1)
+	ok, err = reader.VerifyChecksumIfExists()
+	if !ok || err != nil {
+		t.Fatal(errors.New("checksum validation failed"))
+	}
 	meta, err = reader.ReadMessageMetadata()
 	if err != nil {
 		t.Fatal(err)
@@ -63,6 +72,10 @@ func TestReadMessageMetadata(t *testing.T) {
 
 	// read message with batch of 10
 	reader = NewMessageReaderFromArray(rawBatchMessage10)
+	ok, err = reader.VerifyChecksumIfExists()
+	if !ok || err != nil {
+		t.Fatal(errors.New("checksum validation failed"))
+	}
 	meta, err = reader.ReadMessageMetadata()
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +98,11 @@ func TestReadBrokerEntryMetadata(t *testing.T) {
 
 func TestReadMessageOldFormat(t *testing.T) {
 	reader := NewMessageReaderFromArray(rawCompatSingleMessage)
-	_, err := reader.ReadMessageMetadata()
+	ok, err := reader.VerifyChecksumIfExists()
+	if !ok || err != nil {
+		t.Fatal(errors.New("checksum validation failed"))
+	}
+	_, err = reader.ReadMessageMetadata()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,6 +121,10 @@ func TestReadMessageOldFormat(t *testing.T) {
 
 func TestReadMessagesBatchSize1(t *testing.T) {
 	reader := NewMessageReaderFromArray(rawBatchMessage1)
+	ok, err := reader.VerifyChecksumIfExists()
+	if !ok || err != nil {
+		t.Fatal(errors.New("checksum validation failed"))
+	}
 	meta, err := reader.ReadMessageMetadata()
 	if err != nil {
 		t.Fatal(err)
@@ -125,6 +146,10 @@ func TestReadMessagesBatchSize1(t *testing.T) {
 
 func TestReadMessagesBatchSize10(t *testing.T) {
 	reader := NewMessageReaderFromArray(rawBatchMessage10)
+	ok, err := reader.VerifyChecksumIfExists()
+	if !ok || err != nil {
+		t.Fatal(errors.New("checksum validation failed"))
+	}
 	meta, err := reader.ReadMessageMetadata()
 	if err != nil {
 		t.Fatal(err)

--- a/pulsar/internal/topic_name.go
+++ b/pulsar/internal/topic_name.go
@@ -138,3 +138,11 @@ func IsV2TopicName(tn *TopicName) bool {
 func GetTopicRestPath(tn *TopicName) string {
 	return fmt.Sprintf("%s/%s/%s", tn.Domain, tn.Namespace, url.QueryEscape(tn.Topic))
 }
+
+func IsPersistent(topic string) bool {
+	tn, err := ParseTopicName(topic)
+	if err != nil {
+		return false
+	}
+	return tn.Domain == "persistent"
+}

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -160,6 +160,9 @@ type MessageID interface {
 
 	// String returns message id in string format
 	String() string
+
+	//equal compare another MessageID and returns true both are same and false otherwise.
+	equal(other MessageID) bool
 }
 
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation

--- a/pulsar/payload_processor.go
+++ b/pulsar/payload_processor.go
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"errors"
+
+	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
+	"github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/bits-and-blooms/bitset"
+)
+
+var (
+	ErrBatchDeSerialization = errors.New("failed to deserialize")
+)
+
+type MessagePayloadProcessor interface {
+	//Passing payload as byte slice instead of explosing internal Buffer
+	Process(ctx *MessagePayloadContext, payload []byte, schema Schema, consume ConsumeMessages) error
+}
+
+// MessagePayloadContext only carries the nessesary data to process the message
+type MessagePayloadContext struct {
+	batch           bool
+	topic           string
+	redeliveryCount uint32
+	msgID           MessageID
+	startMsgID      MessageID
+	ackSet          *bitset.BitSet
+	schema          Schema
+	schemaInfoCache *schemaInfoCache
+	msgMetaData     *pb.MessageMetadata
+	brokerMetaData  *pb.BrokerEntryMetadata
+	pc              *partitionConsumer
+	logger          log.Logger
+}
+
+func (ctx MessagePayloadContext) GetTopic() string {
+	return ctx.topic
+}
+
+func (ctx MessagePayloadContext) IsBatch() bool {
+	return ctx.batch
+}
+
+func (ctx MessagePayloadContext) GetNumMessages() int {
+	if ctx.msgMetaData.NumMessagesInBatch == nil {
+		return 0
+	}
+	return int(*ctx.msgMetaData.NumMessagesInBatch)
+}
+
+func (ctx MessagePayloadContext) GetProperty(key string) (value string, found bool) {
+	for _, kv := range ctx.msgMetaData.Properties {
+		if *kv.Key == key {
+			return *kv.Value, true
+		}
+	}
+	return "", false
+}
+
+func (ctx MessagePayloadContext) GetProperties() map[string]string {
+	return toStringMap(ctx.msgMetaData.Properties)
+}
+
+// ConsumeMessages will be used to dispatch messages from Processor
+type ConsumeMessages func([]Message)

--- a/pulsar/payload_processor_impl.go
+++ b/pulsar/payload_processor_impl.go
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import "context"
+
+type DefaultPayloadProcessor struct {
+}
+
+func (p DefaultPayloadProcessor) Process(
+	ctx *MessagePayloadContext,
+	payload []byte,
+	schmea Schema,
+	consume ConsumeMessages) error {
+	messages := make([]Message, 0, 10)
+	reader := NewPayloadReader(ctx, payload, true)
+
+	for reader.HasNext() {
+		msg, err := reader.Next(context.Background())
+		if err != nil {
+			return ErrBatchDeSerialization
+		}
+		if msg != nil {
+			messages = append(messages, msg)
+		}
+	}
+	consume(messages)
+	return nil
+}

--- a/pulsar/payload_processor_impl_test.go
+++ b/pulsar/payload_processor_impl_test.go
@@ -1,0 +1,256 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProducerConsumerWithDefaultProcessor(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := "my-topic1"
+	ctx := context.Background()
+
+	// create consumer
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:                   topic,
+		SubscriptionName:        "my-sub",
+		Type:                    Exclusive,
+		MessagePayloadProcessor: DefaultPayloadProcessor{},
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: false,
+		BatchingMaxSize: 10,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 10 messages
+	for i := 0; i < 10; i++ {
+		producer.SendAsync(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+			Key:     "pulsar",
+		}, func(mi MessageID, pm *ProducerMessage, err error) {
+			assert.Nil(t, err)
+		})
+	}
+
+	// receive 10 messages
+	for i := 0; i < 10; i++ {
+		msg, err := consumer.Receive(context.Background())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		expectMsg := fmt.Sprintf("hello-%d", i)
+
+		assert.Equal(t, []byte(expectMsg), msg.Payload())
+		assert.Equal(t, "pulsar", msg.Key())
+		// ack message
+		consumer.Ack(msg)
+	}
+}
+
+type CustomBatchFormatMeta struct {
+	numMessages int
+}
+
+/**
+ * A batch message whose format is customized.
+ *
+ * 1. First 2 bytes represent the number of messages.
+ * 2. Each message is a string, whose format is
+ *   1. First 2 bytes represent the length `N`.
+ *   2. Followed N bytes are the bytes of the string.
+ */
+type CustomBatchFormat struct {
+}
+
+func (f CustomBatchFormat) Serialize(messages []string) []byte {
+	buf := make([]byte, 2, 1024)
+	binary.LittleEndian.PutUint16(buf, uint16(len(messages)))
+	fmt.Println("len ", len(messages))
+
+	for _, message := range messages {
+		sizeBytes := make([]byte, 2)
+		binary.LittleEndian.PutUint16(sizeBytes, uint16(len(message)))
+		buf = append(buf, sizeBytes...)
+		buf = append(buf, []byte(message)...)
+	}
+	return buf
+}
+
+func (f CustomBatchFormat) ReadMetaData(data *[]byte) CustomBatchFormatMeta {
+	numMsgs := binary.LittleEndian.Uint16(*data)
+	*data = (*data)[2:]
+	return CustomBatchFormatMeta{
+		numMessages: int(numMsgs),
+	}
+}
+
+func (f CustomBatchFormat) ReadMessage(data *[]byte) []byte {
+	size := binary.LittleEndian.Uint16(*data)
+	*data = (*data)[2:]
+	fmt.Println("Message Size = ", size)
+	fmt.Println("Bytes after = ", *data)
+	msg := (*data)[:size]
+	*data = (*data)[size:]
+	return msg
+}
+
+type CustomBatchPayloadProcessor struct {
+}
+
+func (p CustomBatchPayloadProcessor) Process(
+	ctx *MessagePayloadContext,
+	payload []byte,
+	schema Schema,
+	consumer ConsumeMessages) error {
+	entryFormat, found := ctx.GetProperty("entry.format")
+	if found && entryFormat != "custom" {
+		return DefaultPayloadProcessor{}.Process(ctx, payload, schema, consumer)
+	}
+	fmt.Println("Payload  = ", payload)
+	customEntryFormat := CustomBatchFormat{}
+	meta := customEntryFormat.ReadMetaData(&payload)
+
+	messages := make([]Message, meta.numMessages)
+	fmt.Println("Num Messages = ", meta.numMessages)
+	for index := 0; index < meta.numMessages; index++ {
+		msgPayload := customEntryFormat.ReadMessage(&payload)
+		fmt.Println("message = ", msgPayload)
+		fmt.Println("Remaining bytes = ", payload)
+		msg := &MessageImpl{
+			payLoad:      msgPayload,
+			topic:        ctx.topic,
+			producerName: *ctx.msgMetaData.ProducerName,
+			msgID: &messageID{
+				ledgerID:     ctx.msgID.LedgerID(),
+				entryID:      ctx.msgID.EntryID(),
+				batchSize:    int32(meta.numMessages),
+				partitionIdx: ctx.msgID.PartitionIdx(),
+				batchIdx:     int32(index),
+			},
+		}
+
+		messages = append(messages, msg)
+	}
+	consumer(messages)
+	return nil
+}
+
+type CustomBatchProducer struct {
+	producer Producer
+	messages []string
+}
+
+// Send method won't send messages immediately, We'll serialize and send only when
+// Flush is called.
+func (cp *CustomBatchProducer) SendAsync(message string) {
+	if cp.messages == nil {
+		cp.messages = make([]string, 0, 10)
+	}
+	cp.messages = append(cp.messages, message)
+}
+
+func (cp *CustomBatchProducer) Flush() error {
+	customFormat := CustomBatchFormat{}
+	payload := customFormat.Serialize(cp.messages)
+	cp.messages = nil
+	msg := &ProducerMessage{
+		Payload: payload,
+		Properties: map[string]string{
+			"entry.format": "custom",
+		},
+	}
+	_, err := cp.producer.Send(context.Background(), msg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cp *CustomBatchProducer) Close() {
+	cp.producer.Close()
+}
+
+func TestProducerConsumerWithCustomProcessor(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := "my-topic2"
+	// create consumer
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:                   topic,
+		SubscriptionName:        "my-sub",
+		Type:                    Exclusive,
+		MessagePayloadProcessor: CustomBatchPayloadProcessor{},
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	customBatchMsgProducer := CustomBatchProducer{producer: producer}
+
+	// send 10 messages
+	for i := 0; i < 10; i++ {
+		customBatchMsgProducer.SendAsync(fmt.Sprintf("hello-%d", i))
+	}
+	customBatchMsgProducer.Flush()
+
+	// receive 10 messages
+	for i := 0; i < 10; i++ {
+		msg, err := consumer.Receive(context.Background())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		expectMsg := fmt.Sprintf("hello-%d", i)
+		assert.Equal(t, []byte(expectMsg), msg.Payload())
+		// ack message
+		consumer.Ack(msg)
+	}
+}

--- a/pulsar/payload_reader_impl.go
+++ b/pulsar/payload_reader_impl.go
@@ -1,0 +1,204 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar/internal"
+	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
+)
+
+var (
+	ErrNoMoreMessagesToRead = errors.New("no more messages to read")
+	ErrNotImplemented       = errors.New("method not implemented")
+)
+
+// PayloadReader implements Reader interface and provide convinent methods
+// for processing byte slice payload.
+// In PIP-96, two methods(getMessageAt & asSingleMessage) are propsed for Java Client.
+// Provide similar capablities using this reader
+type PayloadReader struct {
+	buffer internal.Buffer
+	msgCtx *MessagePayloadContext
+	// currentBatchIdx will be increased after every successful Next call
+	currentBatchIdx int
+	errorOccurred   bool
+	containMeta     bool
+}
+
+func NewPayloadReader(msgCtx *MessagePayloadContext, payload []byte, containMeta bool) *PayloadReader {
+	return &PayloadReader{
+		buffer:      internal.NewBufferWrapper(payload),
+		msgCtx:      msgCtx,
+		containMeta: containMeta,
+	}
+}
+
+func (pr *PayloadReader) Reset(data []byte) {
+	pr.buffer = internal.NewBufferWrapper(data)
+}
+
+func (pr *PayloadReader) Topic() string {
+	return pr.msgCtx.topic
+}
+
+func (pr *PayloadReader) Next(ctx context.Context) (Message, error) {
+	if !(pr.currentBatchIdx < pr.msgCtx.GetNumMessages() && !pr.errorOccurred) {
+		return nil, ErrNoMoreMessagesToRead
+	}
+	if pr.msgCtx.IsBatch() {
+		return pr.readNextBatchMessage()
+	}
+	return pr.readAsSingleMessage()
+}
+
+func (pr *PayloadReader) HasNext() bool {
+	return pr.currentBatchIdx < pr.msgCtx.GetNumMessages() && !pr.errorOccurred
+}
+
+func (pr *PayloadReader) Close() {
+}
+
+func (pr *PayloadReader) Seek(id MessageID) error {
+	return ErrNotImplemented
+}
+
+func (pr *PayloadReader) SeekByTime(time time.Time) error {
+	return ErrNotImplemented
+}
+
+func (pr *PayloadReader) readAsSingleMessage() (Message, error) {
+	var messageIndex *uint64
+	var brokerPublishTime *time.Time
+
+	msg := &MessageImpl{
+		publishTime:         timeFromUnixTimestampMillis(pr.msgCtx.msgMetaData.GetPublishTime()),
+		eventTime:           timeFromUnixTimestampMillis(pr.msgCtx.msgMetaData.GetEventTime()),
+		key:                 pr.msgCtx.msgMetaData.GetPartitionKey(),
+		orderingKey:         string(pr.msgCtx.msgMetaData.OrderingKey),
+		producerName:        pr.msgCtx.msgMetaData.GetProducerName(),
+		payLoad:             pr.buffer.ReadableSlice(),
+		msgID:               pr.msgCtx.msgID,
+		properties:          internal.ConvertToStringMap(pr.msgCtx.msgMetaData.GetProperties()),
+		topic:               pr.msgCtx.topic,
+		replicationClusters: pr.msgCtx.msgMetaData.GetReplicateTo(),
+		replicatedFrom:      pr.msgCtx.msgMetaData.GetReplicatedFrom(),
+		redeliveryCount:     pr.msgCtx.redeliveryCount,
+		schema:              pr.msgCtx.schema,
+		schemaVersion:       pr.msgCtx.msgMetaData.GetSchemaVersion(),
+		schemaInfoCache:     pr.msgCtx.schemaInfoCache,
+		encryptionContext:   createEncryptionContext(pr.msgCtx.msgMetaData),
+		index:               messageIndex,
+		brokerPublishTime:   brokerPublishTime,
+	}
+	return msg, nil
+}
+
+func (pr *PayloadReader) readNextBatchMessage() (Message, error) {
+	// avoid increasing pr.currentBatchIdx until it finishes successfully
+	index := pr.currentBatchIdx + 1
+
+	msgReader := internal.NewBatchMessageReader(pr.buffer)
+
+	var singleMsgMeta *pb.SingleMessageMetadata
+	var payload []byte
+	var err error
+	if pr.containMeta {
+		singleMsgMeta, payload, err = msgReader.ReadMessage()
+		if err != nil || payload == nil {
+			pr.errorOccurred = true
+			return nil, err
+		}
+	} else {
+		payload = pr.buffer.ReadableSlice()
+		singleMsgMeta = &pb.SingleMessageMetadata{}
+	}
+
+	if pr.msgCtx.ackSet != nil && !pr.msgCtx.ackSet.Test(uint(index)) {
+		pr.msgCtx.logger.Debugf("Ignoring message from %vth message, which has been acknowledged", index)
+		return nil, nil
+	}
+
+	trackingMsgID := newTrackingMessageID(
+		pr.msgCtx.msgID.LedgerID(),
+		pr.msgCtx.msgID.EntryID(),
+		int32(index),
+		pr.msgCtx.msgID.PartitionIdx(),
+		int32(pr.msgCtx.GetNumMessages()),
+		newAckTracker(uint(pr.msgCtx.GetNumMessages())))
+	trackingMsgID.consumer = pr.msgCtx.pc
+
+	if pr.msgCtx.pc.messageShouldBeDiscarded(trackingMsgID) {
+		pr.msgCtx.pc.AckID(trackingMsgID)
+		return nil, nil
+	}
+
+	var msgID MessageID
+	isChunkedMsg := pr.msgCtx.msgMetaData.GetNumChunksFromMsg() > 1
+	if isChunkedMsg {
+		ctx := pr.msgCtx.pc.chunkedMsgCtxMap.get(pr.msgCtx.msgMetaData.GetUuid())
+		if ctx == nil {
+			// chunkedMsgCtxMap has closed because of consumer closed
+			pr.msgCtx.pc.log.Warnf("get chunkedMsgCtx for chunk with uuid %s failed because consumer has closed",
+				pr.msgCtx.msgMetaData.Uuid)
+			return nil, nil
+		}
+		cmid := newChunkMessageID(ctx.firstChunkID(), ctx.lastChunkID())
+		// set the consumer so we know how to ack the message id
+		cmid.consumer = pr.msgCtx.pc
+		// clean chunkedMsgCtxMap
+		pr.msgCtx.pc.chunkedMsgCtxMap.remove(pr.msgCtx.msgMetaData.GetUuid())
+		pr.msgCtx.pc.unAckChunksTracker.add(cmid, ctx.chunkedMsgIDs)
+		msgID = cmid
+	} else {
+		msgID = trackingMsgID
+	}
+
+	if pr.msgCtx.pc.ackGroupingTracker.isDuplicate(msgID) {
+		return nil, nil
+	}
+
+	msgIndex := getMessageIndex(pr.msgCtx.brokerMetaData, index+1, pr.msgCtx.GetNumMessages())
+	brokerPublishTime := getBrokerPublishTime(pr.msgCtx.brokerMetaData)
+	msg := &MessageImpl{
+		publishTime:         timeFromUnixTimestampMillis(pr.msgCtx.msgMetaData.GetPublishTime()),
+		eventTime:           timeFromUnixTimestampMillis(singleMsgMeta.GetEventTime()),
+		key:                 singleMsgMeta.GetPartitionKey(),
+		producerName:        pr.msgCtx.msgMetaData.GetProducerName(),
+		properties:          internal.ConvertToStringMap(singleMsgMeta.GetProperties()),
+		topic:               pr.msgCtx.topic,
+		msgID:               trackingMsgID,
+		payLoad:             payload,
+		schema:              pr.msgCtx.schema,
+		replicationClusters: pr.msgCtx.msgMetaData.GetReplicateTo(),
+		replicatedFrom:      pr.msgCtx.msgMetaData.GetReplicatedFrom(),
+		redeliveryCount:     pr.msgCtx.redeliveryCount,
+		schemaVersion:       pr.msgCtx.msgMetaData.GetSchemaVersion(),
+		schemaInfoCache:     pr.msgCtx.schemaInfoCache,
+		orderingKey:         string(singleMsgMeta.GetOrderingKey()),
+		encryptionContext:   createEncryptionContext(pr.msgCtx.msgMetaData),
+		brokerPublishTime:   &brokerPublishTime,
+		index:               &msgIndex,
+	}
+	pr.currentBatchIdx = pr.currentBatchIdx + 1
+
+	return msg, nil
+}

--- a/pulsar/payload_reader_impl_test.go
+++ b/pulsar/payload_reader_impl_test.go
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar/internal"
+	proto "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPayloadReader(t *testing.T) {
+	msgCtx := &MessagePayloadContext{}
+	payload := make([]byte, 10)
+	containMeta := false
+
+	pr := NewPayloadReader(msgCtx, payload, containMeta)
+
+	assert.Equal(t, msgCtx, pr.msgCtx)
+	assert.Equal(t, payload, pr.buffer.ReadableSlice())
+	assert.Equal(t, containMeta, pr.containMeta)
+}
+
+func TestReset(t *testing.T) {
+	payload := make([]byte, 2)
+	pr := NewPayloadReader(&MessagePayloadContext{}, payload, true)
+
+	assert.Equal(t, payload, pr.buffer.ReadableSlice())
+	pr.Reset(make([]byte, 0))
+
+	assert.NotEqual(t, pr.buffer.ReadableSlice(), payload)
+	assert.Equal(t, len(pr.buffer.ReadableSlice()), 0)
+}
+
+func TestTopic(t *testing.T) {
+	msgCtx := &MessagePayloadContext{topic: "test1"}
+
+	pr := NewPayloadReader(msgCtx, make([]byte, 2), false)
+
+	assert.Equal(t, pr.Topic(), "test1")
+}
+
+func TestNext(t *testing.T) {
+	var batchSize int32 = 10
+	pr := &PayloadReader{
+		buffer:        internal.NewBuffer(10),
+		errorOccurred: true,
+		msgCtx: &MessagePayloadContext{
+			msgMetaData: &proto.MessageMetadata{NumMessagesInBatch: &batchSize},
+		},
+	}
+	_, err := pr.Next(context.Background())
+
+	assert.Equal(t, err, ErrNoMoreMessagesToRead)
+
+	pr.errorOccurred = false
+
+	_, err = pr.Next(context.Background())
+	assert.Nil(t, err)
+
+	pr.currentBatchIdx = 10
+
+	_, err = pr.Next(context.Background())
+	assert.Equal(t, err, ErrNoMoreMessagesToRead)
+}
+
+func TestHasNext(t *testing.T) {
+	var batchSize int32 = 10
+	pr := &PayloadReader{
+		buffer:        internal.NewBuffer(10),
+		errorOccurred: false,
+		msgCtx: &MessagePayloadContext{
+			msgMetaData: &proto.MessageMetadata{NumMessagesInBatch: &batchSize},
+		},
+	}
+
+	hasNext := pr.HasNext()
+	assert.True(t, hasNext)
+
+	pr.errorOccurred = true
+	hasNext = pr.HasNext()
+	assert.False(t, hasNext)
+
+	pr.errorOccurred = false
+	pr.currentBatchIdx = 10
+	hasNext = pr.HasNext()
+	assert.False(t, hasNext)
+}
+
+func TestSeek(t *testing.T) {
+	pr := &PayloadReader{}
+	err := pr.Seek(&myMessageID{})
+	assert.Equal(t, err, ErrNotImplemented)
+}
+
+func TestSeekByTime(t *testing.T) {
+	pr := &PayloadReader{}
+	err := pr.SeekByTime(time.Now())
+	assert.Equal(t, err, ErrNotImplemented)
+}
+
+func TestReadAsSingleMessage(t *testing.T) {
+	var batchSize int32 = 1
+	payload := make([]byte, 10)
+	pr := &PayloadReader{
+		buffer: internal.NewBufferWrapper(payload),
+		msgCtx: &MessagePayloadContext{
+			topic:       "test1",
+			msgMetaData: &proto.MessageMetadata{NumMessagesInBatch: &batchSize},
+		},
+	}
+	msg, err := pr.readAsSingleMessage()
+	assert.Nil(t, err)
+	assert.Equal(t, msg.Payload(), payload)
+	assert.Equal(t, msg.Topic(), "test1")
+}
+
+func TestReadNextBatchMessage(t *testing.T) {
+	var batchSize int32 = 10
+	pr := &PayloadReader{
+		buffer: internal.NewBufferWrapper(batchMessage10),
+		msgCtx: &MessagePayloadContext{
+			msgID:       &messageID{},
+			topic:       "test1",
+			msgMetaData: &proto.MessageMetadata{NumMessagesInBatch: &batchSize},
+			pc: &partitionConsumer{
+				ackGroupingTracker: &timedAckGroupingTracker{
+					lastCumulativeAck: &messageID{},
+				},
+			},
+		},
+		containMeta: true,
+	}
+	for i := 0; i < int(batchSize); i++ {
+		msg, err := pr.readNextBatchMessage()
+		assert.Nil(t, err)
+		assert.Equal(t, len("hello"), len(msg.Payload()))
+	}
+}
+
+// Message with batch of 10
+// singe message metadata properties:<key:"a" value:"1" > properties:<key:"b" value:"2" >
+// payload = "hello"
+var batchMessage10 = []byte{
+	0x00, 0x00, 0x00, 0x16, 0x0a,
+	0x06, 0x0a, 0x01, 0x61, 0x12, 0x01, 0x31, 0x0a,
+	0x06, 0x0a, 0x01, 0x62, 0x12, 0x01, 0x32, 0x18,
+	0x05, 0x28, 0x05, 0x40, 0x00, 0x68, 0x65, 0x6c,
+	0x6c, 0x6f, 0x00, 0x00, 0x00, 0x16, 0x0a, 0x06,
+	0x0a, 0x01, 0x61, 0x12, 0x01, 0x31, 0x0a, 0x06,
+	0x0a, 0x01, 0x62, 0x12, 0x01, 0x32, 0x18, 0x05,
+	0x28, 0x05, 0x40, 0x01, 0x68, 0x65, 0x6c, 0x6c,
+	0x6f, 0x00, 0x00, 0x00, 0x16, 0x0a, 0x06, 0x0a,
+	0x01, 0x61, 0x12, 0x01, 0x31, 0x0a, 0x06, 0x0a,
+	0x01, 0x62, 0x12, 0x01, 0x32, 0x18, 0x05, 0x28,
+	0x05, 0x40, 0x02, 0x68, 0x65, 0x6c, 0x6c, 0x6f,
+	0x00, 0x00, 0x00, 0x16, 0x0a, 0x06, 0x0a, 0x01,
+	0x61, 0x12, 0x01, 0x31, 0x0a, 0x06, 0x0a, 0x01,
+	0x62, 0x12, 0x01, 0x32, 0x18, 0x05, 0x28, 0x05,
+	0x40, 0x03, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00,
+	0x00, 0x00, 0x16, 0x0a, 0x06, 0x0a, 0x01, 0x61,
+	0x12, 0x01, 0x31, 0x0a, 0x06, 0x0a, 0x01, 0x62,
+	0x12, 0x01, 0x32, 0x18, 0x05, 0x28, 0x05, 0x40,
+	0x04, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00,
+	0x00, 0x16, 0x0a, 0x06, 0x0a, 0x01, 0x61, 0x12,
+	0x01, 0x31, 0x0a, 0x06, 0x0a, 0x01, 0x62, 0x12,
+	0x01, 0x32, 0x18, 0x05, 0x28, 0x05, 0x40, 0x05,
+	0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00,
+	0x16, 0x0a, 0x06, 0x0a, 0x01, 0x61, 0x12, 0x01,
+	0x31, 0x0a, 0x06, 0x0a, 0x01, 0x62, 0x12, 0x01,
+	0x32, 0x18, 0x05, 0x28, 0x05, 0x40, 0x06, 0x68,
+	0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x16,
+	0x0a, 0x06, 0x0a, 0x01, 0x61, 0x12, 0x01, 0x31,
+	0x0a, 0x06, 0x0a, 0x01, 0x62, 0x12, 0x01, 0x32,
+	0x18, 0x05, 0x28, 0x05, 0x40, 0x07, 0x68, 0x65,
+	0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0x16, 0x0a,
+	0x06, 0x0a, 0x01, 0x61, 0x12, 0x01, 0x31, 0x0a,
+	0x06, 0x0a, 0x01, 0x62, 0x12, 0x01, 0x32, 0x18,
+	0x05, 0x28, 0x05, 0x40, 0x08, 0x68, 0x65, 0x6c,
+	0x6c, 0x6f, 0x00, 0x00, 0x00, 0x16, 0x0a, 0x06,
+	0x0a, 0x01, 0x61, 0x12, 0x01, 0x31, 0x0a, 0x06,
+	0x0a, 0x01, 0x62, 0x12, 0x01, 0x32, 0x18, 0x05,
+	0x28, 0x05, 0x40, 0x09, 0x68, 0x65, 0x6c, 0x6c,
+	0x6f,
+}

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -481,6 +481,12 @@ func (id *myMessageID) String() string {
 	return fmt.Sprintf("%d:%d:%d", mid.LedgerID(), mid.EntryID(), mid.PartitionIdx())
 }
 
+func (id *myMessageID) equal(other MessageID) bool {
+	return id.LedgerID() == other.LedgerID() &&
+		id.EntryID() == other.EntryID() &&
+		id.BatchIdx() == other.BatchIdx()
+}
+
 func TestReaderOnSpecificMessageWithCustomMessageID(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION
Hi Team,

This PR introduces message payload processor feature to  Golang client. (PIP-96)  

 - added support for custom payload processor
 - added default payload processor 
 - added a byte slice reader to process messages similar to Java Client 
 
  _(In Java, the methods for  reading messages are implemented as part of MessagePayloadContext https://github.com/apache/pulsar/blob/master/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/MessagePayloadContext.java#L65-#L79
 In this PR, I used MessagePayloadContext just to carry the information and separated the above methods into a reader.)_
 - added tests for pulsar message format and custom message format similar
      to java implementation

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Fixes #962 

### Motivation

As per PIP-96 proposal, it adds capabilities to process messages by the client using pluggable message processor.  Same functionalities are implemented for Golang client.

### Modifications

- In Java Client implementation, checksum is only validated if the first bytes matches with magic number. However, the current Golang client always try to verify the checksum and return errors if checksum is not present.  Due to this reasons, If we KoP and Kafka entry.format, We'll get errors when parsing MessageMeta.  **To avoid that,  Checksum validation was separated from reading messages (We can log precise errors) and implemented similar logic we have in Java Client.** 

- A few unexposed struct and APIs were exposed to the client. Changed the visibility as the client needs to use them when processing messages. 


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
   - added tests with Default Payload processor. It'll process pulsar messages
   - added tests with custom payload processor for different entry format.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes, not breaking changes)

1.  New field in ConsumerOptions (MessagePayloadProcessor)

  ```go
	consumer, err := client.Subscribe(ConsumerOptions{
		Topic:                   topic,
		SubscriptionName:        "my-sub",
		Type:                    Exclusive,
		MessagePayloadProcessor: DefaultPayloadProcessor{},
	})
```
2. previously `message` visibility was limited. It has changed

Old

```golang
type message struct {
```
New

```golang
type MessageImpl struct {
	publishTime         time.Time
```




  - The schema: (no )
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

This PR adds new feature. I have added Godoc comments in code. If additional docs/separate PR required, I could contribute. 
