### PR TITLE
double check before consumer reconnect

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1644,6 +1644,13 @@ func (pc *partitionConsumer) reconnectToBroker() {
 		pc.log.Info("Reconnecting to broker in ", delayReconnectTime)
 		time.Sleep(delayReconnectTime)
 
+		// double check
+		if pc.getConsumerState() != consumerReady {
+			// Consumer is already closing
+			pc.log.Info("consumer state not ready, exit reconnect")
+			return
+		}
+
 		err := pc.grabConn()
 		if err == nil {
 			// Successfully reconnected


### PR DESCRIPTION
### Motivation

I have a topic with 4 partitions and multiple subscriptions. One of the subscriptions (in keyshared mode) is stuck while consuming from one partition, while the other subscriptions and this particular subscription consuming from other partitions are working fine.
After communicating with the cloud service provider, they believe that it is caused by a consumer not acknowledging the messages it received. However, in my code, I have closed the consumer, so the server should not be waiting indefinitely.
After checking the logs and the code, I believe the situation was as follows:
1. The server notifies the consumer to reconnect and starts sleeping at this line: https://github.com/apache/pulsar-client-go/blob/master/pulsar/consumer_partition.go#L1645.
2. In my code logic, I closed the consumer. At this point, since the connection is closed, the corresponding error message is printed in the log: [Failed to close consumer], err: connection closed
3. The sleep ends, the reconnect is successful, but this new connection is leaked, and the messages within it cannot be consumed.
4. In my code logic, I recreate the consumer, but due to the issue in the previous step, the new consumer is unable to receive any messages.

### Modifications

In the reconnectToBroker method, after the sleep, a double check is performed to confirm the status of the consumer.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)