### PR TITLE
[Improve] Add admin api GetListActiveBrokers

### DIFF
--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -27,6 +27,9 @@ import (
 
 // Brokers is admin interface for brokers management
 type Brokers interface {
+
+	// GetListActiveBrokers Get the list of active brokers in the local cluster.
+	GetListActiveBrokers() ([]string, error)
 	// GetActiveBrokers returns the list of active brokers in the cluster.
 	GetActiveBrokers(cluster string) ([]string, error)
 
@@ -78,6 +81,16 @@ func (c *pulsarClient) Brokers() Brokers {
 
 func (b *broker) GetActiveBrokers(cluster string) ([]string, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, cluster)
+	var res []string
+	err := b.pulsar.Client.Get(endpoint, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (b *broker) GetListActiveBrokers() ([]string, error) {
+	endpoint := b.pulsar.endpoint(b.basePath)
 	var res []string
 	err := b.pulsar.Client.Get(endpoint, &res)
 	if err != nil {

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -58,3 +58,18 @@ func TestGetLeaderBroker(t *testing.T) {
 	assert.NotEmpty(t, leaderBroker.ServiceURL)
 	assert.NotEmpty(t, leaderBroker.BrokerID)
 }
+
+func TestGetAllActiveBrokers(t *testing.T) {
+	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
+	assert.NoError(t, err)
+	cfg := &config.Config{
+		Token: string(readFile),
+	}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	brokers, err := admin.Brokers().GetListActiveBrokers()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, brokers)
+}


### PR DESCRIPTION

### Motivation

To keep consistent with the [Java client](https://github.com/apache/pulsar/pull/14702).


### Modifications

Add admin api GetListActiveBrokers

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
