### PR TITLE
[fix][issue 1098] check batchBuilder in case batch is disabled

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -867,6 +867,12 @@ type pendingItem struct {
 }
 
 func (p *partitionProducer) internalFlushCurrentBatch() {
+	if p.batchBuilder == nil {
+		// batch is not enabled
+		// the batch flush ticker should be stopped but it might still called once depends on when stop() is called concurrently
+		// so we add check to prevent the flow continues on a nil batchBuilder
+		return
+	}
 	if p.batchBuilder.IsMultiBatches() {
 		p.internalFlushCurrentBatches()
 		return

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -869,7 +869,8 @@ type pendingItem struct {
 func (p *partitionProducer) internalFlushCurrentBatch() {
 	if p.batchBuilder == nil {
 		// batch is not enabled
-		// the batch flush ticker should be stopped but it might still called once depends on when stop() is called concurrently
+		// the batch flush ticker should be stopped but it might still called once
+		// depends on when stop() is called concurrently
 		// so we add check to prevent the flow continues on a nil batchBuilder
 		return
 	}


### PR DESCRIPTION
Fixes #1098 

### Motivation

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x8a8eaa]

goroutine 1 [running]:

github.com/apache/pulsar-client-go/pulsar.(*partitionProducer).internalFlushCurrentBatch(0xc00c6ccc60)
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.11.0/pulsar/producer_partition.go:869 +0x2a
github.com/apache/pulsar-client-go/pulsar.(*partitionProducer).runEventsLoop(0xc00c6ccc60)
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.11.0/pulsar/producer_partition.go:457 +0x1d7
created by github.com/apache/pulsar-client-go/pulsar.newPartitionProducer in goroutine 5713
	/go/pkg/mod/github.com/apache/pulsar-client-go@v0.11.0/pulsar/producer_partition.go:203 +0x9bb
when the producer option set to DisableBatching: true, the time.ticker wil be created and close after a while, when ticker.Stop() over 10ms (default value) since created it will cause the ticker still tick, and cause nil pointer dereference eventually.

### Modifications

Add one more check to evaluate if `batchBuilder` is nil, in non-batch scenario, it should return immediate. 

To understand the behaviour of ticker, write a small test code of ticker that ticker.C (the timer) sometime is called while the Stop() is called. That's why it's good to check the batchBuilder. If the batchBuilder object fails to be created, it should be caught at [line 294 at producer_partition.go](https://github.com/apache/pulsar-client-go/blob/master/pulsar/producer_partition.go#L294). So if batch is enabled, it should not be nil. Therefore we can use the nil check to stop any non-batch calls to proceed with the flush.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: ( no)
  - The schema: (no )
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
