### PR TITLE
[Improve] PIP-313 Add GetLastMessageIDs API

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -281,7 +281,7 @@ type Consumer interface {
 	// GetLastMessageIDs get all the last message id of the topics the consumer subscribed.
 	//
 	// The list of MessageID instances of all the topics that the consumer subscribed
-	GetLastMessageIDs() ([]MessageID, error)
+	GetLastMessageIDs() ([]*TopicMessageID, error)
 
 	// Receive a single message.
 	// This calls blocks until a message is available.

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -278,6 +278,11 @@ type Consumer interface {
 	// where more than one consumer are currently connected.
 	UnsubscribeForce() error
 
+	// GetLastMessageIDs get all the last message id of the topics the consumer subscribed.
+	//
+	// The list of MessageID instances of all the topics that the consumer subscribed
+	GetLastMessageIDs() ([]MessageID, error)
+
 	// Receive a single message.
 	// This calls blocks until a message is available.
 	Receive(context.Context) (Message, error)

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -281,7 +281,7 @@ type Consumer interface {
 	// GetLastMessageIDs get all the last message id of the topics the consumer subscribed.
 	//
 	// The list of MessageID instances of all the topics that the consumer subscribed
-	GetLastMessageIDs() ([]*TopicMessageID, error)
+	GetLastMessageIDs() ([]TopicMessageID, error)
 
 	// Receive a single message.
 	// This calls blocks until a message is available.

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -472,14 +472,15 @@ func (c *consumer) unsubscribe(force bool) error {
 	return nil
 }
 
-func (c *consumer) GetLastMessageIDs() ([]MessageID, error) {
-	ids := make([]MessageID, 0)
+func (c *consumer) GetLastMessageIDs() ([]*TopicMessageID, error) {
+	ids := make([]*TopicMessageID, 0)
 	for _, pc := range c.consumers {
 		id, err := pc.getLastMessageID()
+		tm := &TopicMessageID{Topic: pc.topic, MessageID: id}
 		if err != nil {
 			return nil, err
 		}
-		ids = append(ids, id)
+		ids = append(ids, tm)
 	}
 	return ids, nil
 }

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -472,11 +472,11 @@ func (c *consumer) unsubscribe(force bool) error {
 	return nil
 }
 
-func (c *consumer) GetLastMessageIDs() ([]*TopicMessageID, error) {
-	ids := make([]*TopicMessageID, 0)
+func (c *consumer) GetLastMessageIDs() ([]TopicMessageID, error) {
+	ids := make([]TopicMessageID, 0)
 	for _, pc := range c.consumers {
 		id, err := pc.getLastMessageID()
-		tm := &TopicMessageID{Topic: pc.topic, MessageID: id}
+		tm := &topicMessageID{topic: pc.topic, track: id}
 		if err != nil {
 			return nil, err
 		}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -472,6 +472,18 @@ func (c *consumer) unsubscribe(force bool) error {
 	return nil
 }
 
+func (c *consumer) GetLastMessageIDs() ([]MessageID, error) {
+	ids := make([]MessageID, 0)
+	for _, pc := range c.consumers {
+		id, err := pc.getLastMessageID()
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 func (c *consumer) Receive(ctx context.Context) (message Message, err error) {
 	for {
 		select {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -109,6 +109,18 @@ func (c *multiTopicConsumer) UnsubscribeForce() error {
 	return errs
 }
 
+func (c *multiTopicConsumer) GetLastMessageIDs() ([]MessageID, error) {
+	ids := make([]MessageID, 0)
+	for _, c := range c.consumers {
+		id, err := c.GetLastMessageIDs()
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id...)
+	}
+	return ids, nil
+}
+
 func (c *multiTopicConsumer) Receive(ctx context.Context) (message Message, err error) {
 	for {
 		select {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -109,8 +109,8 @@ func (c *multiTopicConsumer) UnsubscribeForce() error {
 	return errs
 }
 
-func (c *multiTopicConsumer) GetLastMessageIDs() ([]*TopicMessageID, error) {
-	ids := make([]*TopicMessageID, 0)
+func (c *multiTopicConsumer) GetLastMessageIDs() ([]TopicMessageID, error) {
+	ids := make([]TopicMessageID, 0)
 	for _, c := range c.consumers {
 		id, err := c.GetLastMessageIDs()
 		if err != nil {

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -109,8 +109,8 @@ func (c *multiTopicConsumer) UnsubscribeForce() error {
 	return errs
 }
 
-func (c *multiTopicConsumer) GetLastMessageIDs() ([]MessageID, error) {
-	ids := make([]MessageID, 0)
+func (c *multiTopicConsumer) GetLastMessageIDs() ([]*TopicMessageID, error) {
+	ids := make([]*TopicMessageID, 0)
 	for _, c := range c.consumers {
 		id, err := c.GetLastMessageIDs()
 		if err != nil {

--- a/pulsar/consumer_multitopic_test.go
+++ b/pulsar/consumer_multitopic_test.go
@@ -193,12 +193,12 @@ func TestMultiTopicGetLastMessageIDs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, topic1Partition+topic2Partition+topic3Partition, len(topicMessageIDs))
 	for _, id := range topicMessageIDs {
-		if strings.Contains(id.Topic, topic1) {
-			assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/topic1Partition-1)
-		} else if strings.Contains(id.Topic, topic2) {
-			assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/topic2Partition-1)
-		} else if strings.Contains(id.Topic, topic3) {
-			assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/topic3Partition-1)
+		if strings.Contains(id.Topic(), topic1) {
+			assert.Equal(t, int(id.EntryID()), totalMessage/topic1Partition-1)
+		} else if strings.Contains(id.Topic(), topic2) {
+			assert.Equal(t, int(id.EntryID()), totalMessage/topic2Partition-1)
+		} else if strings.Contains(id.Topic(), topic3) {
+			assert.Equal(t, int(id.EntryID()), totalMessage/topic3Partition-1)
 		}
 	}
 

--- a/pulsar/consumer_multitopic_test.go
+++ b/pulsar/consumer_multitopic_test.go
@@ -22,6 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apache/pulsar-client-go/pulsaradmin"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -189,6 +193,10 @@ func TestMultiTopicGetLastMessageIDs(t *testing.T) {
 		}
 	}
 
+	// create admin
+	admin, err := pulsaradmin.NewClient(&config.Config{})
+	assert.Nil(t, err)
+
 	topicMessageIDs, err := consumer.GetLastMessageIDs()
 	assert.Nil(t, err)
 	assert.Equal(t, topic1Partition+topic2Partition+topic3Partition, len(topicMessageIDs))
@@ -200,6 +208,13 @@ func TestMultiTopicGetLastMessageIDs(t *testing.T) {
 		} else if strings.Contains(id.Topic(), topic3) {
 			assert.Equal(t, int(id.EntryID()), totalMessage/topic3Partition-1)
 		}
+
+		topicName, err := utils.GetTopicName(id.Topic())
+		assert.Nil(t, err)
+		messages, err := admin.Subscriptions().GetMessagesByID(*topicName, id.LedgerID(), id.EntryID())
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(messages))
+
 	}
 
 }

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -148,8 +148,8 @@ func (c *regexConsumer) UnsubscribeForce() error {
 	return errs
 }
 
-func (c *regexConsumer) GetLastMessageIDs() ([]*TopicMessageID, error) {
-	ids := make([]*TopicMessageID, 0)
+func (c *regexConsumer) GetLastMessageIDs() ([]TopicMessageID, error) {
+	ids := make([]TopicMessageID, 0)
 	for _, c := range c.consumers {
 		id, err := c.GetLastMessageIDs()
 		if err != nil {

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -148,8 +148,8 @@ func (c *regexConsumer) UnsubscribeForce() error {
 	return errs
 }
 
-func (c *regexConsumer) GetLastMessageIDs() ([]MessageID, error) {
-	ids := make([]MessageID, 0)
+func (c *regexConsumer) GetLastMessageIDs() ([]*TopicMessageID, error) {
+	ids := make([]*TopicMessageID, 0)
 	for _, c := range c.consumers {
 		id, err := c.GetLastMessageIDs()
 		if err != nil {

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -148,6 +148,18 @@ func (c *regexConsumer) UnsubscribeForce() error {
 	return errs
 }
 
+func (c *regexConsumer) GetLastMessageIDs() ([]MessageID, error) {
+	ids := make([]MessageID, 0)
+	for _, c := range c.consumers {
+		id, err := c.GetLastMessageIDs()
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id...)
+	}
+	return ids, nil
+}
+
 func (c *regexConsumer) Receive(ctx context.Context) (message Message, err error) {
 	for {
 		select {

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -491,10 +491,10 @@ func TestRegexTopicGetLastMessageIDs(t *testing.T) {
 		}
 	}
 
-	messageIDs, err := consumer.GetLastMessageIDs()
+	topicMessageIDs, err := consumer.GetLastMessageIDs()
 	assert.Nil(t, err)
-	assert.Equal(t, len(topics), len(messageIDs))
-	for _, id := range messageIDs {
-		assert.Equal(t, int(id.EntryID()), totalMessage/partition-1)
+	assert.Equal(t, len(topics), len(topicMessageIDs))
+	for _, id := range topicMessageIDs {
+		assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/partition-1)
 	}
 }

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -443,3 +443,58 @@ func cloneConsumers(rc *regexConsumer) map[string]Consumer {
 	}
 	return consumers
 }
+
+func TestRegexTopicGetLastMessageIDs(t *testing.T) {
+
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	partition := 1
+	topic1 := fmt.Sprintf("regex-topic-%v", time.Now().Nanosecond())
+	topic2 := fmt.Sprintf("regex-topic-%v", time.Now().Nanosecond())
+	err = createPartitionedTopic(topic1, partition)
+	assert.Nil(t, err)
+	err = createPartitionedTopic(topic2, partition)
+	assert.Nil(t, err)
+	topics := []string{topic1, topic2}
+
+	// create consumer
+	topicsPattern := "persistent://public/default/regex-topic-.*"
+	consumer, err := client.Subscribe(ConsumerOptions{
+		TopicsPattern:    topicsPattern,
+		SubscriptionName: "my-sub",
+		Type:             Shared,
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// produce messages
+	totalMessage := 20
+	for i, topic := range topics {
+		p, err := client.CreateProducer(ProducerOptions{
+			Topic:           topic,
+			DisableBatching: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = genMessages(p, totalMessage, func(idx int) string {
+			return fmt.Sprintf("topic-%d-hello-%d", i+1, idx)
+		})
+		p.Close()
+		if err != nil {
+			assert.Nil(t, err)
+		}
+	}
+
+	messageIDs, err := consumer.GetLastMessageIDs()
+	assert.Nil(t, err)
+	assert.Equal(t, len(topics), len(messageIDs))
+	for _, id := range messageIDs {
+		assert.Equal(t, int(id.EntryID()), totalMessage/partition-1)
+	}
+}

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -495,6 +495,6 @@ func TestRegexTopicGetLastMessageIDs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len(topics), len(topicMessageIDs))
 	for _, id := range topicMessageIDs {
-		assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/partition-1)
+		assert.Equal(t, int(id.EntryID()), totalMessage/partition-1)
 	}
 }

--- a/pulsar/consumer_regex_test.go
+++ b/pulsar/consumer_regex_test.go
@@ -25,6 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/pulsar-client-go/pulsaradmin"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
@@ -491,10 +495,19 @@ func TestRegexTopicGetLastMessageIDs(t *testing.T) {
 		}
 	}
 
+	// create admin
+	admin, err := pulsaradmin.NewClient(&config.Config{})
+	assert.Nil(t, err)
+
 	topicMessageIDs, err := consumer.GetLastMessageIDs()
 	assert.Nil(t, err)
 	assert.Equal(t, len(topics), len(topicMessageIDs))
 	for _, id := range topicMessageIDs {
 		assert.Equal(t, int(id.EntryID()), totalMessage/partition-1)
+		topicName, err := utils.GetTopicName(id.Topic())
+		assert.Nil(t, err)
+		messages, err := admin.Subscriptions().GetMessagesByID(*topicName, id.LedgerID(), id.EntryID())
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(messages))
 	}
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4521,7 +4521,7 @@ func TestConsumerGetLastMessageIDs(t *testing.T) {
 	messageIDs, err := consumer.GetLastMessageIDs()
 	assert.Nil(t, err)
 	assert.Equal(t, partition, len(messageIDs))
-	assert.True(t, strings.HasSuffix(messageIDs[0].Topic, topic))
+	assert.True(t, strings.HasSuffix(messageIDs[0].Topic(), topic))
 
 }
 
@@ -4570,8 +4570,8 @@ func TestPartitionConsumerGetLastMessageIDs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, partition, len(topicMessageIDs))
 	for _, id := range topicMessageIDs {
-		assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/partition-1)
-		assert.True(t, strings.Contains(id.Topic, topic))
+		assert.Equal(t, int(id.EntryID()), totalMessage/partition-1)
+		assert.True(t, strings.Contains(id.Topic(), topic))
 	}
 
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -4520,6 +4521,7 @@ func TestConsumerGetLastMessageIDs(t *testing.T) {
 	messageIDs, err := consumer.GetLastMessageIDs()
 	assert.Nil(t, err)
 	assert.Equal(t, partition, len(messageIDs))
+	assert.True(t, strings.HasSuffix(messageIDs[0].Topic, topic))
 
 }
 
@@ -4564,11 +4566,12 @@ func TestPartitionConsumerGetLastMessageIDs(t *testing.T) {
 		}
 	}
 
-	messageIDs, err := consumer.GetLastMessageIDs()
+	topicMessageIDs, err := consumer.GetLastMessageIDs()
 	assert.Nil(t, err)
-	assert.Equal(t, partition, len(messageIDs))
-	for _, id := range messageIDs {
-		assert.Equal(t, int(id.EntryID()), totalMessage/partition-1)
+	assert.Equal(t, partition, len(topicMessageIDs))
+	for _, id := range topicMessageIDs {
+		assert.Equal(t, int(id.MessageID.EntryID()), totalMessage/partition-1)
+		assert.True(t, strings.Contains(id.Topic, topic))
 	}
 
 }

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -491,3 +491,40 @@ func (id chunkMessageID) Serialize() []byte {
 	data, _ := proto.Marshal(msgID)
 	return data
 }
+
+type topicMessageID struct {
+	track *trackingMessageID
+	topic string
+}
+
+func (t *topicMessageID) Serialize() []byte {
+	return t.track.Serialize()
+}
+
+func (t *topicMessageID) LedgerID() int64 {
+	return t.track.LedgerID()
+}
+
+func (t *topicMessageID) EntryID() int64 {
+	return t.track.EntryID()
+}
+
+func (t *topicMessageID) BatchIdx() int32 {
+	return t.track.BatchIdx()
+}
+
+func (t *topicMessageID) PartitionIdx() int32 {
+	return t.track.PartitionIdx()
+}
+
+func (t *topicMessageID) BatchSize() int32 {
+	return t.track.BatchSize()
+}
+
+func (t *topicMessageID) String() string {
+	return t.track.String()
+}
+
+func (t *topicMessageID) Topic() string {
+	return t.topic
+}

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -111,7 +111,7 @@ func (c *mockConsumer) Name() string {
 	return ""
 }
 
-func (c *mockConsumer) GetLastMessageIDs() ([]*pulsar.TopicMessageID, error) {
-	ids := make([]*pulsar.TopicMessageID, 0)
+func (c *mockConsumer) GetLastMessageIDs() ([]pulsar.TopicMessageID, error) {
+	ids := make([]pulsar.TopicMessageID, 0)
 	return ids, nil
 }

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -111,7 +111,7 @@ func (c *mockConsumer) Name() string {
 	return ""
 }
 
-func (c *mockConsumer) GetLastMessageIDs() ([]pulsar.MessageID, error) {
-	ids := make([]pulsar.MessageID, 0)
+func (c *mockConsumer) GetLastMessageIDs() ([]*pulsar.TopicMessageID, error) {
+	ids := make([]*pulsar.TopicMessageID, 0)
 	return ids, nil
 }

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -110,3 +110,8 @@ func (c *mockConsumer) SeekByTime(time time.Time) error {
 func (c *mockConsumer) Name() string {
 	return ""
 }
+
+func (c *mockConsumer) GetLastMessageIDs() ([]pulsar.MessageID, error) {
+	ids := make([]pulsar.MessageID, 0)
+	return ids, nil
+}

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -167,9 +167,9 @@ type MessageID interface {
 }
 
 // TopicMessageID defined the correspondence between topic and MessageID.
-type TopicMessageID struct {
-	Topic     string
-	MessageID MessageID
+type TopicMessageID interface {
+	MessageID
+	Topic() string
 }
 
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -166,6 +166,12 @@ type MessageID interface {
 	String() string
 }
 
+// TopicMessageID defined the correspondence between topic and MessageID.
+type TopicMessageID struct {
+	Topic     string
+	MessageID MessageID
+}
+
 // DeserializeMessageID reconstruct a MessageID object from its serialized representation
 func DeserializeMessageID(data []byte) (MessageID, error) {
 	return deserializeMessageID(data)


### PR DESCRIPTION
### Motivation
To keep consistent with the Java client.

Releted PR: https://github.com/apache/pulsar/pull/20040


### Modifications

- Add `GetLastMessageIDs`api for consumer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (yes)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
