### PR TITLE
[fix] Fix issue where DisableReplication flag does not work

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -551,12 +551,12 @@ func (p *partitionProducer) internalSend(request *sendRequest) {
 		deliverAt = time.Now().Add(msg.DeliverAfter)
 	}
 
-	mm := p.genMetadata(msg, uncompressedSize, deliverAt)
-
 	// set default ReplicationClusters when DisableReplication
 	if msg.DisableReplication {
 		msg.ReplicationClusters = []string{"__local__"}
 	}
+
+	mm := p.genMetadata(msg, uncompressedSize, deliverAt)
 
 	sendAsBatch := !p.options.DisableBatching &&
 		msg.ReplicationClusters == nil &&


### PR DESCRIPTION
### Motivation

When producing a message, we can specify the `DisableReplication` option, and if set to true, the message is expected not to be replicated to remote clusters. However, this option currently does not work, and even if set to true, messages will be replicated to remote clusters.

The following part is the cause of this issue.
https://github.com/apache/pulsar-client-go/blob/ac9c1a6399336461d2d3ce1cdd31cac6debd5ed5/pulsar/producer_partition.go#L554-L559

If `DisableReplication` is true, `ReplicationClusters` is set to `__local__`. However, the metadata that is actually sent to the broker has already been constructed immediately before that. Therefore, there is no point in changing the value of `ReplicationClusters` here. The order of these two must be reversed.

### Modifications

Construct the metadata after changing `ReplicationClusters` to `__local__`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
