### PR TITLE
[Issue #1073][Reader] Allow subsciption mode to be specified in Reader options

### DIFF
--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -102,6 +102,10 @@ type ReaderOptions struct {
 	// AutoAckIncompleteChunk sets whether reader auto acknowledges incomplete chunked message when it should
 	// be removed (e.g.the chunked message pending queue is full). (default: false)
 	AutoAckIncompleteChunk bool
+
+	// SubscriptionMode specifies the subscription mode to be used when subscribing to a topic.
+	// Default is nil (`NonDurable`)
+	SubscriptionMode *SubscriptionMode
 }
 
 // Reader can be used to scan through all the messages currently available in a topic.

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -98,6 +98,12 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 		options.ExpireTimeOfIncompleteChunk = time.Minute
 	}
 
+	// by default keep subscription mode as non-durable
+	subscriptionMode := NonDurable
+	if options.SubscriptionMode != nil {
+		subscriptionMode = *options.SubscriptionMode
+	}
+
 	consumerOptions := &partitionConsumerOpts{
 		topic:                       options.Topic,
 		consumerName:                options.Name,
@@ -106,7 +112,7 @@ func newReader(client *client, options ReaderOptions) (Reader, error) {
 		receiverQueueSize:           receiverQueueSize,
 		startMessageID:              startMessageID,
 		startMessageIDInclusive:     options.StartMessageIDInclusive,
-		subscriptionMode:            NonDurable,
+		subscriptionMode:            subscriptionMode,
 		readCompacted:               options.ReadCompacted,
 		metadata:                    options.Properties,
 		nackRedeliveryDelay:         defaultNackRedeliveryDelay,


### PR DESCRIPTION
Fixes #1073 

### Motivation

Reader improvement

### Modifications

Added subscription mode to Reader options. If not specified, subscription mode still defaults to non-durable.

