### PR TITLE
Support OAuth2 with scope field

### DIFF
--- a/pulsaradmin/pkg/admin/auth/oauth2.go
+++ b/pulsaradmin/pkg/admin/auth/oauth2.go
@@ -78,7 +78,8 @@ func NewAuthenticationOAuth2WithDefaultFlow(issuer oauth2.Issuer, keyFile string
 	})
 }
 
-func NewAuthenticationOAuth2WithFlow(issuer oauth2.Issuer, flowOptions oauth2.ClientCredentialsFlowOptions) (Provider, error) {
+func NewAuthenticationOAuth2WithFlow(
+	issuer oauth2.Issuer, flowOptions oauth2.ClientCredentialsFlowOptions) (Provider, error) {
 	st := store.NewMemoryStore()
 	flow, err := oauth2.NewDefaultClientCredentialsFlow(flowOptions)
 	if err != nil {

--- a/pulsaradmin/pkg/admin/auth/oauth2.go
+++ b/pulsaradmin/pkg/admin/auth/oauth2.go
@@ -73,10 +73,14 @@ func NewAuthenticationOAuth2(issuer oauth2.Issuer, store store.Store) (*OAuth2Pr
 
 // NewAuthenticationOAuth2WithDefaultFlow uses memory to save the grant
 func NewAuthenticationOAuth2WithDefaultFlow(issuer oauth2.Issuer, keyFile string) (Provider, error) {
-	st := store.NewMemoryStore()
-	flow, err := oauth2.NewDefaultClientCredentialsFlow(oauth2.ClientCredentialsFlowOptions{
+	return NewAuthenticationOAuth2WithFlow(issuer, oauth2.ClientCredentialsFlowOptions{
 		KeyFile: keyFile,
 	})
+}
+
+func NewAuthenticationOAuth2WithFlow(issuer oauth2.Issuer, flowOptions oauth2.ClientCredentialsFlowOptions) (Provider, error) {
+	st := store.NewMemoryStore()
+	flow, err := oauth2.NewDefaultClientCredentialsFlow(flowOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

### Motivation

Current `pulsaradmin` OAuth2 params don't support to input the scope field. Add a function to implement it. `ClientCredentialsFlowOptions` has a `AdditionalScopes` field to set scopes.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
