### PR TITLE
[fix][txn] Fix the transaction acknowledgement and send logic for  chunk message

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -428,9 +428,8 @@ func (pc *partitionConsumer) ackIDCommon(msgID MessageID, withResponse bool, txn
 	if cmid, ok := msgID.(*chunkMessageID); ok {
 		if txn == nil {
 			return pc.unAckChunksTracker.ack(cmid)
-		} else {
-			return pc.unAckChunksTracker.ackWithTxn(cmid, txn)
 		}
+		return pc.unAckChunksTracker.ackWithTxn(cmid, txn)
 	}
 
 	trackingID := toTrackingMessageID(msgID)

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -426,7 +426,11 @@ func (pc *partitionConsumer) ackIDCommon(msgID MessageID, withResponse bool, txn
 	}
 
 	if cmid, ok := msgID.(*chunkMessageID); ok {
-		return pc.unAckChunksTracker.ack(cmid)
+		if txn == nil {
+			return pc.unAckChunksTracker.ack(cmid)
+		} else {
+			return pc.unAckChunksTracker.ackWithTxn(cmid, txn)
+		}
 	}
 
 	trackingID := toTrackingMessageID(msgID)
@@ -2202,9 +2206,19 @@ func (u *unAckChunksTracker) remove(cmid *chunkMessageID) {
 }
 
 func (u *unAckChunksTracker) ack(cmid *chunkMessageID) error {
+	return u.ackWithTxn(cmid, nil)
+}
+
+func (u *unAckChunksTracker) ackWithTxn(cmid *chunkMessageID, txn Transaction) error {
 	ids := u.get(cmid)
 	for _, id := range ids {
-		if err := u.pc.AckID(id); err != nil {
+		var err error
+		if txn == nil {
+			err = u.pc.AckID(id)
+		} else {
+			err = u.pc.AckIDWithTxn(id, txn)
+		}
+		if err != nil {
 			return err
 		}
 	}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -979,13 +979,10 @@ func (p *partitionProducer) failTimeoutMessages() {
 						WithField("properties", sr.msg.Properties)
 				}
 
-				if sr.callback != nil {
+				if sr.totalChunks <= 1 || sr.chunkID == sr.totalChunks-1 {
 					sr.callbackOnce.Do(func() {
 						sr.callback(nil, sr.msg, errSendTimeout)
 					})
-				}
-				if (sr.totalChunks <= 1 || sr.chunkID == sr.totalChunks-1) && sr.transaction != nil {
-					sr.transaction.endSendOrAckOp(nil)
 				}
 			}
 
@@ -1253,9 +1250,6 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 						sr.callback(msgID, sr.msg, nil)
 					}
 					p.options.Interceptors.OnSendAcknowledgement(p, sr.msg, msgID)
-					if sr.transaction != nil {
-						sr.transaction.endSendOrAckOp(nil)
-					}
 				}
 			}
 		}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -979,7 +979,7 @@ func (p *partitionProducer) failTimeoutMessages() {
 						WithField("properties", sr.msg.Properties)
 				}
 
-				if sr.totalChunks <= 1 || sr.chunkID == sr.totalChunks-1 {
+				if sr.callback != nil && (sr.totalChunks <= 1 || sr.chunkID == sr.totalChunks-1) {
 					sr.callbackOnce.Do(func() {
 						sr.callback(nil, sr.msg, errSendTimeout)
 					})

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1253,7 +1253,9 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 						sr.callback(msgID, sr.msg, nil)
 					}
 					p.options.Interceptors.OnSendAcknowledgement(p, sr.msg, msgID)
-					sr.transaction.endSendOrAckOp(nil)
+					if sr.transaction != nil {
+						sr.transaction.endSendOrAckOp(nil)
+					}
 				}
 			}
 		}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -979,10 +979,13 @@ func (p *partitionProducer) failTimeoutMessages() {
 						WithField("properties", sr.msg.Properties)
 				}
 
-				if sr.callback != nil && (sr.totalChunks <= 1 || sr.chunkID == sr.totalChunks-1) {
+				if sr.callback != nil {
 					sr.callbackOnce.Do(func() {
 						sr.callback(nil, sr.msg, errSendTimeout)
 					})
+				}
+				if sr.transaction != nil {
+					sr.transaction.endSendOrAckOp(nil)
 				}
 			}
 
@@ -1251,6 +1254,9 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 					}
 					p.options.Interceptors.OnSendAcknowledgement(p, sr.msg, msgID)
 				}
+			}
+			if sr.transaction != nil {
+				sr.transaction.endSendOrAckOp(nil)
 			}
 		}
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -984,7 +984,7 @@ func (p *partitionProducer) failTimeoutMessages() {
 						sr.callback(nil, sr.msg, errSendTimeout)
 					})
 				}
-				if sr.transaction != nil {
+				if (sr.totalChunks <= 1 || sr.chunkID == sr.totalChunks-1) && sr.transaction != nil {
 					sr.transaction.endSendOrAckOp(nil)
 				}
 			}
@@ -1253,10 +1253,8 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 						sr.callback(msgID, sr.msg, nil)
 					}
 					p.options.Interceptors.OnSendAcknowledgement(p, sr.msg, msgID)
+					sr.transaction.endSendOrAckOp(nil)
 				}
-			}
-			if sr.transaction != nil {
-				sr.transaction.endSendOrAckOp(nil)
 			}
 		}
 

--- a/pulsar/transaction_test.go
+++ b/pulsar/transaction_test.go
@@ -482,7 +482,8 @@ func TestSendAndAckChunkMessage(t *testing.T) {
 
 	// Send a large message that will be split into chunks.
 	msgID, err := producer.Send(context.Background(), &ProducerMessage{
-		Payload: createTestMessagePayload(_brokerMaxMessageSize),
+		Transaction: txn,
+		Payload:     createTestMessagePayload(_brokerMaxMessageSize),
 	})
 	require.NoError(t, err)
 	_, ok := msgID.(*chunkMessageID)

--- a/pulsar/transaction_test.go
+++ b/pulsar/transaction_test.go
@@ -423,6 +423,14 @@ func TestTransactionAbort(t *testing.T) {
 	// Abort the transaction.
 	_ = txn.Abort(context.Background())
 
+	consumerShouldNotReceiveMessage(t, consumer)
+
+	// Clean up: Close the consumer and producer instances.
+	consumer.Close()
+	producer.Close()
+}
+
+func consumerShouldNotReceiveMessage(t *testing.T, consumer Consumer) {
 	// Expectation: The consumer should not receive any messages.
 	done := make(chan struct{})
 	go func() {
@@ -438,8 +446,104 @@ func TestTransactionAbort(t *testing.T) {
 		require.Fail(t, "The consumer should not receive any messages")
 	case <-time.After(time.Second):
 	}
+}
 
-	// Clean up: Close the consumer and producer instances.
+func TestSendAndAckChunkMessage(t *testing.T) {
+	topic := newTopicName()
+	sub := "my-sub"
+
+	// Prepare: Create PulsarClient and initialize the transaction coordinator client.
+	_, client := createTcClient(t)
+
+	// Create transaction and register the send operation.
+	txn, err := client.NewTransaction(time.Hour)
+	require.Nil(t, err)
+	txn.(*transaction).registerSendOrAckOp()
+
+	// Create a producer with chunking enabled to send a large message that will be split into chunks.
+	producer, err := client.CreateProducer(ProducerOptions{
+		Name:            "test",
+		Topic:           topic,
+		EnableChunking:  true,
+		DisableBatching: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, producer)
+	defer producer.Close()
+
+	// Subscribe to the consumer.
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		Type:             Exclusive,
+		SubscriptionName: sub,
+	})
+	require.NoError(t, err)
+	defer consumer.Close()
+
+	// Send a large message that will be split into chunks.
+	msgID, err := producer.Send(context.Background(), &ProducerMessage{
+		Payload: createTestMessagePayload(_brokerMaxMessageSize),
+	})
+	require.NoError(t, err)
+	_, ok := msgID.(*chunkMessageID)
+	require.True(t, ok)
+
+	// Attempt to commit the transaction, it should not succeed at this point.
+	err = txn.Commit(context.Background())
+	require.NotNil(t, err)
+
+	// End the previously registered send operation, allowing the transaction to commit successfully.
+	txn.(*transaction).endSendOrAckOp(nil)
+
+	// Commit the transaction successfully now.
+	err = txn.Commit(context.Background())
+	require.Nil(t, err)
+
+	// Receive the message using a new transaction and ack it.
+	txn2, err := client.NewTransaction(time.Hour)
+	require.Nil(t, err)
+	message, err := consumer.Receive(context.Background())
+	require.Nil(t, err)
+
+	err = consumer.AckWithTxn(message, txn2)
+	require.Nil(t, err)
+
+	txn2.Abort(context.Background())
+
+	// Close the consumer to simulate reconnection and receive the same message again.
 	consumer.Close()
-	producer.Close()
+
+	// Subscribe to the consumer again.
+	consumer, err = client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		Type:             Exclusive,
+		SubscriptionName: sub,
+	})
+	require.Nil(t, err)
+	message, err = consumer.Receive(context.Background())
+	require.Nil(t, err)
+	require.NotNil(t, message)
+
+	// Create a new transaction and ack the message again.
+	txn3, err := client.NewTransaction(time.Hour)
+	require.Nil(t, err)
+
+	err = consumer.AckWithTxn(message, txn3)
+	require.Nil(t, err)
+
+	// Commit the third transaction.
+	err = txn3.Commit(context.Background())
+	require.Nil(t, err)
+
+	// Close the consumer again.
+	consumer.Close()
+
+	// Subscribe to the consumer again and verify that no message is received.
+	consumer, err = client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		Type:             Exclusive,
+		SubscriptionName: sub,
+	})
+	require.Nil(t, err)
+	consumerShouldNotReceiveMessage(t, consumer)
 }

--- a/pulsar/transaction_test.go
+++ b/pulsar/transaction_test.go
@@ -448,7 +448,7 @@ func consumerShouldNotReceiveMessage(t *testing.T, consumer Consumer) {
 	}
 }
 
-func TestSendAndAckChunkMessage(t *testing.T) {
+func TestAckChunkMessage(t *testing.T) {
 	topic := newTopicName()
 	sub := "my-sub"
 
@@ -489,14 +489,6 @@ func TestSendAndAckChunkMessage(t *testing.T) {
 	_, ok := msgID.(*chunkMessageID)
 	require.True(t, ok)
 
-	// Attempt to commit the transaction, it should not succeed at this point.
-	err = txn.Commit(context.Background())
-	require.NotNil(t, err)
-
-	// End the previously registered send operation, allowing the transaction to commit successfully.
-	txn.(*transaction).endSendOrAckOp(nil)
-
-	// Commit the transaction successfully now.
 	err = txn.Commit(context.Background())
 	require.Nil(t, err)
 


### PR DESCRIPTION
Master https://github.com/apache/pulsar-client-go/issues/1060
### Motivation
1. For the chunk message, we only register the send operation once but end the send operation multiple times when receiving the send response. It will make the transaction can be committed before all the operations are completed.
2. When we use transaction ack for chunk messages, the provided transaction is ignored, resulting in the chunk message actually being acknowledged using the non-transactional ack method.
### Modifications
1. Only end the send operation when receive the last chunk message.
2. Add the check for the transaction when the massage is a chunk message.
### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
