### PR TITLE
[Fix][Producer] Stop block request even if Value and Payload are both set

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1114,7 +1114,7 @@ func (p *partitionProducer) internalSendAsync(ctx context.Context, msg *Producer
 
 	if msg.Value != nil && msg.Payload != nil {
 		p.log.Error("Can not set Value and Payload both")
-		runCallback(callback, nil, msg, errors.New("can not set Value and Payload both"))
+		runCallback(callback, nil, msg, newError(InvalidMessage, "Can not set Value and Payload both"))
 		return
 	}
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -474,6 +474,7 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 	p.log.Debug("Received send request: ", *request.msg)
 
 	msg := request.msg
+
 	// read payload from message
 	uncompressedPayload := msg.Payload
 	uncompressedPayloadSize := int64(len(uncompressedPayload))
@@ -483,7 +484,6 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 
 	// The block chan must be closed when returned with exception
 	defer request.stopBlock()
-
 	if !p.canAddToQueue(request, uncompressedPayloadSize) {
 		return
 	}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -473,8 +473,10 @@ func runCallback(cb func(MessageID, *ProducerMessage, error), id MessageID, msg 
 func (p *partitionProducer) internalSend(request *sendRequest) {
 	p.log.Debug("Received send request: ", *request.msg)
 
-	msg := request.msg
+	// The block chan must be closed when returned with exception
+	defer request.stopBlock()
 
+	msg := request.msg
 	// read payload from message
 	uncompressedPayload := msg.Payload
 	uncompressedPayloadSize := int64(len(uncompressedPayload))
@@ -487,8 +489,6 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		return
 	}
 
-	// The block chan must be closed when returned with exception
-	defer request.stopBlock()
 	if !p.canAddToQueue(request, uncompressedPayloadSize) {
 		return
 	}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/stretchr/testify/assert"
 

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -28,15 +28,13 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-
+	
 	"github.com/apache/pulsar-client-go/pulsar/internal"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/apache/pulsar-client-go/pulsar/crypto"
 	plog "github.com/apache/pulsar-client-go/pulsar/log"
+	log "github.com/sirupsen/logrus"
 )
 
 func TestInvalidURL(t *testing.T) {

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1617,7 +1617,7 @@ func TestMultipleSchemaOfKeyBasedBatchProducerConsumer(t *testing.T) {
 	}
 	producer.Flush()
 
-	// // create consumer
+	//// create consumer
 	consumer, err := client.Subscribe(ConsumerOptions{
 		Topic:                       topic,
 		SubscriptionName:            "my-sub2",
@@ -1708,7 +1708,7 @@ func TestMultipleSchemaProducerConsumer(t *testing.T) {
 	}
 	producer.Flush()
 
-	// // create consumer
+	//// create consumer
 	consumer, err := client.Subscribe(ConsumerOptions{
 		Topic:                       topic,
 		SubscriptionName:            "my-sub2",

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -28,7 +28,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-	
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION


<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation
Currently, if `!p.options.DisableBlockIfQueueFull` and `msg.Value != nil && msg.Payload != nil`, request will be blocked forever 'cause `defer request.stopBlock()` is set up after the verify logic. 
```go
if msg.Value != nil && msg.Payload != nil {
	p.log.Error("Can not set Value and Payload both")
	runCallback(request.callback, nil, request.msg, errors.New("can not set Value and Payload both"))
	return
}

// The block chan must be closed when returned with exception
defer request.stopBlock()
```
Here is the PR to stop block request even if Value and Payload are both set

### Modifications

- pulsar/producer_partition.go

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
