### PR TITLE
[Issue 1105][pulsaradmin] fix AutoTopicCreation for type non-partitioned

### DIFF
--- a/pulsaradmin/pkg/utils/topic_auto_creation_config.go
+++ b/pulsaradmin/pkg/utils/topic_auto_creation_config.go
@@ -20,5 +20,5 @@ package utils
 type TopicAutoCreationConfig struct {
 	Allow      bool      `json:"allowAutoTopicCreation"`
 	Type       TopicType `json:"topicType"`
-	Partitions int       `json:"defaultNumPartitions"`
+	Partitions *int      `json:"defaultNumPartitions"`
 }


### PR DESCRIPTION
Fixes #1105

### Motivation

To allow setting the AutoTopicCreation policy to non-partitioned it is required to not send the partitions parameter, by making Partitions a pointer instead of an int this is possible.

### Modifications

Change type of Partitions in TopicAutoCreationConfig from int to *int

### Verifying this change

- [x] Make sure that the change passes the CI checks.

I tested it by using it in our application as the admin code currently does not have much test code. I saw here https://github.com/apache/pulsar-client-go/pull/1085 that there are reorganization plans + setting up test scaffolding in the future.
