### PR TITLE
Allow user to specify TLS ciphers an min/max TLS version

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -120,6 +120,15 @@ type ClientOptions struct {
 	// Configure whether the Pulsar client verify the validity of the host name from broker (default: false)
 	TLSValidateHostname bool
 
+	// TLSCipherSuites is a list of enabled TLS 1.0–1.2 cipher suites. See tls.Config CipherSuites for more information.
+	TLSCipherSuites []uint16
+
+	// TLSMinVersion contains the minimum TLS version that is acceptable. See tls.Config MinVersion for more information.
+	TLSMinVersion uint16
+
+	// TLSMaxVersion contains the maximum TLS version that is acceptable. See tls.Config MaxVersion for more information.
+	TLSMaxVersion uint16
+
 	// Configure the net model for vpc user to connect the pulsar broker
 	ListenerName string
 

--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -91,6 +91,9 @@ func newClient(options ClientOptions) (Client, error) {
 			TrustCertsFilePath:      options.TLSTrustCertsFilePath,
 			ValidateHostname:        options.TLSValidateHostname,
 			ServerName:              url.Hostname(),
+			CipherSuites:            options.TLSCipherSuites,
+			MinVersion:              options.TLSMinVersion,
+			MaxVersion:              options.TLSMaxVersion,
 		}
 	default:
 		return nil, newError(InvalidConfiguration, fmt.Sprintf("Invalid URL scheme '%s'", url.Scheme))

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -50,6 +50,9 @@ type TLSOptions struct {
 	AllowInsecureConnection bool
 	ValidateHostname        bool
 	ServerName              string
+	CipherSuites            []uint16
+	MinVersion              uint16
+	MaxVersion              uint16
 }
 
 var (
@@ -1046,6 +1049,9 @@ func (c *connection) closed() bool {
 func (c *connection) getTLSConfig() (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: c.tlsOptions.AllowInsecureConnection,
+		CipherSuites:       c.tlsOptions.CipherSuites,
+		MinVersion:         c.tlsOptions.MinVersion,
+		MaxVersion:         c.tlsOptions.MaxVersion,
 	}
 
 	if c.tlsOptions.TrustCertsFilePath != "" {

--- a/pulsar/internal/http_client.go
+++ b/pulsar/internal/http_client.go
@@ -339,6 +339,9 @@ func getDefaultTransport(tlsConfig *TLSOptions) (http.RoundTripper, error) {
 	if tlsConfig != nil {
 		cfg := &tls.Config{
 			InsecureSkipVerify: tlsConfig.AllowInsecureConnection,
+			CipherSuites:       tlsConfig.CipherSuites,
+			MinVersion:         tlsConfig.MinVersion,
+			MaxVersion:         tlsConfig.MaxVersion,
 		}
 		if len(tlsConfig.TrustCertsFilePath) > 0 {
 			rootCA, err := os.ReadFile(tlsConfig.TrustCertsFilePath)


### PR DESCRIPTION
My company requires specific cipher suites and control over TLS version used for security.

### Modifications

ClientOptions now has TLSCipherSuites, TLSMinVersion, and TLSMaxVersion. These are used when creating tls.Config objects.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage, simple pass-along variables to tls.Config objects.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (don't know)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
  - If a feature is not applicable for documentation, explain why? Simple pass-along features with comments.
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
