### PR TITLE
fix: flush block

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1381,6 +1381,11 @@ func (p *partitionProducer) LastSequenceID() int64 {
 }
 
 func (p *partitionProducer) Flush() error {
+	if p.getProducerState() != producerReady {
+		// Producer is closing
+		return errProducerClosed
+	}
+
 	flushReq := &flushRequest{
 		doneCh: make(chan struct{}),
 		err:    nil,


### PR DESCRIPTION
### summary

When the producer's close method is executed, the runEventsLoop coroutine will exit. If producer.flush is executed at this time, there is a possibility of blocking.

`If you close first and then flush, `Flush()` will block.`

```
go func() {
      close() := func() {
            close(internalQueue)
            producer.Close()
      }
}()

go func() {
      for _, msg := range internalQueue {
          producer.Send(...)
      }
      producer.Flush() // block
}
```

Sometimes, we cannot control the order of concurrent execution. 😁