### PR TITLE
fix dynamic config

### DIFF
--- a/pulsaradmin/pkg/admin/admin.go
+++ b/pulsaradmin/pkg/admin/admin.go
@@ -112,3 +112,8 @@ func (c *pulsarClient) endpoint(componentPath string, parts ...string) string {
 		path.Join(escapedParts...),
 	)
 }
+
+// this function won't do any escaping
+func (c *pulsarClient) endpointWithFullPath(componentPath string, fullPath string) string {
+	return path.Join(utils.MakeHTTPPath(c.APIVersion.String(), componentPath), fullPath)
+}

--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -19,7 +19,6 @@ package admin
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
@@ -120,8 +119,8 @@ func (b *broker) GetOwnedNamespaces(cluster, brokerURL string) (map[string]utils
 }
 
 func (b *broker) UpdateDynamicConfiguration(configName, configValue string) error {
-	value := url.QueryEscape(configValue)
-	endpoint := b.pulsar.endpoint(b.basePath, "/configuration/", configName, value)
+	value := fmt.Sprintf("/configuration/%s/%s", configName, configValue)
+	endpoint := b.pulsar.endpointWithFullPath(b.basePath, value)
 	return b.pulsar.Client.Post(endpoint, nil)
 }
 

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -73,3 +73,21 @@ func TestGetAllActiveBrokers(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, brokers)
 }
+
+func TestUpdateDynamicConfiguration(t *testing.T) {
+	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
+	assert.NoError(t, err)
+	cfg := &config.Config{
+		Token: string(readFile),
+	}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	err = admin.Brokers().UpdateDynamicConfiguration("allowAutoSubscriptionCreation", "true")
+	assert.NoError(t, err)
+
+	configurations, err := admin.Brokers().GetDynamicConfigurationNames()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, configurations)
+}


### PR DESCRIPTION
If users use a custom dynamic configuration, it's better not to do any escaping for the config value. Let the user fill it out manually.

The original implementation will escape the value twice, the first time is here:

https://github.com/apache/pulsar-client-go/blob/a1ce5e6d48fd00d07d45958a5c7482751f0cbb68/pulsaradmin/pkg/admin/brokers.go#L123-L123

the second time is here:

https://github.com/apache/pulsar-client-go/blob/a1ce5e6d48fd00d07d45958a5c7482751f0cbb68/pulsaradmin/pkg/admin/admin.go#L107-L109

