### PR TITLE
[Improve][Producer] normalize and export the errors

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4299,7 +4299,7 @@ func TestConsumerMemoryLimit(t *testing.T) {
 		Payload: createTestMessagePayload(1),
 	})
 	// Producer can't send message
-	assert.Equal(t, true, errors.Is(err, errMemoryBufferIsFull))
+	assert.Equal(t, true, errors.Is(err, ErrMemoryBufferIsFull))
 }
 
 func TestMultiConsumerMemoryLimit(t *testing.T) {

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -1061,8 +1061,8 @@ func TestMaxMessageSize(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	// Need to set BatchingMaxSize > serverMaxMessageSize to avoid errMessageTooLarge
-	// being masked by an earlier errFailAddToBatch
+	// Need to set BatchingMaxSize > serverMaxMessageSize to avoid ErrMessageTooLarge
+	// being masked by an earlier ErrFailAddToBatch
 	producer, err := client.CreateProducer(ProducerOptions{
 		Topic:           newTopicName(),
 		BatchingMaxSize: uint(2 * serverMaxMessageSize),
@@ -1088,7 +1088,7 @@ func TestMaxMessageSize(t *testing.T) {
 	// So when bias <= 0, the uncompressed payload will not exceed maxMessageSize,
 	// but encryptedPayloadSize exceeds maxMessageSize, Send() will return an internal error.
 	// When bias = 1, the first check of maxMessageSize (for uncompressed payload) is valid,
-	// Send() will return errMessageTooLarge
+	// Send() will return ErrMessageTooLarge
 	for bias := -1; bias <= 1; bias++ {
 		payload := make([]byte, serverMaxMessageSize+bias)
 		ID, err := producer.Send(context.Background(), &ProducerMessage{
@@ -1098,7 +1098,7 @@ func TestMaxMessageSize(t *testing.T) {
 			assert.Equal(t, true, errors.Is(err, internal.ErrExceedMaxMessageSize))
 			assert.Nil(t, ID)
 		} else {
-			assert.Equal(t, errMessageTooLarge, err)
+			assert.Equal(t, ErrMessageTooLarge, err)
 		}
 	}
 
@@ -1111,7 +1111,7 @@ func TestMaxMessageSize(t *testing.T) {
 			assert.Equal(t, true, errors.Is(err, internal.ErrExceedMaxMessageSize))
 			assert.Nil(t, ID)
 		} else {
-			assert.Equal(t, errMessageTooLarge, err)
+			assert.Equal(t, ErrMessageTooLarge, err)
 		}
 	}
 }
@@ -1191,7 +1191,7 @@ func TestTopicTermination(t *testing.T) {
 			})
 			if err != nil {
 				e := err.(*Error)
-				if e.result == TopicTerminated || err == errProducerClosed {
+				if e.result == TopicTerminated || err == ErrProducerClosed {
 					terminatedChan <- true
 				} else {
 					terminatedChan <- false
@@ -2348,7 +2348,7 @@ func TestFailPendingMessageWithClose(t *testing.T) {
 			Payload: make([]byte, 1024),
 		}, func(id MessageID, message *ProducerMessage, e error) {
 			if e != nil {
-				assert.Equal(t, errProducerClosed, e)
+				assert.Equal(t, ErrProducerClosed, e)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation
Currently, producing retrying is not implemented by the client, when I want to retry, it depend on the errors returned by the callback, some errors can retry, some should stop and fail fast(for example the queue is full), but the errors are not normalized and exported now, this PR normalize and export the errors of the producer.

### Modifications

1. export the errors
```go
        ErrFailAddToBatch     = newError(AddToBatchFailed, "message add to batch failed")
	ErrSendTimeout        = newError(TimeoutError, "message send timeout")
	ErrSendQueueIsFull    = newError(ProducerQueueIsFull, "producer send queue is full")
	ErrContextExpired     = newError(TimeoutError, "message send context expired")
	ErrMessageTooLarge    = newError(MessageTooBig, "message size exceeds MaxMessageSize")
	ErrMetaTooLarge       = newError(InvalidMessage, "message metadata size exceeds MaxMessageSize")
	ErrProducerClosed     = newError(ProducerClosed, "producer already been closed")
	ErrMemoryBufferIsFull = newError(ClientMemoryBufferIsFull, "client memory buffer is full")
	ErrSchema                  = newError(SchemaFailure, "schema error")
	ErrTransaction        = newError(TransactionNoFoundError, "transaction error")
	ErrInvalidMessage     = newError(InvalidMessage, "invalid message")
	ErrTopicNotfound      = newError(TopicNotFound, "topic not found")
	ErrTopicTerminated    = newError(TopicTerminated, "topic terminated")
	ErrProducerBlocked    = newError(ProducerBlockedQuotaExceededException, "producer blocked")
	ErrProducerFenced     = newError(ProducerFenced, "producer fenced")
```
2. use `errors.Join(ErrSchema, err)` to return an error
3. In the application code, use `errors.Is(err, pulsar.ErrChema)` to determine if an error can retry or not.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
