### PR TITLE
Fix broken master by upgrading JRE to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG GOLANG_IMAGE=golang:latest
 FROM $PULSAR_IMAGE as pulsar
 FROM $GOLANG_IMAGE
 
-RUN apt-get update && apt-get install -y openjdk-11-jre-headless ca-certificates
+RUN apt-get update && apt-get install -y openjdk-17-jre-headless ca-certificates
 
 COPY --from=pulsar /pulsar /pulsar
 


### PR DESCRIPTION
### Motivation

The master branch is broken:

```
E: Package 'openjdk-11-jre-headless' has no installation candidate
The command '/bin/sh -c apt-get update && apt-get install -y openjdk-11-jre-headless ca-certificates' returned a non-zero code: 100
make: *** [Makefile:41: container] Error 100
```

See https://github.com/apache/pulsar-client-go/actions/runs/5274623023/jobs/9543594971?pr=1029

It's because the latest `golang` image does not have the `openjdk-11-jre-headless`

### Modifications

Install `openjdk-17-jre-headless` instead.