### PR TITLE
Fix BytesSchema

### DIFF
--- a/pulsar/schema.go
+++ b/pulsar/schema.go
@@ -93,6 +93,8 @@ func NewSchema(schemaType SchemaType, schemaData []byte, properties map[string]s
 	var schemaDef = string(schemaData)
 	var s Schema
 	switch schemaType {
+	case BYTES:
+		s = NewBytesSchema(properties)
 	case STRING:
 		s = NewStringSchema(properties)
 	case JSON:

--- a/pulsar/table_view_test.go
+++ b/pulsar/table_view_test.go
@@ -91,6 +91,13 @@ func TestTableViewSchemas(t *testing.T) {
 		valueCheck    func(t *testing.T, got interface{}) // Overrides expValueOut for more complex checks
 	}{
 		{
+			name:          "BytesSchema",
+			schema:        NewBytesSchema(nil),
+			schemaType:    []byte(`any`),
+			producerValue: []byte(`hello pulsar`),
+			expValueOut:   []byte(`hello pulsar`),
+		},
+		{
 			name:          "StringSchema",
 			schema:        NewStringSchema(nil),
 			schemaType:    strPointer("hello pulsar"),


### PR DESCRIPTION
This fixes #1175 

### Motivation

This fixes the BytesSchema by adding it into the switch-case in the NewBytes constructor, and adds a test showing that it can be used in a producer and consumer. Before the fix, the test fails due to the unrecognised schema in the constructor and the producer and consumer fail to encode the message.

The motivation is that BytesSchema appears to be intended as the default schema (e.g. see [here](https://github.com/petermnhull/pulsar-client-go/blob/master/pulsar/consumer_impl.go#L92) for the Consumer) instead of defining no schema at all, but this code-path is never hit as no Schemas have the NONE type.

I first started looking at this when using a TableView with a topic without a defined or consistent Schema, and I have a work in progress branch for that which will rely on this.

### Modifications

- Add BytesSchema type into constructor for NewSchema.
- Add test for BytesSchema usage.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:
  - Added test showing NewBytes fails without the accompanying fix.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: yes, allows use of BytesSchema
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? _no_
  - If yes, how is the feature documented? _not applicable_
  - If a feature is not applicable for documentation, explain why? _small fix, equivalent functionality also has no documentation_
