### PR TITLE
[fix][build] Build test container image using current hardware platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ ARG PULSAR_IMAGE=apachepulsar/pulsar:latest
 FROM $PULSAR_IMAGE
 USER root
 ARG GO_VERSION=1.18
+ARG ARCH=amd64
 
-RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o golang.tar.gz && \
+RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -o golang.tar.gz && \
     mkdir -p /pulsar/go && tar -C /pulsar -xzf golang.tar.gz
 
 ENV PATH /pulsar/go/bin:$PATH

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_NAME = pulsar-client-go-test:latest
 PULSAR_VERSION ?= 3.2.0
 PULSAR_IMAGE = apachepulsar/pulsar:$(PULSAR_VERSION)
 GO_VERSION ?= 1.18
-CONTAINER_ARCH ?= $(shell uname -m)
+CONTAINER_ARCH ?= $(shell uname -m | sed s/x86_64/amd64/)
 
 # Golang standard bin directory.
 GOPATH ?= $(shell go env GOPATH)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ IMAGE_NAME = pulsar-client-go-test:latest
 PULSAR_VERSION ?= 3.2.0
 PULSAR_IMAGE = apachepulsar/pulsar:$(PULSAR_VERSION)
 GO_VERSION ?= 1.18
+CONTAINER_ARCH ?= $(shell uname -m)
 
 # Golang standard bin directory.
 GOPATH ?= $(shell go env GOPATH)
@@ -38,8 +39,10 @@ bin/golangci-lint:
 	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 container:
-	docker build -t ${IMAGE_NAME} --build-arg GO_VERSION="${GO_VERSION}" \
-	    --build-arg PULSAR_IMAGE="${PULSAR_IMAGE}" .
+	docker build -t ${IMAGE_NAME} \
+	  --build-arg GO_VERSION="${GO_VERSION}" \
+	  --build-arg PULSAR_IMAGE="${PULSAR_IMAGE}" \
+	  --build-arg ARCH="${CONTAINER_ARCH}" .
 
 test: container
 	docker run -i ${IMAGE_NAME} bash -c "cd /pulsar/pulsar-client-go && ./scripts/run-ci.sh"


### PR DESCRIPTION
### Motivation

Test container image is built for `amd64` platforms only. This makes it difficult to test and run on others, notably Apple Silicon chips running `arm64`.

### Modifications

The source of the problem is using the hardcoded `amd64` Go binary distribution during the image build. On Apple Silicon, running `make test` yields the following error:

```
...
docker run -i pulsar-client-go-test:latest bash -c "cd /pulsar/pulsar-client-go && ./scripts/run-ci.sh"
+ export GOPATH=/pulsar/go
+ GOPATH=/pulsar/go
+ export GOCACHE=/tmp/go-cache
+ GOCACHE=/tmp/go-cache
+ go mod download
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
 ./scripts/run-ci.sh: line 26:     7 Trace/breakpoint trap   go mod download
make: *** [test] Error 133
```

Sourcing the local platform name from `uname -m` and using it to download the corresponding Go distribution solves the issue:

```
...
docker run -i pulsar-client-go-test:latest bash -c "cd /pulsar/pulsar-client-go && ./scripts/run-ci.sh"
+ export GOPATH=/pulsar/go
+ GOPATH=/pulsar/go
+ export GOCACHE=/tmp/go-cache
+ GOCACHE=/tmp/go-cache
+ go mod download
+ go build ./pulsar
+ go build -o bin/pulsar-perf ./perf
+ scripts/pulsar-test-service-start.sh
...
```

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): _No_
  - The public API: _No_
  - The schema: _No_
  - The default values of configurations: _No_
  - The wire protocol: _No_

### Documentation

  - Does this pull request introduce a new feature? _No_
  - If yes, how is the feature documented? _Not applicable_
  - If a feature is not applicable for documentation, explain why? _Relevant only for build/test workflows_
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
