### PR TITLE
Fix openjdk-17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG GOLANG_IMAGE=golang:latest
 FROM $PULSAR_IMAGE as pulsar
 FROM $GOLANG_IMAGE
 
-RUN apt-get update && apt-get install -y openjdk-17-jre-headless ca-certificates
+RUN apt-get update && apt-get install -y openjdk-17-jre ca-certificates
 
 COPY --from=pulsar /pulsar /pulsar
 


### PR DESCRIPTION
### Motivation

The master branch is broken:
```
head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
Exception in thread "main" java.lang.InternalError: Error loading java.security file
```

See https://github.com/apache/pulsar-client-go/actions/runs/5368805969/jobs/9740647704?pr=999

### Modifications

Use `openjdk-17-jre` to replace `openjdk-17-jre-headless`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
https://github.com/crossoverJie/pulsar-client-go/pull/4

