### PR TITLE
[transaction] Avoid a panic when using transaction

### DIFF
--- a/pulsar/transaction_impl.go
+++ b/pulsar/transaction_impl.go
@@ -101,7 +101,7 @@ func (txn *transaction) Commit(ctx context.Context) error {
 	if err == nil {
 		atomic.StoreInt32((*int32)(&txn.state), int32(TxnCommitted))
 	} else {
-		if err.(*Error).Result() == TransactionNoFoundError || err.(*Error).Result() == InvalidStatus {
+		if e, ok := err.(*Error); ok && (e.Result() == TransactionNoFoundError || e.Result() == InvalidStatus) {
 			atomic.StoreInt32((*int32)(&txn.state), int32(TxnError))
 			return err
 		}
@@ -127,7 +127,7 @@ func (txn *transaction) Abort(ctx context.Context) error {
 	if err == nil {
 		atomic.StoreInt32((*int32)(&txn.state), int32(TxnAborted))
 	} else {
-		if err.(*Error).Result() == TransactionNoFoundError || err.(*Error).Result() == InvalidStatus {
+		if e, ok := err.(*Error); ok && (e.Result() == TransactionNoFoundError || e.Result() == InvalidStatus) {
 			atomic.StoreInt32((*int32)(&txn.state), int32(TxnError))
 		} else {
 			txn.opsFlow <- true


### PR DESCRIPTION
### Motivation

When aborting or committing a transaction, it can happen that an error returned from the client triggers a panic when attempting to cast it to a Pulsar error.

### Modifications

A proper check is performed when casting the error.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
