### PR TITLE
[Improve] Add admin api ForceDeleteSchema

### DIFF
--- a/pulsaradmin/pkg/admin/schema.go
+++ b/pulsaradmin/pkg/admin/schema.go
@@ -38,6 +38,9 @@ type Schema interface {
 	// DeleteSchema deletes the schema associated with a given <tt>topic</tt>
 	DeleteSchema(topic string) error
 
+	// ForceDeleteSchema force deletes the schema associated with a given <tt>topic</tt>
+	ForceDeleteSchema(topic string) error
+
 	// CreateSchemaByPayload creates a schema for a given <tt>topic</tt>
 	CreateSchemaByPayload(topic string, schemaPayload utils.PostSchemaPayload) error
 }
@@ -112,6 +115,14 @@ func (s *schemas) GetSchemaInfoByVersion(topic string, version int64) (*utils.Sc
 }
 
 func (s *schemas) DeleteSchema(topic string) error {
+	return s.delete(topic, false)
+}
+
+func (s *schemas) ForceDeleteSchema(topic string) error {
+	return s.delete(topic, true)
+}
+
+func (s *schemas) delete(topic string, force bool) error {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return err
@@ -120,9 +131,10 @@ func (s *schemas) DeleteSchema(topic string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "schema")
 
-	fmt.Println(endpoint)
+	queryParams := make(map[string]string)
+	queryParams["force"] = strconv.FormatBool(force)
 
-	return s.pulsar.Client.Delete(endpoint)
+	return s.pulsar.Client.DeleteWithQueryParams(endpoint, queryParams)
 }
 
 func (s *schemas) CreateSchemaByPayload(topic string, schemaPayload utils.PostSchemaPayload) error {

--- a/pulsaradmin/pkg/admin/schema_test.go
+++ b/pulsaradmin/pkg/admin/schema_test.go
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package admin
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemas_DeleteSchema(t *testing.T) {
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	schemaPayload := utils.PostSchemaPayload{
+		SchemaType: "STRING",
+		Schema:     "",
+	}
+	topic := fmt.Sprintf("my-topic-%v", time.Now().Nanosecond())
+	err = admin.Schemas().CreateSchemaByPayload(topic, schemaPayload)
+	assert.NoError(t, err)
+
+	info, err := admin.Schemas().GetSchemaInfo(topic)
+	assert.NoError(t, err)
+	assert.Equal(t, schemaPayload.SchemaType, info.Type)
+
+	err = admin.Schemas().DeleteSchema(topic)
+	assert.NoError(t, err)
+
+	_, err = admin.Schemas().GetSchemaInfo(topic)
+	assert.Errorf(t, err, "Schema not found")
+
+}
+func TestSchemas_ForceDeleteSchema(t *testing.T) {
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	schemaPayload := utils.PostSchemaPayload{
+		SchemaType: "STRING",
+		Schema:     "",
+	}
+	topic := fmt.Sprintf("my-topic-%v", time.Now().Nanosecond())
+	err = admin.Schemas().CreateSchemaByPayload(topic, schemaPayload)
+	assert.NoError(t, err)
+
+	info, err := admin.Schemas().GetSchemaInfo(topic)
+	assert.NoError(t, err)
+	assert.Equal(t, schemaPayload.SchemaType, info.Type)
+
+	err = admin.Schemas().ForceDeleteSchema(topic)
+	assert.NoError(t, err)
+
+	_, err = admin.Schemas().GetSchemaInfo(topic)
+	assert.Errorf(t, err, "Schema not found")
+
+}


### PR DESCRIPTION
### Motivation

To keep consistent with the Java client.


### Modifications

Add admin api ForceDeleteSchema

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
