### PR TITLE
[fix] Correct the SendAsync() description

### DIFF
--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -224,8 +224,7 @@ type Producer interface {
 	Send(context.Context, *ProducerMessage) (MessageID, error)
 
 	// SendAsync a message in asynchronous mode
-	// This call is blocked when the `event channel` becomes full (default: 10) or the
-	// `maxPendingMessages` becomes full (default: 1000)
+	// This call is blocked when the `maxPendingMessages` becomes full (default: 1000)
 	// The callback will report back the message being published and
 	// the eventual error in publishing
 	SendAsync(context.Context, *ProducerMessage, func(MessageID, *ProducerMessage, error))


### PR DESCRIPTION
### Motivation

After #1029 , `eventChan` is split into `dataChan` and `cmdChan`.  But the description of `SendAsync()` is not modified.

https://github.com/apache/pulsar-client-go/blob/9867c29ca329302e97ddd9c6a99f66853c7f447f/pulsar/producer.go#L226-L231

### Modifications

- Correct the description of SendAsync() description

### Verifying this change

- [x] Make sure that the change passes the CI checks.
