### PR TITLE
[fix] Complete comment on ProducerInterceptor interface BeforeSend method

### DIFF
--- a/pulsar/producer_interceptor.go
+++ b/pulsar/producer_interceptor.go
@@ -19,6 +19,7 @@ package pulsar
 
 type ProducerInterceptor interface {
 	// BeforeSend This is called before send the message to the brokers. This method is allowed to modify the
+	// message.
 	BeforeSend(producer Producer, message *ProducerMessage)
 
 	// OnSendAcknowledgement This method is called when the message sent to the broker has been acknowledged,


### PR DESCRIPTION
### Motivation

The comment against the `BeforeSend` method in the `ProducerInterceptor` interface is incomplete. Whilst it's fairly easy to infer the missing words, the comment is clearer when complete.

https://github.com/apache/pulsar-client-go/blob/af56e6031d8021ddcff188f94c4d744eba3b3211/pulsar/producer_interceptor.go#L21-L22

### Modifications

Completed the comment so it reads

```
// BeforeSend This is called before send the message to the brokers. This method is allowed to modify the
// message.
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

This is the first time I've come across these interceptors so I've verified that the `BeforeSend` method can modify the message: https://go.dev/play/p/UQ4Q1MNPOpf

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? It is the documentation.
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
