### PR TITLE
Fix: client reconnected every authenticationRefreshCheckSeconds when using tls authentication

### DIFF
--- a/pulsar/auth/tls.go
+++ b/pulsar/auth/tls.go
@@ -70,7 +70,7 @@ func (p *tlsAuthProvider) GetTLSCertificate() (*tls.Certificate, error) {
 }
 
 func (p *tlsAuthProvider) GetData() ([]byte, error) {
-	return []byte{}, nil
+	return nil, nil
 }
 
 func (tlsAuthProvider) Close() error {

--- a/pulsar/auth/tls.go
+++ b/pulsar/auth/tls.go
@@ -70,7 +70,7 @@ func (p *tlsAuthProvider) GetTLSCertificate() (*tls.Certificate, error) {
 }
 
 func (p *tlsAuthProvider) GetData() ([]byte, error) {
-	return nil, nil
+	return []byte{}, nil
 }
 
 func (tlsAuthProvider) Close() error {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -823,6 +823,11 @@ func (c *connection) handleAuthChallenge(authChallenge *pb.CommandAuthChallenge)
 		return
 	}
 
+	// Broker expect authData to be not nil
+	if authData == nil {
+		authData = []byte{}
+	}
+
 	cmdAuthResponse := &pb.CommandAuthResponse{
 		ProtocolVersion: proto.Int32(PulsarProtocolVersion),
 		ClientVersion:   proto.String(ClientVersionString),

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -823,7 +823,7 @@ func (c *connection) handleAuthChallenge(authChallenge *pb.CommandAuthChallenge)
 		return
 	}
 
-	// Broker expect authData to be not nil
+	// Brokers expect authData to be not nil
 	if authData == nil {
 		authData = []byte{}
 	}


### PR DESCRIPTION
### Motivation

When using pulsar tls authentication with a broker that sets the authenticationRefreshCheckSeconds the connection was dropped for each authentication refresh check. After analyzing logs and tcpdumps I concluded that this error appears because the tls authentication is returning null, witch does not pass a validation in the broker.
After analyzing the tls auth implementation in Java (that works), I concluded that the GetData method should return empty byte array instead of nil.

```
2023-07-20 15:32:32 2023-07-20T14:32:32,225+0000 [pulsar-io-29-5] INFO  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.1:42304] Refreshing authentication credentials for originalPrincipal null and authRole pulsar-admin
2023-07-20 15:32:32 2023-07-20T14:32:32,225+0000 [pulsar-io-29-9] INFO  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.1:42306] Refreshing authentication credentials for originalPrincipal null and authRole pulsar-admin
2023-07-20 15:32:32 2023-07-20T14:32:32,225+0000 [pulsar-io-29-6] INFO  org.apache.pulsar.broker.service.ServerCnx - [/172.18.0.1:33616] Refreshing authentication credentials for originalPrincipal null and authRole pulsar-admin
2023-07-20 15:32:32 2023-07-20T14:32:32,228+0000 [pulsar-io-29-6] WARN  org.apache.pulsar.broker.service.ServerCnx - [/172.18.0.1:33616] Got exception java.lang.IllegalArgumentException
2023-07-20 15:32:32     at com.google.common.base.Preconditions.checkArgument(Preconditions.java:131)
2023-07-20 15:32:32     at org.apache.pulsar.broker.service.ServerCnx.handleAuthResponse(ServerCnx.java:897)
2023-07-20 15:32:32     at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:362)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
2023-07-20 15:32:32     at io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:200)
2023-07-20 15:32:32     at io.netty.handler.flow.FlowControlHandler.channelRead(FlowControlHandler.java:162)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
2023-07-20 15:32:32     at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
2023-07-20 15:32:32     at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
2023-07-20 15:32:32     at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1373)
2023-07-20 15:32:32     at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1247)
2023-07-20 15:32:32     at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1287)
2023-07-20 15:32:32     at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529)
2023-07-20 15:32:32     at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468)
2023-07-20 15:32:32     at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
2023-07-20 15:32:32     at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
2023-07-20 15:32:32     at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
2023-07-20 15:32:32     at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
2023-07-20 15:32:32     at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
2023-07-20 15:32:32     at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:499)
2023-07-20 15:32:32     at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:397)
2023-07-20 15:32:32     at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
2023-07-20 15:32:32     at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
2023-07-20 15:32:32     at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
2023-07-20 15:32:32     at java.base/java.lang.Thread.run(Thread.java:829)
2023-07-20 15:32:32 
```

### Modifications

Changed tls auth GetData to return empty byte array instead of nil.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations:  no
  - The wire protocol:  no

### Documentation

  - Does this pull request introduce a new feature?  no
