### PR TITLE
[Improve] Add admin api GetLeaderBroker

### DIFF
--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -58,6 +58,9 @@ type Brokers interface {
 
 	// HealthCheckWithTopicVersion run a health check on the broker
 	HealthCheckWithTopicVersion(utils.TopicVersion) error
+
+	// GetLeaderBroker get the information of the leader broker.
+	GetLeaderBroker() (utils.BrokerInfo, error)
 }
 
 type broker struct {
@@ -161,4 +164,13 @@ func (b *broker) HealthCheckWithTopicVersion(topicVersion utils.TopicVersion) er
 		return fmt.Errorf("health check returned unexpected result: %s", string(buf))
 	}
 	return nil
+}
+func (b *broker) GetLeaderBroker() (utils.BrokerInfo, error) {
+	endpoint := b.pulsar.endpoint(b.basePath, "/leaderBroker")
+	var brokerInfo utils.BrokerInfo
+	err := b.pulsar.Client.Get(endpoint, &brokerInfo)
+	if err != nil {
+		return brokerInfo, err
+	}
+	return brokerInfo, nil
 }

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -42,3 +42,15 @@ func TestBrokerHealthCheckWithTopicVersion(t *testing.T) {
 	err = admin.Brokers().HealthCheckWithTopicVersion(utils.TopicVersionV2)
 	assert.NoError(t, err)
 }
+
+func TestGetLeaderBroker(t *testing.T) {
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+	leaderBroker, err := admin.Brokers().GetLeaderBroker()
+	assert.NoError(t, err)
+	assert.NotNil(t, leaderBroker)
+	assert.Equal(t, leaderBroker.ServiceURL, "http://localhost:8080")
+	assert.Equal(t, leaderBroker.BrokerID, "localhost:8080")
+}

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -44,7 +44,11 @@ func TestBrokerHealthCheckWithTopicVersion(t *testing.T) {
 }
 
 func TestGetLeaderBroker(t *testing.T) {
-	cfg := &config.Config{}
+	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
+	assert.NoError(t, err)
+	cfg := &config.Config{
+		Token: string(readFile),
+	}
 	admin, err := New(cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, admin)

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -55,6 +55,6 @@ func TestGetLeaderBroker(t *testing.T) {
 	leaderBroker, err := admin.Brokers().GetLeaderBroker()
 	assert.NoError(t, err)
 	assert.NotNil(t, leaderBroker)
-	assert.Equal(t, leaderBroker.ServiceURL, "http://localhost:8080")
-	assert.Equal(t, leaderBroker.BrokerID, "localhost:8080")
+	assert.NotEmpty(t, leaderBroker.ServiceURL)
+	assert.NotEmpty(t, leaderBroker.BrokerID)
 }

--- a/pulsaradmin/pkg/utils/data.go
+++ b/pulsaradmin/pkg/utils/data.go
@@ -474,6 +474,11 @@ type GetStatsOptions struct {
 	ExcludeConsumers         bool `json:"exclude_consumers"`
 }
 
+type BrokerInfo struct {
+	BrokerID   string `json:"brokerId"`
+	ServiceURL string `json:"serviceUrl"`
+}
+
 type TopicVersion string
 
 const (


### PR DESCRIPTION


### Motivation

To keep consistent with the [Java client](https://github.com/apache/pulsar/pull/9799).

### Modifications

Add `GetLeaderBroker` interface.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
