### PR TITLE
[Fix] Multiple calls to client.Close causes panic

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -20,6 +20,7 @@ package pulsar
 import (
 	"fmt"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/auth"
@@ -47,6 +48,7 @@ type client struct {
 	metrics       *internal.Metrics
 	tcClient      *transactionCoordinatorClient
 	memLimit      internal.MemoryLimitController
+	closeOnce     sync.Once
 
 	log log.Logger
 }
@@ -266,7 +268,9 @@ func (c *client) TopicPartitions(topic string) ([]string, error) {
 }
 
 func (c *client) Close() {
-	c.handlers.Close()
-	c.cnxPool.Close()
-	c.lookupService.Close()
+	c.closeOnce.Do(func() {
+		c.handlers.Close()
+		c.cnxPool.Close()
+		c.lookupService.Close()
+	})
 }

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1238,3 +1238,10 @@ func TestAutoCloseIdleConnection(t *testing.T) {
 
 	cli.Close()
 }
+
+func TestMultipleCloseClient(t *testing.T) {
+	client, err := NewClient(ClientOptions{URL: serviceURL})
+	assert.Nil(t, err)
+	client.Close()
+	client.Close()
+}


### PR DESCRIPTION


Fixes #1026 


### Motivation


Multiple calls to `client.Close` causes panic.


### Modifications


Add `closeOnce sync.Once`

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:


  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
