### PR TITLE
[Improve] Supplement schema admin api.

### DIFF
--- a/pulsaradmin/pkg/utils/schema_util.go
+++ b/pulsaradmin/pkg/utils/schema_util.go
@@ -44,6 +44,11 @@ type GetSchemaResponse struct {
 	Properties map[string]string `json:"properties"`
 }
 
+type IsCompatibility struct {
+	IsCompatibility             bool                        `json:"compatibility"`
+	SchemaCompatibilityStrategy SchemaCompatibilityStrategy `json:"schemaCompatibilityStrategy"`
+}
+
 func ConvertGetSchemaResponseToSchemaInfo(tn *TopicName, response GetSchemaResponse) *SchemaInfo {
 	info := new(SchemaInfo)
 	schema := make([]byte, 0, 10)
@@ -59,6 +64,24 @@ func ConvertGetSchemaResponseToSchemaInfo(tn *TopicName, response GetSchemaRespo
 	info.Name = tn.GetLocalName()
 
 	return info
+}
+
+func ConvertSchemaDataToStringLegacy(schemaInfo SchemaInfo) string {
+	schema := schemaInfo.Schema
+	if schema == nil {
+		return ""
+	}
+	// TODO: KEY_VALUE
+	return string(schema)
+
+}
+
+func ConvertSchemaInfoToPostSchemaPayload(schemaInfo SchemaInfo) PostSchemaPayload {
+	return PostSchemaPayload{
+		SchemaType: schemaInfo.Type,
+		Schema:     ConvertSchemaDataToStringLegacy(schemaInfo),
+		Properties: schemaInfo.Properties,
+	}
 }
 
 func ConvertGetSchemaResponseToSchemaInfoWithVersion(tn *TopicName, response GetSchemaResponse) *SchemaInfoWithVersion {


### PR DESCRIPTION
### Motivation

To keep consistent with the Java client.


### Modifications

- CreateSchemaBySchemaInfo
- GetVersionBySchemaInfo
- GetVersionByPayload
- TestCompatibilityWithSchemaInfo
- TestCompatibilityWithPostSchemaPayload

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
