### PR TITLE
[Improve] Add admin topic api CreateWithProperties

### DIFF
--- a/pulsaradmin/pkg/admin/topic_test.go
+++ b/pulsaradmin/pkg/admin/topic_test.go
@@ -65,6 +65,39 @@ func TestCreateTopic(t *testing.T) {
 	t.Error("Couldn't find topic: " + topic)
 }
 
+func TestTopics_CreateWithProperties(t *testing.T) {
+	topic := newTopicName()
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	// Create non-partition topic
+	topicName, err := utils.GetTopicName(topic)
+	assert.NoError(t, err)
+	err = admin.Topics().CreateWithProperties(*topicName, 0, map[string]string{
+		"key1": "value1",
+	})
+	assert.NoError(t, err)
+
+	properties, err := admin.Topics().GetProperties(*topicName)
+	assert.NoError(t, err)
+	assert.Equal(t, properties["key1"], "value1")
+
+	// Create partition topic
+	topic = newTopicName()
+	topicName, err = utils.GetTopicName(topic)
+	assert.NoError(t, err)
+	err = admin.Topics().CreateWithProperties(*topicName, 4, map[string]string{
+		"key2": "value2",
+	})
+	assert.NoError(t, err)
+
+	properties, err = admin.Topics().GetProperties(*topicName)
+	assert.NoError(t, err)
+	assert.Equal(t, properties["key2"], "value2")
+}
+
 func TestPartitionState(t *testing.T) {
 	randomName := newTopicName()
 	topic := "persistent://public/default/" + randomName

--- a/pulsaradmin/pkg/rest/client.go
+++ b/pulsaradmin/pkg/rest/client.go
@@ -26,6 +26,17 @@ import (
 	"path"
 )
 
+type MediaType string
+
+const (
+	ApplicationJSON          MediaType = "application/json"
+	PartitionedTopicMetaJSON MediaType = "application/vnd.partitioned-topic-metadata+json"
+)
+
+func (m MediaType) String() string {
+	return string(m)
+}
+
 // Client is a base client that is used to make http request to the ServiceURL
 type Client struct {
 	ServiceURL  string
@@ -65,10 +76,10 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 	if r.contentType != "" {
 		req.Header.Set("Content-Type", r.contentType)
 	} else if req.Body != nil {
-		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Content-Type", ApplicationJSON.String())
 	}
 
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", ApplicationJSON.String())
 	req.Header.Set("User-Agent", c.useragent())
 	hc := c.HTTPClient
 	if hc == nil {
@@ -160,9 +171,16 @@ func (c *Client) Put(endpoint string, in interface{}) error {
 }
 
 func (c *Client) PutWithQueryParams(endpoint string, in, obj interface{}, params map[string]string) error {
+	return c.PutWithCustomMediaType(endpoint, in, obj, params, "")
+}
+func (c *Client) PutWithCustomMediaType(endpoint string, in, obj interface{}, params map[string]string,
+	mediaType MediaType) error {
 	req, err := c.newRequest(http.MethodPut, endpoint)
 	if err != nil {
 		return err
+	}
+	if mediaType != "" {
+		req.contentType = mediaType.String()
 	}
 	req.obj = in
 


### PR DESCRIPTION
### Motivation

To keep consistent with the [Java client](https://github.com/apache/pulsar/pull/12818).


### Modifications

- Add admin topic api CreateWithProperties
-  Add admin topic api GetProperties

### Verifying this change

- [x] Make sure that the change passes the CI checks.



This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (yes)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (GoDocs)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
