### PR TITLE
[fix] Close producer when receive UnknownError exception

### DIFF
--- a/pulsar/internal/connection_test.go
+++ b/pulsar/internal/connection_test.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"testing"
+
+	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
+	"github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockListener struct{}
+
+func (p *mockListener) ReceivedSendReceipt(*pb.CommandSendReceipt) {}
+func (p *mockListener) ConnectionClosed(*pb.CommandCloseProducer)  {}
+func (p *mockListener) SetRedirectedClusterURI(string)             {}
+
+func TestHandleSendError(t *testing.T) {
+	mockConnection := &connection{
+		log:       log.NewLoggerWithLogrus(logrus.StandardLogger()),
+		listeners: make(map[uint64]ConnectionListener),
+	}
+	mockConnection.listeners[1] = &mockListener{}
+	assert.Equal(
+		t,
+		len(mockConnection.listeners),
+		1,
+	)
+
+	producerIndex := uint64(1)
+	unknownError := pb.ServerError_UnknownError
+	errorMessage := "unknown error"
+	sendUnknownError := pb.CommandSendError{
+		ProducerId: &producerIndex,
+		Error:      &unknownError,
+		Message:    &errorMessage,
+	}
+	mockConnection.handleSendError(&sendUnknownError)
+	assert.Equal(
+		t,
+		len(mockConnection.listeners),
+		0,
+	)
+}


### PR DESCRIPTION
### Motivation
When `pulsar/internal/connection.go` send messages encounters errors, it will check if this error is a recoverable error. If so, the connection will try to create a new producer and send messages again, otherwise it will close and return.

Currently connection only have two [unrecoverable send errors](https://github.com/apache/pulsar-client-go/blob/552b541fa7e3de339739a262e63e3d7ee6d554ee/pulsar/internal/connection.go#L864) in send messages response: `TopicTerminatedError` and `NotAllowedError`. And I think we could regard one more `UnknownError` as an unrecoverable error too, because broker will use this `UnknownError` as an [unhandled corner cases](https://github.com/apache/pulsar/blob/4399b2743cdc01070a871b32f7bc02ac736e9c80/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java#L290), which we always need to pay attention to.

### Modifications
Add `pb.ServerError_UnknownError` in `pulsar/internal/connection.go/handleSendError` function, close producers when exception occured.

### Verifying this change
- [x] Make sure that the change passes the CI checks.
This change added tests and can be verified.

### Does this pull request potentially affect one of the following parts:
*If `yes` was chosen, please highlight the changes*
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
