### PR TITLE
[fix] [issue 1057]:  Fix the producer flush opertion is not guarantee to flush all messages

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1041,11 +1041,13 @@ func (p *partitionProducer) internalFlushCurrentBatches() {
 }
 
 func (p *partitionProducer) internalFlush(fr *flushRequest) {
-	oldDataChan := p.dataChan
-	p.dataChan = make(chan *sendRequest, p.options.MaxPendingMessages)
-	for len(oldDataChan) != 0 {
-		pendingData := <-oldDataChan
-		p.internalSend(pendingData)
+	if len(p.dataChan) != 0 {
+		oldDataChan := p.dataChan
+		p.dataChan = make(chan *sendRequest, p.options.MaxPendingMessages)
+		for len(oldDataChan) != 0 {
+			pendingData := <-oldDataChan
+			p.internalSend(pendingData)
+		}
 	}
 
 	p.internalFlushCurrentBatch()

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1041,6 +1041,7 @@ func (p *partitionProducer) internalFlushCurrentBatches() {
 }
 
 func (p *partitionProducer) internalFlush(fr *flushRequest) {
+	// clear all the messages which have sent to dataChan before flush
 	if len(p.dataChan) != 0 {
 		oldDataChan := p.dataChan
 		p.dataChan = make(chan *sendRequest, p.options.MaxPendingMessages)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1041,6 +1041,12 @@ func (p *partitionProducer) internalFlushCurrentBatches() {
 }
 
 func (p *partitionProducer) internalFlush(fr *flushRequest) {
+	oldDataChan := p.dataChan
+	p.dataChan = make(chan *sendRequest, p.options.MaxPendingMessages)
+	for len(oldDataChan) != 0 {
+		pendingData := <-oldDataChan
+		p.internalSend(pendingData)
+	}
 
 	p.internalFlushCurrentBatch()
 


### PR DESCRIPTION
Fixes #1057 

### Motivation

`dataChan` is introduced by #1029  to fix the problem of reconnectToBroker. But it missed that if a flush operation excuted, there may still be some messages in `dataChan`. And these messages can't be flushed.

### Modifications

- Fix the producer flush opertion is not guarantee to flush all messages

### Verifying this change

- [x] Make sure that the change passes the CI checks.
