### PR TITLE
[fix] [issue 1064] Fix the panic when try to flush in DisableBatching=true

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1042,7 +1042,9 @@ func (p *partitionProducer) internalFlushCurrentBatches() {
 
 func (p *partitionProducer) internalFlush(fr *flushRequest) {
 
-	p.internalFlushCurrentBatch()
+	if !p.options.DisableBatching {
+		p.internalFlushCurrentBatch()
+	}
 
 	pi, ok := p.pendingQueue.PeekLast().(*pendingItem)
 	if !ok {


### PR DESCRIPTION
Fixes #1064 

### Motivation

If we set producer `DisableBatching=true`, it will be panic when call `producer.Flush()`. More details in #1064 .

### Modifications

- Avoid panic in non-batching producer
- Add unit test to cover `Flush()` in non-batching producer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

