### PR TITLE
[fix] Fix comment for ConnectionMaxIdleTime

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -153,7 +153,7 @@ type ClientOptions struct {
 	MetricsRegisterer prometheus.Registerer
 
 	// Release the connection if it is not used for more than ConnectionMaxIdleTime.
-	// Default is 60 seconds, negative such as -1 to disable.
+	// Default is 180 seconds, minimum is 60 seconds. Negative such as -1 to disable.
 	ConnectionMaxIdleTime time.Duration
 
 	EnableTransaction bool


### PR DESCRIPTION
### Motivation

The default value of `ConnectionMaxIdleTime` is said to be 60 seconds in the comment,
https://github.com/apache/pulsar-client-go/blob/2a15a251d25bd2a6276051d71873e9e106cc1e85/pulsar/client.go#L155-L157

but it actually seems to be 180 seconds. 60 seconds is the minimum value, not the default value.
https://github.com/apache/pulsar-client-go/blob/2a15a251d25bd2a6276051d71873e9e106cc1e85/pulsar/client_impl.go#L39-L40

### Verifying this change

- [x] Make sure that the change passes the CI checks.