### PR TITLE
When topic is terminated. Client must not retry connecting to broker.

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -439,6 +439,27 @@ func (p *partitionProducer) reconnectToBroker() {
 			break
 		}
 
+		if strings.Contains(errMsg, "TopicTerminatedError") {
+			p.log.Info("Topic was terminated, failing pending messages, will not reconnect")
+			pendingItems := p.pendingQueue.ReadableSlice()
+			for _, item := range pendingItems {
+				pi := item.(*pendingItem)
+				if pi != nil {
+					pi.Lock()
+					requests := pi.sendRequests
+					for _, req := range requests {
+						sr := req.(*sendRequest)
+						if sr != nil {
+							sr.done(nil, newError(TopicTerminated, err.Error()))
+						}
+					}
+					pi.Unlock()
+				}
+			}
+			p.setProducerState(producerClosing)
+			break
+		}
+
 		if maxRetry > 0 {
 			maxRetry--
 		}


### PR DESCRIPTION
### Motivation
GoLang Pulsar client library has no support for Topic termination.
When a topic is terminated following should happen at client library side.
1. Producers should stop reconnecting. As once topic is terminated, it is permanent. 
2. All the pending messages should be failed. 


### Modifications
If reconnect is failing with TopicTerminated error. 
Run through the pending messages queue and complete the callback.
After that exit the reconnect loop and set producer state as closing.
Marking producer state producerClosing will ensure that new messages are immediately failed.   
