### PR TITLE
[fix] Fix Infinite Loop in Reader's `HasNext` Function

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -40,14 +40,15 @@ const (
 )
 
 type client struct {
-	cnxPool       internal.ConnectionPool
-	rpcClient     internal.RPCClient
-	handlers      internal.ClientHandlers
-	lookupService internal.LookupService
-	metrics       *internal.Metrics
-	tcClient      *transactionCoordinatorClient
-	memLimit      internal.MemoryLimitController
-	closeOnce     sync.Once
+	cnxPool          internal.ConnectionPool
+	rpcClient        internal.RPCClient
+	handlers         internal.ClientHandlers
+	lookupService    internal.LookupService
+	metrics          *internal.Metrics
+	tcClient         *transactionCoordinatorClient
+	memLimit         internal.MemoryLimitController
+	closeOnce        sync.Once
+	operationTimeout time.Duration
 
 	log log.Logger
 }
@@ -161,9 +162,10 @@ func newClient(options ClientOptions) (Client, error) {
 	c := &client{
 		cnxPool: internal.NewConnectionPool(tlsConfig, authProvider, connectionTimeout, keepAliveInterval,
 			maxConnectionsPerHost, logger, metrics, connectionMaxIdleTime),
-		log:      logger,
-		metrics:  metrics,
-		memLimit: internal.NewMemoryLimitController(memLimitBytes, defaultMemoryLimitTriggerThreshold),
+		log:              logger,
+		metrics:          metrics,
+		memLimit:         internal.NewMemoryLimitController(memLimitBytes, defaultMemoryLimitTriggerThreshold),
+		operationTimeout: operationTimeout,
 	}
 	serviceNameResolver := internal.NewPulsarServiceNameResolver(url)
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -594,6 +594,7 @@ func (pc *partitionConsumer) getLastMessageID() (*trackingMessageID, error) {
 			return msgID, nil
 		}
 		if remainTime <= 0 {
+			pc.log.WithError(err).Error("Failed to getLastMessageID")
 			return nil, fmt.Errorf("failed to getLastMessageID due to %w", err)
 		}
 		nextDelay := backoff.Next()

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -113,6 +113,7 @@ type Reader interface {
 	Next(context.Context) (Message, error)
 
 	// HasNext checks if there is any message available to read from the current position
+	// If there is any errors, it will return false
 	HasNext() bool
 
 	// Close the reader and stop the broker to push more messages

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -173,16 +173,11 @@ func (r *reader) HasNext() bool {
 		return true
 	}
 
-	for {
-		lastMsgID, err := r.pc.getLastMessageID()
-		if err != nil {
-			r.log.WithError(err).Error("Failed to get last message id from broker")
-			continue
-		} else {
-			r.lastMessageInBroker = lastMsgID
-			break
-		}
+	lastMsgID, err := r.pc.getLastMessageID()
+	if err != nil {
+		return false
 	}
+	r.lastMessageInBroker = lastMsgID
 
 	return r.hasMoreMessages()
 }

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -874,7 +874,6 @@ func TestReaderWithSchema(t *testing.T) {
 	assert.Equal(t, *res, value)
 }
 
-//nolint:unparam
 func newTestBackoffPolicy(minBackoff, maxBackoff time.Duration) *testBackoffPolicy {
 	return &testBackoffPolicy{
 		curBackoff: 0,

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -1049,15 +1049,15 @@ func TestReaderHasNextRetryFailed(t *testing.T) {
 	r, err := client.CreateReader(ReaderOptions{
 		Topic:          topic,
 		StartMessageID: EarliestMessageID(),
-		// Retry the connection 10 seconds after it's disconnected.
-		BackoffPolicy: newTestBackoffPolicy(10*time.Second, 10*time.Second),
+		// Retry the connection 1 second after it's disconnected.
+		BackoffPolicy: newTestBackoffPolicy(1*time.Second, 1*time.Second),
 	})
 	assert.Nil(t, err)
 
 	// Disconnect the connection
 	r.(*reader).c.consumers[0].conn.Load().(internal.Connection).Close()
-	minTimer := time.NewTimer(10 * time.Second) // Timer to check if r.HasNext() blocked for at least 10s
-	maxTimer := time.NewTimer(20 * time.Second) // Timer to ensure r.HasNext() doesn't block for more than 20s
+	minTimer := time.NewTimer(1 * time.Second) // Timer to check if r.HasNext() blocked for at least 1s
+	maxTimer := time.NewTimer(2 * time.Second) // Timer to ensure r.HasNext() doesn't block for more than 2s
 
 	done := make(chan bool)
 	go func() {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -874,6 +874,7 @@ func TestReaderWithSchema(t *testing.T) {
 	assert.Equal(t, *res, value)
 }
 
+//nolint:unparam
 func newTestBackoffPolicy(minBackoff, maxBackoff time.Duration) *testBackoffPolicy {
 	return &testBackoffPolicy{
 		curBackoff: 0,


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #1171

### Motivation

If `getLastMessageId` continually fails, the reader.HasNext can get stuck in an infinite loop. Without any backoff, the reader would keep trying forever.

### Modifications

- Implemented a backoff policy for `getLastMessageID`.
- If HasNext fails, it now returns false.

#### Should the reader.HasNext returned `false` in case of failure?

Currently, the `HasNext` method doesn't report errors. However, failure is still possible. For instance, if `getLastMessageID` repeatedly fails and hits the retry limit. An option is to keep trying forever, but this would stall all user code. This isn't user-friendly, so I rejected this solution.

#### Couldn't utilize the BackOffPolicy in the Reader Options

The `HasNext` retry mechanism requires to use of `IsMaxBackoffReached` for the backoff. But it isn't exposed in the `BackOffPolicy` interface. Introducing a new method to the `BackOffPolicy` would introduce breaking changes for the user backoff implementation. So, I choose not to implement it. Before we do it, we need to refine the BackOffPolicy.

### Verifying this ch
This change added tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
