### PR TITLE
[Issue 1021][client] FIX: use maphash instead of crypto/sha256 for hash function of hashmap in Schema.hash()

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -101,12 +101,12 @@ type partitionProducer struct {
 
 type schemaCache struct {
 	lock    sync.RWMutex
-	schemas map[string][]byte
+	schemas map[uint64][]byte
 }
 
 func newSchemaCache() *schemaCache {
 	return &schemaCache{
-		schemas: make(map[string][]byte),
+		schemas: make(map[uint64][]byte),
 	}
 }
 
@@ -122,9 +122,9 @@ func (s *schemaCache) Get(schema *SchemaInfo) (schemaVersion []byte) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	key := schema.hash()
-	return s.schemas[key]
+	return s.schemas[schema.hash()]
 }
+
 func newPartitionProducer(client *client, topic string, options *ProducerOptions, partitionIdx int,
 	metrics *internal.LeveledMetrics) (
 	*partitionProducer, error) {

--- a/pulsar/schema.go
+++ b/pulsar/schema.go
@@ -19,10 +19,9 @@ package pulsar
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash/maphash"
 	"reflect"
 	"unsafe"
 
@@ -69,10 +68,11 @@ type SchemaInfo struct {
 	Properties map[string]string
 }
 
-func (s SchemaInfo) hash() string {
-	h := sha256.New()
+func (s SchemaInfo) hash() uint64 {
+	h := maphash.Hash{}
+	h.SetSeed(seed)
 	h.Write([]byte(s.Schema))
-	return hex.EncodeToString(h.Sum(nil))
+	return h.Sum64()
 }
 
 type Schema interface {
@@ -182,6 +182,8 @@ type ProtoSchema struct {
 	AvroCodec
 	SchemaInfo
 }
+
+var seed = maphash.MakeSeed()
 
 // NewProtoSchema creates a new ProtoSchema
 // Note: the function will panic if creation of codec fails


### PR DESCRIPTION
use golang/hash/maphash instead of crypto/sha256 for hash function of hashmap in Schema.hash()
as the hash function is used for determining the hash key, it is safe to use a non-cryptographic function.

Fixes #1021

### Motivation

Improve performance of the SchemaCache by replacing the cryptographic hash function.

### Modifications

Replaced the crypto/sha256 with golang/hash/maphash function.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
