### PR TITLE
[Improve]Change base image to apachepulsar/pulsar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.18', '1.19', '1.20', '1.21']
+        go-version: ['1.18', '1.19', '1.20', '1.21.0']
     steps:
       - uses: actions/checkout@v3
       - name: clean docker cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,15 @@
 # set via the Makefile or CLI
 ARG PULSAR_IMAGE=apachepulsar/pulsar:latest
 FROM $PULSAR_IMAGE
+USER root
 ARG GO_VERSION=1.18
 
 RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
     mkdir -p /pulsar/go && tar -C /pulsar -xzf golang.tar.gz
 
 ENV PATH /pulsar/go/bin:$PATH
+
+RUN apt-get update && apt-get install -y git && apt-get install -y gcc
 
 
 ### Add pulsar config
@@ -38,4 +41,3 @@ COPY integration-tests/conf/.htpasswd \
 COPY . /pulsar/pulsar-client-go
 
 ENV PULSAR_EXTRA_OPTS="-Dpulsar.auth.basic.conf=/pulsar/conf/.htpasswd"
-USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,4 @@ COPY integration-tests/conf/.htpasswd \
 COPY . /pulsar/pulsar-client-go
 
 ENV PULSAR_EXTRA_OPTS="-Dpulsar.auth.basic.conf=/pulsar/conf/.htpasswd"
+USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,14 @@
 # Explicit version of Pulsar and Golang images should be
 # set via the Makefile or CLI
 ARG PULSAR_IMAGE=apachepulsar/pulsar:latest
-ARG GOLANG_IMAGE=golang:latest
+FROM $PULSAR_IMAGE
+ARG GO_VERSION=1.18
 
-FROM $PULSAR_IMAGE as pulsar
-FROM $GOLANG_IMAGE
+RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
+    mkdir -p /pulsar/go && tar -C /pulsar -xzf golang.tar.gz
 
-RUN apt-get update && apt-get install -y openjdk-17-jre ca-certificates
+ENV PATH /pulsar/go/bin:$PATH
 
-COPY --from=pulsar /pulsar /pulsar
 
 ### Add pulsar config
 COPY integration-tests/certs /pulsar/certs

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ IMAGE_NAME = pulsar-client-go-test:latest
 PULSAR_VERSION ?= 3.2.0
 PULSAR_IMAGE = apachepulsar/pulsar:$(PULSAR_VERSION)
 GO_VERSION ?= 1.18
-GOLANG_IMAGE = golang:$(GO_VERSION)
 
 # Golang standard bin directory.
 GOPATH ?= $(shell go env GOPATH)
@@ -39,7 +38,7 @@ bin/golangci-lint:
 	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 container:
-	docker build -t ${IMAGE_NAME} --build-arg GOLANG_IMAGE="${GOLANG_IMAGE}" \
+	docker build -t ${IMAGE_NAME} --build-arg GO_VERSION="${GO_VERSION}" \
 	    --build-arg PULSAR_IMAGE="${PULSAR_IMAGE}" .
 
 test: container

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -20,6 +20,7 @@
 set -e -x
 
 export GOPATH=/pulsar/go
+export GOCACHE=/tmp/go-cache
 
 # Install dependencies
 go mod download

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -26,8 +26,8 @@ export GOCACHE=/tmp/go-cache
 go mod download
 
 # Basic compilation
-CGO_ENABLED=0 go build ./pulsar
-CGO_ENABLED=0 go build -buildvcs=false -o bin/pulsar-perf ./perf
+go build ./pulsar
+go build -o bin/pulsar-perf ./perf
 
 scripts/pulsar-test-service-start.sh
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -27,7 +27,7 @@ go mod download
 
 # Basic compilation
 CGO_ENABLED=0 go build ./pulsar
-go build -o bin/pulsar-perf ./perf
+go build -buildvcs=false -o bin/pulsar-perf ./perf
 
 scripts/pulsar-test-service-start.sh
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -26,7 +26,7 @@ export GOCACHE=/tmp/go-cache
 go mod download
 
 # Basic compilation
-go build ./pulsar
+CGO_ENABLED=0 go build ./pulsar
 go build -o bin/pulsar-perf ./perf
 
 scripts/pulsar-test-service-start.sh

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -19,7 +19,7 @@
 
 set -e -x
 
-export GOPATH=/
+export GOPATH=/pulsar/go
 
 # Install dependencies
 go mod download

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -27,7 +27,7 @@ go mod download
 
 # Basic compilation
 CGO_ENABLED=0 go build ./pulsar
-go build -buildvcs=false -o bin/pulsar-perf ./perf
+CGO_ENABLED=0 go build -buildvcs=false -o bin/pulsar-perf ./perf
 
 scripts/pulsar-test-service-start.sh
 


### PR DESCRIPTION

### Motivation
There are related discussion records [here](https://github.com/apache/pulsar-client-go/pull/1037). It is recommended to switch the base image to `apachepulsar/pulsar`.


### Modifications

Change base image to `apachepulsar/pulsar`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
