### PR TITLE
[fix][TableView] Correct argument order to Errorf in TableView message handling

### DIFF
--- a/pulsar/table_view_impl.go
+++ b/pulsar/table_view_impl.go
@@ -251,7 +251,7 @@ func (tv *TableViewImpl) handleMessage(msg Message) {
 	} else {
 		payload = reflect.Indirect(reflect.New(tv.options.SchemaValueType)).Interface()
 		if err := msg.GetSchemaValue(&payload); err != nil {
-			tv.logger.Errorf("msg.GetSchemaValue() failed with %w; msg is %v", msg, err)
+			tv.logger.Errorf("msg.GetSchemaValue() failed with %w; msg is %v", err, msg)
 		}
 		tv.data[msg.Key()] = payload
 	}


### PR DESCRIPTION
### Motivation
When TableView fails to read a message with the schema the error message is malformed, e.g.
```
ERRO[0000] msg.GetSchemaValue() failed with %!w(*pulsar.message=&{[..snipped..]}); msg is schema not found for topic: [..snipped..], schema version : [ [0 0 0 0 0 0 0 0] ]
```

The correct formatting will help users to debug their issues.


### Modifications

Switch error args to match the formatting directives and context of the message.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? Trivial error formatting fix
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
