### PR TITLE
feat: added missing fields on TopicStats

### DIFF
--- a/pulsaradmin/pkg/utils/data.go
+++ b/pulsaradmin/pkg/utils/data.go
@@ -242,11 +242,16 @@ type TopicStats struct {
 }
 
 type PublisherStats struct {
-	ProducerID      int64             `json:"producerId"`
-	MsgRateIn       float64           `json:"msgRateIn"`
-	MsgThroughputIn float64           `json:"msgThroughputIn"`
-	AverageMsgSize  float64           `json:"averageMsgSize"`
-	Metadata        map[string]string `json:"metadata"`
+	ProducerID         int64             `json:"producerId"`
+	ProducerName       string	     `json:"producerName"`
+	Address            string            `json:"address"`
+	ClientVersion      string            `json:"clientVersion"`
+	AccessMode         string            `json:"accessMode"`
+	MsgRateIn          float64           `json:"msgRateIn"`
+	MsgThroughputIn    float64           `json:"msgThroughputIn"`
+	ChunkedMessageRate float64           `json:"chunkedMessageRate"`
+	AverageMsgSize     float64           `json:"averageMsgSize"`
+	Metadata           map[string]string `json:"metadata"`
 }
 
 type SubscriptionStats struct {


### PR DESCRIPTION
### Motivation

When using the admin api with golang there is some missing fields on topic stats

### Modifications

Added missing fields on topic stats

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API: yes
  - The schema: yes
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  PulsarDoc
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
