### PR TITLE
[cleanup] Remove AvroCodec from JSONSchema

### DIFF
--- a/pulsar/schema.go
+++ b/pulsar/schema.go
@@ -142,7 +142,6 @@ func initAvroCodec(codec string) (*goavro.Codec, error) {
 }
 
 type JSONSchema struct {
-	AvroCodec
 	SchemaInfo
 }
 


### PR DESCRIPTION


### Modifications

`AvroCodec` is not used.
Remove `AvroCodec` from `JSONSchema`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
