### PR TITLE
Fix SIGSEGV with zstd compression enabled

### DIFF
--- a/pulsar/internal/compression/zstd_cgo.go
+++ b/pulsar/internal/compression/zstd_cgo.go
@@ -25,6 +25,8 @@
 package compression
 
 import (
+	"sync"
+
 	"github.com/DataDog/zstd"
 	log "github.com/sirupsen/logrus"
 )
@@ -33,6 +35,7 @@ type zstdCGoProvider struct {
 	ctx       zstd.Ctx
 	level     Level
 	zstdLevel int
+	mu        sync.Mutex
 }
 
 func newCGoZStdProvider(level Level) Provider {
@@ -61,6 +64,8 @@ func (z *zstdCGoProvider) CompressMaxSize(originalSize int) int {
 }
 
 func (z *zstdCGoProvider) Compress(dst, src []byte) []byte {
+	z.mu.Lock()
+	defer z.mu.Unlock()
 	out, err := z.ctx.CompressLevel(dst, src, z.zstdLevel)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to compress")

--- a/pulsar/internal/compression/zstd_cgo.go
+++ b/pulsar/internal/compression/zstd_cgo.go
@@ -32,15 +32,16 @@ import (
 )
 
 type zstdCGoProvider struct {
-	ctx       zstd.Ctx
+	ctxPool   sync.Pool
 	level     Level
 	zstdLevel int
-	mu        sync.Mutex
 }
 
 func newCGoZStdProvider(level Level) Provider {
 	z := &zstdCGoProvider{
-		ctx: zstd.NewCtx(),
+		ctxPool: sync.Pool{New: func() any {
+			return zstd.NewCtx()
+		}},
 	}
 
 	switch level {
@@ -64,9 +65,9 @@ func (z *zstdCGoProvider) CompressMaxSize(originalSize int) int {
 }
 
 func (z *zstdCGoProvider) Compress(dst, src []byte) []byte {
-	z.mu.Lock()
-	defer z.mu.Unlock()
-	out, err := z.ctx.CompressLevel(dst, src, z.zstdLevel)
+	ctx := z.ctxPool.Get().(zstd.Ctx)
+	defer z.ctxPool.Put(ctx)
+	out, err := ctx.CompressLevel(dst, src, z.zstdLevel)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to compress")
 	}
@@ -75,7 +76,9 @@ func (z *zstdCGoProvider) Compress(dst, src []byte) []byte {
 }
 
 func (z *zstdCGoProvider) Decompress(dst, src []byte, originalSize int) ([]byte, error) {
-	return z.ctx.Decompress(dst, src)
+	ctx := z.ctxPool.Get().(zstd.Ctx)
+	defer z.ctxPool.Put(ctx)
+	return ctx.Decompress(dst, src)
 }
 
 func (z *zstdCGoProvider) Close() error {

--- a/pulsar/internal/utils.go
+++ b/pulsar/internal/utils.go
@@ -39,12 +39,7 @@ func TimestampMillis(t time.Time) uint64 {
 
 // GetAndAdd perform atomic read and update
 func GetAndAdd(n *uint64, diff uint64) uint64 {
-	for {
-		v := *n
-		if atomic.CompareAndSwapUint64(n, v, v+diff) {
-			return v
-		}
-	}
+	return atomic.AddUint64(n, diff)
 }
 
 func ParseRelativeTimeInSeconds(relativeTime string) (time.Duration, error) {

--- a/pulsar/internal/utils.go
+++ b/pulsar/internal/utils.go
@@ -39,7 +39,12 @@ func TimestampMillis(t time.Time) uint64 {
 
 // GetAndAdd perform atomic read and update
 func GetAndAdd(n *uint64, diff uint64) uint64 {
-	return atomic.AddUint64(n, diff)
+	for {
+		v := atomic.LoadUint64(n)
+		if atomic.CompareAndSwapUint64(n, v, v+diff) {
+			return v
+		}
+	}
 }
 
 func ParseRelativeTimeInSeconds(relativeTime string) (time.Duration, error) {

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2357,6 +2357,34 @@ func TestFailPendingMessageWithClose(t *testing.T) {
 	assert.Equal(t, 0, partitionProducerImp.pendingQueue.Size())
 }
 
+func TestSendConcurrently(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+	testProducer, err := client.CreateProducer(ProducerOptions{
+		Topic:            newTopicName(),
+		CompressionType:  ZSTD,
+		CompressionLevel: Better,
+		DisableBatching:  true,
+	})
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			_, err := testProducer.Send(context.Background(), &ProducerMessage{
+				Payload: make([]byte, 100),
+			})
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
 type pendingQueueWrapper struct {
 	pendingQueue   internal.BlockingQueue
 	writtenBuffers *[]internal.Buffer


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #1163

Thanks @0x4500 for reporting this issue and providing the analysis. 

### Motivation

https://github.com/apache/pulsar-client-go/pull/1121 introduces a regression bug. The compression logic has been moved from `internalSend` to `internalSendAsync` which leads to the compression being executed concurrently.

However, `zstd_cgo` doesn't support concurrent compression of data. To prevent this, we need to introduce a mutex.

### Modifications

- Add mutex for zstd_cgo


### Verifying this change

I have run the benchmark and shows that this change has a minimal impact on performance.

Before this PR(I have also provided other compression provider benchmark for reference.):
```
BenchmarkCompression
BenchmarkCompression/zlib
BenchmarkCompression/zlib-12         	     388	   2904783 ns/op	  34.63 MB/s
BenchmarkCompression/lz4
BenchmarkCompression/lz4-12          	    4832	    239997 ns/op	 419.20 MB/s
BenchmarkCompression/zstd-pure-go-fastest
BenchmarkCompression/zstd-pure-go-fastest-12         	    2618	    428303 ns/op	 234.89 MB/s
BenchmarkCompression/zstd-pure-go-default
BenchmarkCompression/zstd-pure-go-default-12         	    1794	    633533 ns/op	 158.80 MB/s
BenchmarkCompression/zstd-pure-go-best
BenchmarkCompression/zstd-pure-go-best-12            	    1299	    905872 ns/op	 111.06 MB/s
BenchmarkCompression/zstd-cgo-level-fastest
BenchmarkCompression/zstd-cgo-level-fastest-12       	    7480	    176366 ns/op	 570.44 MB/s
BenchmarkCompression/zstd-cgo-level-default
BenchmarkCompression/zstd-cgo-level-default-12       	    1867	    587183 ns/op	 171.34 MB/s
BenchmarkCompression/zstd-cgo-level-best
BenchmarkCompression/zstd-cgo-level-best-12          	     620	   1855183 ns/op	  54.23 MB/s
PASS
```

After this PR:
```
BenchmarkCompression
BenchmarkCompression/zlib
BenchmarkCompression/zlib-12         	     351	   2974837 ns/op	  33.82 MB/s
BenchmarkCompression/lz4
BenchmarkCompression/lz4-12          	    4575	    223056 ns/op	 451.03 MB/s
BenchmarkCompression/zstd-pure-go-fastest
BenchmarkCompression/zstd-pure-go-fastest-12         	    2474	    412231 ns/op	 244.05 MB/s
BenchmarkCompression/zstd-pure-go-default
BenchmarkCompression/zstd-pure-go-default-12         	    1666	    641311 ns/op	 156.88 MB/s
BenchmarkCompression/zstd-pure-go-best
BenchmarkCompression/zstd-pure-go-best-12            	    1228	    882828 ns/op	 113.96 MB/s
BenchmarkCompression/zstd-cgo-level-fastest
BenchmarkCompression/zstd-cgo-level-fastest-12       	    6919	    176977 ns/op	 568.47 MB/s
BenchmarkCompression/zstd-cgo-level-default
BenchmarkCompression/zstd-cgo-level-default-12       	    1855	    586434 ns/op	 171.56 MB/s
BenchmarkCompression/zstd-cgo-level-best
BenchmarkCompression/zstd-cgo-level-best-12          	     667	   1799175 ns/op	  55.92 MB/s
PASS
```

This change added tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
