### PR TITLE
[Improve] Add optional parameters for getPartitionedStats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 #
 
 IMAGE_NAME = pulsar-client-go-test:latest
-PULSAR_VERSION ?= 2.10.3
+PULSAR_VERSION ?= 3.2.0
 PULSAR_IMAGE = apachepulsar/pulsar:$(PULSAR_VERSION)
 GO_VERSION ?= 1.18
 GOLANG_IMAGE = golang:$(GO_VERSION)

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -2219,6 +2219,12 @@ func TestConsumerAddTopicPartitions(t *testing.T) {
 	assert.Nil(t, err)
 	defer producer.Close()
 
+	// Increase number of partitions to 10
+	makeHTTPCall(t, http.MethodPost, testURL, "10")
+
+	// Wait for the producer/consumers to pick up the change
+	time.Sleep(1 * time.Second)
+
 	consumer, err := client.Subscribe(ConsumerOptions{
 		Topic:               topic,
 		SubscriptionName:    "my-sub",
@@ -2226,12 +2232,6 @@ func TestConsumerAddTopicPartitions(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	defer consumer.Close()
-
-	// Increase number of partitions to 10
-	makeHTTPCall(t, http.MethodPost, testURL, "10")
-
-	// Wait for the producer/consumers to pick up the change
-	time.Sleep(1 * time.Second)
 
 	// Publish messages ensuring that they will go to all the partitions
 	ctx := context.Background()

--- a/pulsaradmin/pkg/admin/topic.go
+++ b/pulsaradmin/pkg/admin/topic.go
@@ -431,7 +431,8 @@ func (t *topics) GetPartitionedStats(topic utils.TopicName, perPartition bool) (
 	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &stats, params, true)
 	return stats, err
 }
-func (t *topics) GetPartitionedStatsWithOption(topic utils.TopicName, perPartition bool, option utils.GetStatsOptions) (utils.PartitionedTopicStats, error) {
+func (t *topics) GetPartitionedStatsWithOption(topic utils.TopicName, perPartition bool,
+	option utils.GetStatsOptions) (utils.PartitionedTopicStats, error) {
 	var stats utils.PartitionedTopicStats
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitioned-stats")
 	params := map[string]string{

--- a/pulsaradmin/pkg/admin/topic_test.go
+++ b/pulsaradmin/pkg/admin/topic_test.go
@@ -149,7 +149,7 @@ func TestNonPartitionState(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, admin)
 
-	// Create partition topic
+	// Create non-partition topic
 	topicName, err := utils.GetTopicName(topic)
 	assert.NoError(t, err)
 	err = admin.Topics().Create(*topicName, 0)

--- a/pulsaradmin/pkg/admin/topic_test.go
+++ b/pulsaradmin/pkg/admin/topic_test.go
@@ -18,10 +18,20 @@
 package admin
 
 import (
+	"context"
+	"fmt"
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
+	"log"
 	"testing"
+	"time"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
+)
+
+var (
+	lookupURL = "pulsar://localhost:6650"
 )
 
 func TestCreateTopic(t *testing.T) {
@@ -52,4 +62,153 @@ func TestCreateTopic(t *testing.T) {
 		}
 	}
 	t.Error("Couldn't find topic: " + topic)
+}
+
+func TestPartitionState(t *testing.T) {
+	randomName := newTopicName()
+	topic := "persistent://public/default/" + randomName
+
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	// Create partition topic
+	topicName, err := utils.GetTopicName(topic)
+	assert.NoError(t, err)
+	err = admin.Topics().Create(*topicName, 4)
+	assert.NoError(t, err)
+
+	// Send message
+	ctx := context.Background()
+
+	// create consumer
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:            topic,
+		SubscriptionName: "my-sub",
+		Type:             pulsar.Exclusive,
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// create producer
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic:           topic,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 10 messages
+	for i := 0; i < 10; i++ {
+		if _, err := producer.Send(ctx, &pulsar.ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+			Key:     "pulsar",
+			Properties: map[string]string{
+				"key-1": "pulsar-1",
+			},
+		}); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	stats, err := admin.Topics().GetPartitionedStatsWithOption(*topicName, true, utils.GetStatsOptions{
+		GetPreciseBacklog:        false,
+		SubscriptionBacklogSize:  false,
+		GetEarliestTimeInBacklog: false,
+		ExcludePublishers:        true,
+		ExcludeConsumers:         true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, len(stats.Publishers), 0)
+
+	for _, topicStats := range stats.Partitions {
+		assert.Equal(t, len(topicStats.Publishers), 0)
+		for _, subscriptionStats := range topicStats.Subscriptions {
+			assert.Equal(t, len(subscriptionStats.Consumers), 0)
+		}
+	}
+
+	for _, subscriptionStats := range stats.Subscriptions {
+		assert.Equal(t, len(subscriptionStats.Consumers), 0)
+	}
+
+}
+func TestNonPartitionState(t *testing.T) {
+	randomName := newTopicName()
+	topic := "persistent://public/default/" + randomName
+
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	// Create partition topic
+	topicName, err := utils.GetTopicName(topic)
+	assert.NoError(t, err)
+	err = admin.Topics().Create(*topicName, 0)
+	assert.NoError(t, err)
+
+	// Send message
+	ctx := context.Background()
+
+	// create consumer
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:            topic,
+		SubscriptionName: "my-sub",
+		Type:             pulsar.Exclusive,
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// create producer
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic:           topic,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 10 messages
+	for i := 0; i < 10; i++ {
+		if _, err := producer.Send(ctx, &pulsar.ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+			Key:     "pulsar",
+			Properties: map[string]string{
+				"key-1": "pulsar-1",
+			},
+		}); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	stats, err := admin.Topics().GetStatsWithOption(*topicName, utils.GetStatsOptions{
+		GetPreciseBacklog:        false,
+		SubscriptionBacklogSize:  false,
+		GetEarliestTimeInBacklog: false,
+		ExcludePublishers:        true,
+		ExcludeConsumers:         true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, len(stats.Publishers), 0)
+	for _, subscriptionStats := range stats.Subscriptions {
+		assert.Equal(t, len(subscriptionStats.Consumers), 0)
+	}
+
+}
+
+func newTopicName() string {
+	return fmt.Sprintf("my-topic-%v", time.Now().Nanosecond())
 }

--- a/pulsaradmin/pkg/admin/topic_test.go
+++ b/pulsaradmin/pkg/admin/topic_test.go
@@ -20,11 +20,12 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/apache/pulsar-client-go/pulsar"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"

--- a/pulsaradmin/pkg/utils/data.go
+++ b/pulsaradmin/pkg/utils/data.go
@@ -465,3 +465,11 @@ type CompactedLedger struct {
 	Offloaded       bool  `json:"offloaded"`
 	UnderReplicated bool  `json:"underReplicated"`
 }
+
+type GetStatsOptions struct {
+	GetPreciseBacklog        bool `json:"get_precise_backlog"`
+	SubscriptionBacklogSize  bool `json:"subscription_backlog_size"`
+	GetEarliestTimeInBacklog bool `json:"get_earliest_time_in_backlog"`
+	ExcludePublishers        bool `json:"exclude_publishers"`
+	ExcludeConsumers         bool `json:"exclude_consumers"`
+}


### PR DESCRIPTION
### Motivation
To keep consistent with the Java client.

Releted PR: https://github.com/apache/pulsar/pull/21611


### Modifications

Add `GetStatsOptions` params.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
