### PR TITLE
fix: channel deadlock in regexp consumer

### DIFF
--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -241,6 +241,7 @@ func runRegexConsumerDiscoverPatternFoo(t *testing.T, c Client, namespace string
 func TestRegexConsumer(t *testing.T) {
 	t.Run("MatchOneTopic", runWithClientNamespace(runRegexConsumerMatchOneTopic))
 	t.Run("AddTopic", runWithClientNamespace(runRegexConsumerAddMatchingTopic))
+	t.Run("AutoDiscoverTopics", runWithClientNamespace(runRegexConsumerAutoDiscoverTopics))
 }
 
 func runRegexConsumerMatchOneTopic(t *testing.T, c Client, namespace string) {
@@ -336,6 +337,68 @@ func runRegexConsumerAddMatchingTopic(t *testing.T, c Client, namespace string) 
 
 	ctx := context.Background()
 	for i := 0; i < 5; i++ {
+		m, err := consumer.Receive(ctx)
+		if err != nil {
+			t.Errorf("failed to receive message error: %+v", err)
+		} else {
+			assert.Truef(t, strings.HasPrefix(string(m.Payload()), "foo-"),
+				"message does not start with foo: %s", string(m.Payload()))
+		}
+	}
+}
+
+func runRegexConsumerAutoDiscoverTopics(t *testing.T, c Client, namespace string) {
+	topicsPattern := fmt.Sprintf("persistent://%s/foo.*", namespace)
+	opts := ConsumerOptions{
+		TopicsPattern:    topicsPattern,
+		SubscriptionName: "regex-sub",
+		// this is purposefully short to test parallelism between discover and subscribe calls
+		AutoDiscoveryPeriod: 1 * time.Nanosecond,
+	}
+	consumer, err := c.Subscribe(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer consumer.Close()
+
+	topicInRegex1 := namespace + "/foo-topic-1"
+	p1, err := c.CreateProducer(ProducerOptions{
+		Topic:           topicInRegex1,
+		DisableBatching: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p1.Close()
+
+	topicInRegex2 := namespace + "/foo-topic-2"
+	p2, err := c.CreateProducer(ProducerOptions{
+		Topic:           topicInRegex2,
+		DisableBatching: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p2.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	err = genMessages(p1, 5, func(idx int) string {
+		return fmt.Sprintf("foo-message-%d", idx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = genMessages(p2, 5, func(idx int) string {
+		return fmt.Sprintf("foo-message-%d", idx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
 		m, err := consumer.Receive(ctx)
 		if err != nil {
 			t.Errorf("failed to receive message error: %+v", err)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->
### Motivation

When using a regexp consumer, there's a race condition between producing and consuming new discovered topics. If the discover topic takes too long or the auto discovery period is too short, then multiple ticker.C messages may be processed in a row which will block on the subcsribe/unsubscribe channels as they only have a buffer size of 1. This will block new topics from being discovered forever.

### Modifications

Moved the consumers into their own goroutines and use an unbuffered channel. There's multiple ways to go about it but it's good practice to keep consumers and producers separate. Consumers are run until the channels they are consumed from are closed, which happens when the producer (monitor) returns.

### Verifying this change

- [ x ] Make sure that the change passes the CI checks.

  - *Added integration tests that fail when the patch is not there. There's 2-3 discover calls and then the monitor blocks indefinitely and the topics are not discovered. 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  - If a feature is not applicable for documentation, explain why? not a feature
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
