### PR TITLE
[Improve] Add admin api HealthCheckWithTopicVersion

### DIFF
--- a/integration-tests/tokens/admin-token
+++ b/integration-tests/tokens/admin-token
@@ -1,0 +1,1 @@
+eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.MKSR5Mb2wu_FQlMYACv2i4ubMCn4h4Dj_aIDo1dPsDk

--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -145,7 +145,7 @@ func (b *broker) GetAllDynamicConfigurations() (map[string]string, error) {
 }
 
 func (b *broker) HealthCheck() error {
-	return b.HealthCheckWithTopicVersion(utils.V1)
+	return b.HealthCheckWithTopicVersion(utils.TopicVersionV1)
 }
 func (b *broker) HealthCheckWithTopicVersion(topicVersion utils.TopicVersion) error {
 	endpoint := b.pulsar.endpoint(b.basePath, "/health")

--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -53,8 +53,11 @@ type Brokers interface {
 	// GetAllDynamicConfigurations returns values of all overridden dynamic-configs
 	GetAllDynamicConfigurations() (map[string]string, error)
 
-	// HealthCheck run a health check on the broker
+	// Deprecated: Use HealthCheckWithTopicVersion instead
 	HealthCheck() error
+
+	// HealthCheckWithTopicVersion run a health check on the broker
+	HealthCheckWithTopicVersion(utils.TopicVersion) error
 }
 
 type broker struct {
@@ -142,9 +145,14 @@ func (b *broker) GetAllDynamicConfigurations() (map[string]string, error) {
 }
 
 func (b *broker) HealthCheck() error {
+	return b.HealthCheckWithTopicVersion(utils.V1)
+}
+func (b *broker) HealthCheckWithTopicVersion(topicVersion utils.TopicVersion) error {
 	endpoint := b.pulsar.endpoint(b.basePath, "/health")
 
-	buf, err := b.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
+	buf, err := b.pulsar.Client.GetWithQueryParams(endpoint, nil, map[string]string{
+		"topicVersion": topicVersion.String(),
+	}, false)
 	if err != nil {
 		return err
 	}

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -37,8 +37,8 @@ func TestBrokerHealthCheckWithTopicVersion(t *testing.T) {
 	assert.NotNil(t, admin)
 	err = admin.Brokers().HealthCheck()
 	assert.NoError(t, err)
-	err = admin.Brokers().HealthCheckWithTopicVersion(utils.V1)
+	err = admin.Brokers().HealthCheckWithTopicVersion(utils.TopicVersionV1)
 	assert.NoError(t, err)
-	err = admin.Brokers().HealthCheckWithTopicVersion(utils.V2)
+	err = admin.Brokers().HealthCheckWithTopicVersion(utils.TopicVersionV2)
 	assert.NoError(t, err)
 }

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"os"
 	"testing"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
@@ -25,9 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_broker_HealthCheckWithTopicVersion(t *testing.T) {
+func TestBrokerHealthCheckWithTopicVersion(t *testing.T) {
+	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
+	assert.NoError(t, err)
 	cfg := &config.Config{
-		Token: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.MKSR5Mb2wu_FQlMYACv2i4ubMCn4h4Dj_aIDo1dPsDk",
+		Token: string(readFile),
 	}
 	admin, err := New(cfg)
 	assert.NoError(t, err)

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -20,19 +20,16 @@ package admin
 import (
 	"testing"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/auth"
-
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_broker_HealthCheckWithTopicVersion(t *testing.T) {
-	cfg := &config.Config{}
-	tokenAuth, err := auth.NewAuthenticationToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9."+
-		"MKSR5Mb2wu_FQlMYACv2i4ubMCn4h4Dj_aIDo1dPsDk", nil)
-	assert.NoError(t, err)
-	admin, err := NewPulsarClientWithAuthProvider(cfg, tokenAuth)
+	cfg := &config.Config{
+		Token: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.MKSR5Mb2wu_FQlMYACv2i4ubMCn4h4Dj_aIDo1dPsDk",
+	}
+	admin, err := New(cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, admin)
 	err = admin.Brokers().HealthCheck()

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package admin
+
+import (
+	"testing"
+
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_broker_HealthCheckWithTopicVersion(t *testing.T) {
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+	err = admin.Brokers().HealthCheck()
+	assert.NoError(t, err)
+	err = admin.Brokers().HealthCheckWithTopicVersion(utils.V1)
+	assert.NoError(t, err)
+	err = admin.Brokers().HealthCheckWithTopicVersion(utils.V2)
+	assert.NoError(t, err)
+}

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -20,6 +20,8 @@ package admin
 import (
 	"testing"
 
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/auth"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +29,10 @@ import (
 
 func Test_broker_HealthCheckWithTopicVersion(t *testing.T) {
 	cfg := &config.Config{}
-	admin, err := New(cfg)
+	tokenAuth, err := auth.NewAuthenticationToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9."+
+		"MKSR5Mb2wu_FQlMYACv2i4ubMCn4h4Dj_aIDo1dPsDk", nil)
+	assert.NoError(t, err)
+	admin, err := NewPulsarClientWithAuthProvider(cfg, tokenAuth)
 	assert.NoError(t, err)
 	assert.NotNil(t, admin)
 	err = admin.Brokers().HealthCheck()

--- a/pulsaradmin/pkg/utils/data.go
+++ b/pulsaradmin/pkg/utils/data.go
@@ -473,3 +473,14 @@ type GetStatsOptions struct {
 	ExcludePublishers        bool `json:"exclude_publishers"`
 	ExcludeConsumers         bool `json:"exclude_consumers"`
 }
+
+type TopicVersion string
+
+const (
+	V1 TopicVersion = "V1"
+	V2 TopicVersion = "V2"
+)
+
+func (t TopicVersion) String() string {
+	return string(t)
+}

--- a/pulsaradmin/pkg/utils/data.go
+++ b/pulsaradmin/pkg/utils/data.go
@@ -477,8 +477,8 @@ type GetStatsOptions struct {
 type TopicVersion string
 
 const (
-	V1 TopicVersion = "V1"
-	V2 TopicVersion = "V2"
+	TopicVersionV1 TopicVersion = "V1"
+	TopicVersionV2 TopicVersion = "V2"
 )
 
 func (t TopicVersion) String() string {


### PR DESCRIPTION

### Motivation

To keep consistent with the Java client.

Releted PR: https://github.com/apache/pulsar/pull/11268


### Modifications

Add `HealthCheckWithTopicVersion` interface.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
