### PR TITLE
[improve] add a lint-docker command in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ lint: bin/golangci-lint
 bin/golangci-lint:
 	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
+# an alternative to above `make lint` command
+# use golangCi-lint docker to avoid local golang env issues
+# https://golangci-lint.run/welcome/install/
+lint-docker:
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.51.2 golangci-lint run -v
+
 container:
 	docker build -t ${IMAGE_NAME} \
 	  --build-arg GO_VERSION="${GO_VERSION}" \


### PR DESCRIPTION
### Motivation
I encountered [install failure](https://github.com/apache/pulsar-client-go/pull/1202#issuecomment-2050097685) when I ran `make lint` to linter my code.
I think we may get some errors when local go env is a little bit complicated, and sometimes it is better to run linter in an official linter docker.

### Modifications
I add an alternative `make lint-docker` Makefile command so that we can run linter in a docker file.

### Verifying this change
- [x] Make sure that the change passes the CI checks.
This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
