### PR TITLE
Fix custom value with `/`

### DIFF
--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -124,9 +124,10 @@ func TestUpdateDynamicConfigurationWithCustomURL(t *testing.T) {
 	encoded := url.QueryEscape(value)
 
 	resp, err := client.MakeRequestWithURL(http.MethodPost, &url.URL{
-		Scheme:  u.Scheme,
-		User:    u.User,
-		Host:    u.Host,
+		Scheme: u.Scheme,
+		User:   u.User,
+		Host:   u.Host,
+		// use this config to test, will restore it later
 		Path:    "/admin/v2/brokers/configuration/allowAutoSubscriptionCreation/" + value,
 		RawPath: "/admin/v2/brokers/configuration/allowAutoSubscriptionCreation/" + encoded,
 	})
@@ -147,4 +148,8 @@ func TestUpdateDynamicConfigurationWithCustomURL(t *testing.T) {
 	err = json.Unmarshal([]byte(configurations["allowAutoSubscriptionCreation"]), &m)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://example.com/", m["key/123"])
+
+	// restore the config
+	err = admin.Brokers().UpdateDynamicConfiguration("allowAutoSubscriptionCreation", "true")
+	assert.NoError(t, err)
 }

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -18,10 +18,15 @@
 package admin
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/url"
 	"os"
 	"testing"
 
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/auth"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -90,4 +95,56 @@ func TestUpdateDynamicConfiguration(t *testing.T) {
 	configurations, err := admin.Brokers().GetDynamicConfigurationNames()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, configurations)
+}
+
+func TestUpdateDynamicConfigurationWithCustomURL(t *testing.T) {
+	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
+	assert.NoError(t, err)
+	cfg := &config.Config{
+		WebServiceURL: DefaultWebServiceURL,
+		Token:         string(readFile),
+	}
+
+	authProvider, err := auth.GetAuthProvider(cfg)
+	assert.NoError(t, err)
+
+	client := rest.Client{
+		ServiceURL:  cfg.WebServiceURL,
+		VersionInfo: ReleaseVersion,
+		HTTPClient: &http.Client{
+			Timeout:   DefaultHTTPTimeOutDuration,
+			Transport: authProvider,
+		},
+	}
+	u, err := url.Parse(cfg.WebServiceURL)
+	assert.NoError(t, err)
+
+	// example config value with '/'
+	value := `{"key/123":"https://example.com/"}`
+	encoded := url.QueryEscape(value)
+
+	resp, err := client.MakeRequestWithURL(http.MethodPost, &url.URL{
+		Scheme:  u.Scheme,
+		User:    u.User,
+		Host:    u.Host,
+		Path:    "/admin/v2/brokers/configuration/allowAutoSubscriptionCreation/" + value,
+		RawPath: "/admin/v2/brokers/configuration/allowAutoSubscriptionCreation/" + encoded,
+	})
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// get the config, check if it's updated
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	configurations, err := admin.Brokers().GetAllDynamicConfigurations()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, configurations)
+
+	var m map[string]interface{}
+	err = json.Unmarshal([]byte(configurations["allowAutoSubscriptionCreation"]), &m)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/", m["key/123"])
 }

--- a/pulsaradmin/pkg/rest/client.go
+++ b/pulsaradmin/pkg/rest/client.go
@@ -67,13 +67,13 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 	return req, nil
 }
 
-func (c *Client) newRequestWithURL(method string, urlOpt *url.URL) (*request, error) {
+func (c *Client) newRequestWithURL(method string, urlOpt *url.URL) *request {
 	req := &request{
 		method: method,
 		url:    urlOpt,
 		params: make(url.Values),
 	}
-	return req, nil
+	return req
 }
 
 func (c *Client) doRequest(r *request) (*http.Response, error) {
@@ -114,10 +114,7 @@ func (c *Client) MakeRequest(method, endpoint string) (*http.Response, error) {
 }
 
 func (c *Client) MakeRequestWithURL(method string, urlOpt *url.URL) (*http.Response, error) {
-	req, err := c.newRequestWithURL(method, urlOpt)
-	if err != nil {
-		return nil, err
-	}
+	req := c.newRequestWithURL(method, urlOpt)
 
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {

--- a/pulsaradmin/pkg/rest/client.go
+++ b/pulsaradmin/pkg/rest/client.go
@@ -67,6 +67,15 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 	return req, nil
 }
 
+func (c *Client) newRequestWithURL(method string, urlOpt *url.URL) (*request, error) {
+	req := &request{
+		method: method,
+		url:    urlOpt,
+		params: make(url.Values),
+	}
+	return req, nil
+}
+
 func (c *Client) doRequest(r *request) (*http.Response, error) {
 	req, err := r.toHTTP()
 	if err != nil {
@@ -92,6 +101,20 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 // MakeRequest can make a simple request and handle the response by yourself
 func (c *Client) MakeRequest(method, endpoint string) (*http.Response, error) {
 	req, err := c.newRequest(method, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := checkSuccessful(c.doRequest(req))
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *Client) MakeRequestWithURL(method string, urlOpt *url.URL) (*http.Response, error) {
+	req, err := c.newRequestWithURL(method, urlOpt)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsaradmin/pkg/rest/client.go
+++ b/pulsaradmin/pkg/rest/client.go
@@ -67,15 +67,6 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 	return req, nil
 }
 
-func (c *Client) newRequestWithURL(method string, urlOpt *url.URL) *request {
-	req := &request{
-		method: method,
-		url:    urlOpt,
-		params: make(url.Values),
-	}
-	return req
-}
-
 func (c *Client) doRequest(r *request) (*http.Response, error) {
 	req, err := r.toHTTP()
 	if err != nil {
@@ -114,8 +105,11 @@ func (c *Client) MakeRequest(method, endpoint string) (*http.Response, error) {
 }
 
 func (c *Client) MakeRequestWithURL(method string, urlOpt *url.URL) (*http.Response, error) {
-	req := c.newRequestWithURL(method, urlOpt)
-
+	req := &request{
+		method: method,
+		url:    urlOpt,
+		params: make(url.Values),
+	}
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Even https://github.com/apache/pulsar-client-go/pull/1228 fix the double escape error, there still some issue about custom dynamic config.

When the custom config value has `/`, the golang net/http package will unescape it by default. see https://github.com/golang/go/issues/7356

For example, if the config value is a json like `{"key": "https://example.com/"}`, the expected request should be:

```
/admin/v2/brokers/configuration/someConfig/%7B%22key%22%3A%20%22https%3A%2F%2Fexample.com%2F%22%7D
```

But the actual request will be this:

```
/admin/v2/brokers/configuration/someConfig/{"key": "https://example.com/"}
```

And it will causes 404 not found because `/` in the URL. 

If you escape the value twice, it will be:

```
/admin/v2/brokers/configuration/someConfig/%257B%2522key%2522%253A%2520%2522https%253A%252F%252Fexample.com%252F%2522%257D
```

The solution is `url.RawPath` field in this https://github.com/golang/go/commit/874a605af0764a8f340c3de65406963f514e21bc , we need to modify this part to add the RawPath field:
https://github.com/apache/pulsar-client-go/blob/aa090bedcddd5b67ef5f91d4e15ec2caf453d540/pulsaradmin/pkg/rest/client.go#L47-L68


But the `newRequest` is used by many other methods, I don't want to touch it. So an easy solution is to provide a `MakeRequestWithURL` method, users can use it to customize.
