### PR TITLE
[Bug Fix]Fix available permits in MessageReceived

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1093,7 +1093,10 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 	pc.metrics.MessagesReceived.Add(float64(numMsgs))
 	pc.metrics.PrefetchedMessages.Add(float64(numMsgs))
 
-	var bytesReceived int
+	var (
+		bytesReceived   int
+		skippedMessages int32
+	)
 	for i := 0; i < numMsgs; i++ {
 		smm, payload, err := reader.ReadMessage()
 		if err != nil || payload == nil {
@@ -1102,7 +1105,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		}
 		if ackSet != nil && !ackSet.Test(uint(i)) {
 			pc.log.Debugf("Ignoring message from %vth message, which has been acknowledged", i)
-			pc.availablePermits.inc()
+			skippedMessages++
 			continue
 		}
 
@@ -1121,7 +1124,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 
 		if pc.messageShouldBeDiscarded(trackingMsgID) {
 			pc.AckID(trackingMsgID)
-			pc.availablePermits.inc()
+			skippedMessages++
 			continue
 		}
 
@@ -1146,7 +1149,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		}
 
 		if pc.ackGroupingTracker.isDuplicate(msgID) {
-			pc.availablePermits.inc()
+			skippedMessages++
 			continue
 		}
 
@@ -1219,6 +1222,10 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		pc.client.memLimit.ForceReserveMemory(int64(bytesReceived))
 		pc.incomingMessages.Add(int32(len(messages)))
 		pc.markScaleIfNeed()
+	}
+
+	if skippedMessages > 0 {
+		pc.availablePermits.add(skippedMessages)
 	}
 
 	// send messages to the dispatcher

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -206,6 +206,12 @@ func (p *availablePermits) add(delta int32) {
 	p.flowIfNeed()
 }
 
+func (p *availablePermits) incN(delta int32) {
+	for ; delta > 0; delta-- {
+		p.inc()
+	}
+}
+
 func (p *availablePermits) reset() {
 	p.permits.Store(0)
 }
@@ -1225,7 +1231,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 	}
 
 	if skippedMessages > 0 {
-		pc.availablePermits.add(skippedMessages)
+		pc.availablePermits.incN(skippedMessages)
 	}
 
 	// send messages to the dispatcher

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -206,12 +206,6 @@ func (p *availablePermits) add(delta int32) {
 	p.flowIfNeed()
 }
 
-func (p *availablePermits) incN(delta int32) {
-	for ; delta > 0; delta-- {
-		p.inc()
-	}
-}
-
 func (p *availablePermits) reset() {
 	p.permits.Store(0)
 }
@@ -1231,7 +1225,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 	}
 
 	if skippedMessages > 0 {
-		pc.availablePermits.incN(skippedMessages)
+		pc.availablePermits.add(skippedMessages)
 	}
 
 	// send messages to the dispatcher

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1102,6 +1102,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		}
 		if ackSet != nil && !ackSet.Test(uint(i)) {
 			pc.log.Debugf("Ignoring message from %vth message, which has been acknowledged", i)
+			pc.availablePermits.inc()
 			continue
 		}
 
@@ -1120,6 +1121,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 
 		if pc.messageShouldBeDiscarded(trackingMsgID) {
 			pc.AckID(trackingMsgID)
+			pc.availablePermits.inc()
 			continue
 		}
 
@@ -1144,6 +1146,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 		}
 
 		if pc.ackGroupingTracker.isDuplicate(msgID) {
+			pc.availablePermits.inc()
 			continue
 		}
 


### PR DESCRIPTION
Fixes #1180 

### Motivation
In the `MessageReceived`, the number of skipped messages should be increased to available permits to avoid skipped permits leading flow request not be sent.