### PR TITLE
[Improve][Producer] Refactor internalSend() and resouce managment

### DIFF
--- a/pulsar/message_chunking_test.go
+++ b/pulsar/message_chunking_test.go
@@ -568,6 +568,7 @@ func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, whol
 	mm.ChunkId = proto.Int32(int32(chunkID))
 	producerImpl.updateMetadataSeqID(mm, msg)
 
+	// only the last chunk will trigger the callback, can't wait here
 	// doneCh := make(chan struct{})
 	producerImpl.internalSingleSend(
 		mm,
@@ -577,6 +578,7 @@ func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, whol
 			ctx:      context.Background(),
 			msg:      msg,
 			callback: func(id MessageID, producerMessage *ProducerMessage, err error) {
+				// only the last chunk will trigger the callback, can't wait here
 				// close(doneCh)
 			},
 			callbackOnce:        callbackOnce,
@@ -605,5 +607,6 @@ func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, whol
 		uint32(internal.MaxMessageSize),
 	)
 
+	// only the last chunk will trigger the callback, can't wait here
 	// <-doneCh
 }

--- a/pulsar/message_chunking_test.go
+++ b/pulsar/message_chunking_test.go
@@ -568,8 +568,6 @@ func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, whol
 	mm.ChunkId = proto.Int32(int32(chunkID))
 	producerImpl.updateMetadataSeqID(mm, msg)
 
-	// only the last chunk will trigger the callback, can't wait here
-	// doneCh := make(chan struct{})
 	producerImpl.internalSingleSend(
 		mm,
 		msg.Payload,
@@ -578,8 +576,6 @@ func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, whol
 			ctx:      context.Background(),
 			msg:      msg,
 			callback: func(id MessageID, producerMessage *ProducerMessage, err error) {
-				// only the last chunk will trigger the callback, can't wait here
-				// close(doneCh)
 			},
 			callbackOnce:        callbackOnce,
 			flushImmediately:    true,
@@ -606,7 +602,4 @@ func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, whol
 		},
 		uint32(internal.MaxMessageSize),
 	)
-
-	// only the last chunk will trigger the callback, can't wait here
-	// <-doneCh
 }

--- a/pulsar/message_chunking_test.go
+++ b/pulsar/message_chunking_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -178,9 +179,16 @@ func TestMaxPendingChunkMessages(t *testing.T) {
 	defer c.Close()
 	pc := c.(*consumer).consumers[0]
 
-	sendSingleChunk(producer, "0", 0, 2)
+	callbackOnce0 := &sync.Once{}
+	cr0 := newChunkRecorder()
+	msg0 := "chunk-0-0|chunk-0-1|"
+	callbackOnce1 := &sync.Once{}
+	cr1 := newChunkRecorder()
+	msg1 := "chunk-1-0|chunk-1-1|"
+
+	sendSingleChunk(producer, "0", 0, 2, msg0, callbackOnce0, cr0)
 	// MaxPendingChunkedMessage is 1, the chunked message with uuid 0 will be discarded
-	sendSingleChunk(producer, "1", 0, 2)
+	sendSingleChunk(producer, "1", 0, 2, msg1, callbackOnce1, cr1)
 
 	// chunkedMsgCtx with uuid 0 should be discarded
 	retryAssert(t, 3, 200, func() {}, func(t assert.TestingT) bool {
@@ -189,7 +197,7 @@ func TestMaxPendingChunkMessages(t *testing.T) {
 		return assert.Equal(t, 1, len(pc.chunkedMsgCtxMap.chunkedMsgCtxs))
 	})
 
-	sendSingleChunk(producer, "1", 1, 2)
+	sendSingleChunk(producer, "1", 1, 2, msg1, callbackOnce1, cr1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	msg, err := c.Receive(ctx)
@@ -199,7 +207,7 @@ func TestMaxPendingChunkMessages(t *testing.T) {
 	assert.Equal(t, "chunk-1-0|chunk-1-1|", string(msg.Payload()))
 
 	// Ensure that the chunked message of uuid 0 is discarded.
-	sendSingleChunk(producer, "0", 1, 2)
+	sendSingleChunk(producer, "0", 1, 2, msg0, callbackOnce0, cr0)
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	msg, err = c.Receive(ctx)
 	cancel()
@@ -548,30 +556,54 @@ func createTestMessagePayload(size int) []byte {
 }
 
 //nolint:all
-func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int) {
+func sendSingleChunk(p Producer, uuid string, chunkID int, totalChunks int, wholePayload string, callbackOnce *sync.Once, cr *chunkRecorder) {
 	msg := &ProducerMessage{
 		Payload: []byte(fmt.Sprintf("chunk-%s-%d|", uuid, chunkID)),
 	}
 	producerImpl := p.(*producer).producers[0].(*partitionProducer)
-	mm := producerImpl.genMetadata(msg, len(msg.Payload), time.Now())
+	mm := producerImpl.genMetadata(msg, len(wholePayload), time.Now())
 	mm.Uuid = proto.String(uuid)
 	mm.NumChunksFromMsg = proto.Int32(int32(totalChunks))
-	mm.TotalChunkMsgSize = proto.Int32(int32(len(msg.Payload)))
+	mm.TotalChunkMsgSize = proto.Int32(int32(len(wholePayload)))
 	mm.ChunkId = proto.Int32(int32(chunkID))
 	producerImpl.updateMetadataSeqID(mm, msg)
 
-	doneCh := make(chan struct{})
+	// doneCh := make(chan struct{})
 	producerImpl.internalSingleSend(
 		mm,
 		msg.Payload,
 		&sendRequest{
+			producer: producerImpl,
+			ctx:      context.Background(),
+			msg:      msg,
 			callback: func(id MessageID, producerMessage *ProducerMessage, err error) {
-				close(doneCh)
+				// close(doneCh)
 			},
-			msg: msg,
+			callbackOnce:        callbackOnce,
+			flushImmediately:    true,
+			totalChunks:         totalChunks,
+			chunkID:             chunkID,
+			uuid:                uuid,
+			chunkRecorder:       cr,
+			transaction:         nil,
+			memLimit:            nil,
+			reservedMem:         0,
+			semaphore:           nil,
+			reservedSemaphore:   0,
+			sendAsBatch:         false,
+			schema:              nil,
+			schemaVersion:       nil,
+			uncompressedPayload: []byte(wholePayload),
+			uncompressedSize:    int64(len(wholePayload)),
+			compressedPayload:   []byte(wholePayload),
+			compressedSize:      len(wholePayload),
+			payloadChunkSize:    internal.MaxMessageSize - proto.Size(mm),
+			mm:                  mm,
+			deliverAt:           time.Now(),
+			maxMessageSize:      internal.MaxMessageSize,
 		},
 		uint32(internal.MaxMessageSize),
 	)
 
-	<-doneCh
+	// <-doneCh
 }

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1039,12 +1039,12 @@ func (p *partitionProducer) updateMetaData(sr *sendRequest) {
 		deliverAt = time.Now().Add(sr.msg.DeliverAfter)
 	}
 
-	sr.mm = p.genMetadata(sr.msg, int(sr.uncompressedSize), deliverAt)
-
 	// set default ReplicationClusters when DisableReplication
 	if sr.msg.DisableReplication {
 		sr.msg.ReplicationClusters = []string{"__local__"}
 	}
+
+	sr.mm = p.genMetadata(sr.msg, int(sr.uncompressedSize), deliverAt)
 
 	sr.sendAsBatch = !p.options.DisableBatching &&
 		sr.msg.ReplicationClusters == nil &&

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1007,7 +1007,7 @@ func (p *partitionProducer) updateSchema(sr *sendRequest) error {
 	return nil
 }
 
-func (p *partitionProducer) updateUncompressPayload(sr *sendRequest) error {
+func (p *partitionProducer) updateUncompressedPayload(sr *sendRequest) error {
 	// read payload from message
 	sr.uncompressedPayload = sr.msg.Payload
 
@@ -1221,7 +1221,7 @@ func (p *partitionProducer) internalSendAsync(ctx context.Context, msg *Producer
 		return
 	}
 
-	err = p.updateUncompressPayload(sr)
+	err = p.updateUncompressedPayload(sr)
 	if err != nil {
 		p.log.Error(err)
 		sr.done(nil, err)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -491,7 +491,8 @@ func (p *partitionProducer) internalSend(sr *sendRequest) {
 			p.internalFlushCurrentBatch()
 
 			// after flushing try again to add the current payload
-			ok := addRequestToBatch(smm, p, sr.uncompressedPayload, sr, sr.msg, sr.deliverAt, sr.schemaVersion, multiSchemaEnabled)
+			ok := addRequestToBatch(smm, p, sr.uncompressedPayload, sr, sr.msg, sr.deliverAt,
+				sr.schemaVersion, multiSchemaEnabled)
 			if !ok {
 				p.log.WithField("size", sr.uncompressedSize).
 					WithField("properties", sr.msg.Properties).
@@ -1574,12 +1575,12 @@ func (p *partitionProducer) _getConn() internal.Connection {
 	return p.conn.Load().(internal.Connection)
 }
 
-func (p *partitionProducer) releaseSemaphoreAndMem(size int64) {
+func (p *partitionProducer) releaseSemaphoreAndMem(size int64) { //nolint:unused
 	p.publishSemaphore.Release()
 	p.client.memLimit.ReleaseMemory(size)
 }
 
-func (p *partitionProducer) canAddToQueue(sr *sendRequest) bool {
+func (p *partitionProducer) canAddToQueue(sr *sendRequest) bool { //nolint:unused
 	if p.options.DisableBlockIfQueueFull {
 		if !p.publishSemaphore.TryAcquire() {
 			runCallback(sr.callback, nil, sr.msg, errSendQueueIsFull)
@@ -1595,7 +1596,7 @@ func (p *partitionProducer) canAddToQueue(sr *sendRequest) bool {
 	return true
 }
 
-func (p *partitionProducer) canReserveMem(sr *sendRequest, size int64) bool {
+func (p *partitionProducer) canReserveMem(sr *sendRequest, size int64) bool { //nolint:unused
 	if p.options.DisableBlockIfQueueFull {
 		if !p.client.memLimit.TryReserveMemory(size) {
 			p.publishSemaphore.Release()


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #1043

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #1043, #1055 #1059 #1060 #1067, #1068

### Motivation
1. As discussed in #1055, we need to calculate how many pending items and how many memory are required before appending the `sendRequest` to the `dataChan`, but currently, we do schema-encoding/compressing in `internalSend()`, this may lead to inaccurate memory limit cotrolling, and as described in #1043, make the code complicated and difficult to maintain, we need to simplify the send logic;
2. In JAVA client, schema-encoding/compressing are done in application thread, it better to make it work like JAVA client; 
3. As discussed in #1055 and described in #1043, resource(memory and semaphore) acquiring/releasing logic are written across the whole file, we need to simplify the resource management logic, encapsulate them into functions, call them when necessary, make it 'Low Coupling, High Cohesion';
4. As discussed in #1060, transaction is not correctly ended for chunked message, it better to encapsulate the transaction ending logic into one func which will be called when sendRequest is done.

### Modifications

1. Move shema encoding from `internalSend()` to `internalSendAsync()`;
2. Move compressing from `internalSend()` to `internalSendAsync()`;
5. Calculate total chunks before entering the dataChan;
6. Reserve required semaphore and memory before entering the dataChan;
7. `sendRequest` store the semaphore and memory it holds; 
8. Encapsualte relative code blocks into individual funcs to make the skeleton of  `internalSendAsync()` clearer;
9. Add `sendRequest.done()` to release the resources it holds;
10. When a `sendRequest` is done, call `sendRequest.done()` ;
11. In `sendRequest.done()` run callback, update metrics, end transaction, run interceptors callback...

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
