### PR TITLE
[Issue 1218][Reader] Reader Next returns on closed consumer

### DIFF
--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -171,6 +171,8 @@ func (r *reader) Next(ctx context.Context) (Message, error) {
 				return nil, err
 			}
 			return cm.Message, nil
+		case <-r.c.closeCh:
+			return nil, newError(ConsumerClosed, "consumer closed")
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #1218 

### Motivation

Calling Next on a reader already closed will block forever unless the context is canceled. Similarly, the call will not return if a different go routine closes the reader.

### Modifications

Next now listens for the close channel of the consumer to return an error when it closes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
  - *Added an integration test that closes the reader and calls Next*

### Does this pull request potentially affect one of the following parts:

None