### PR TITLE
[improve][client] Implement GetLastMSgID for Reader

### DIFF
--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -136,5 +136,5 @@ type Reader interface {
 	SeekByTime(time time.Time) error
 
 	// GetLastMSgID get the last message id available for consume.
-	GetLastMSgID() (MessageID, error)
+	GetLastMessageID() (MessageID, error)
 }

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -135,6 +135,6 @@ type Reader interface {
 	//
 	SeekByTime(time time.Time) error
 
-	// GetLastMSgID get the last message id available for consume.
+	// GetLastMessageID get the last message id available for consume.
 	GetLastMessageID() (MessageID, error)
 }

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -134,4 +134,7 @@ type Reader interface {
 	//            the message publish time where to reposition the subscription
 	//
 	SeekByTime(time time.Time) error
+
+	// GetLastMSgID get the last message id available for consume.
+	GetLastMSgID() (MessageID, error)
 }

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -245,6 +245,6 @@ func (r *reader) SeekByTime(time time.Time) error {
 	return r.pc.SeekByTime(time)
 }
 
-func (r *reader) GetLastMSgID() (MessageID, error) {
+func (r *reader) GetLastMessageID() (MessageID, error) {
 	return r.pc.getLastMessageID()
 }

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -244,3 +244,7 @@ func (r *reader) SeekByTime(time time.Time) error {
 
 	return r.pc.SeekByTime(time)
 }
+
+func (r *reader) GetLastMSgID() (MessageID, error) {
+	return r.pc.getLastMessageID()
+}


### PR DESCRIPTION
### Motivation
Implement the GetLastMSgID API for Reader.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
