### PR TITLE
fix: fix producer connection

### DIFF
--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -177,7 +177,7 @@ func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.Ba
 		case res := <-ch:
 			// Ignoring producer not ready response.
 			// Continue to wait for the producer to create successfully
-			if res.error == nil && *res.RPCResult.Response.Type == pb.BaseCommand_PRODUCER_SUCCESS {
+			if res.error == nil && res.Response != nil && *res.RPCResult.Response.Type == pb.BaseCommand_PRODUCER_SUCCESS {
 				if !res.RPCResult.Response.ProducerSuccess.GetProducerReady() {
 					timeoutCh = nil
 					break

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -150,11 +150,17 @@ func (c *rpcClient) RequestToHost(serviceNameResolver *ServiceNameResolver, requ
 
 func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
 	cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
-	c.metrics.RPCRequestCount.Inc()
 	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr)
 	if err != nil {
 		return nil, err
 	}
+
+	return c.RequestOnCnx(cnx, requestID, cmdType, message)
+}
+
+func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
+	message proto.Message) (*RPCResult, error) {
+	c.metrics.RPCRequestCount.Inc()
 
 	ch := make(chan result, 1)
 
@@ -181,28 +187,6 @@ func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, request
 		case <-timeoutCh:
 			return nil, ErrRequestTimeOut
 		}
-	}
-}
-
-func (c *rpcClient) RequestOnCnx(cnx Connection, requestID uint64, cmdType pb.BaseCommand_Type,
-	message proto.Message) (*RPCResult, error) {
-	c.metrics.RPCRequestCount.Inc()
-
-	ch := make(chan result, 1)
-
-	cnx.SendRequest(requestID, baseCommand(cmdType, message), func(response *pb.BaseCommand, err error) {
-		ch <- result{&RPCResult{
-			Cnx:      cnx,
-			Response: response,
-		}, err}
-		close(ch)
-	})
-
-	select {
-	case res := <-ch:
-		return res.RPCResult, res.error
-	case <-time.After(c.requestTimeout):
-		return nil, ErrRequestTimeOut
 	}
 }
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -301,7 +301,7 @@ func (p *partitionProducer) grabCnx(assignedBrokerURL string) error {
 		p.log.WithError(err).Error("Failed to create producer at send PRODUCER request")
 		if errors.Is(err, internal.ErrRequestTimeOut) {
 			id := p.client.rpcClient.NewRequestID()
-			_, _ = p.client.rpcClient.RequestOnCnx(res.Cnx, id, pb.BaseCommand_CLOSE_PRODUCER,
+			_, _ = p.client.rpcClient.RequestOnCnx(cnx, id, pb.BaseCommand_CLOSE_PRODUCER,
 				&pb.CommandCloseProducer{
 					ProducerId: &p.producerID,
 					RequestId:  &id,

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -292,12 +292,12 @@ func (p *partitionProducer) grabCnx(assignedBrokerURL string) error {
 		}
 	}
 
-	res, err := p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_PRODUCER, cmdProducer)
+	res, err := p.client.rpcClient.RequestOnCnx(cnx, id, pb.BaseCommand_PRODUCER, cmdProducer)
 	if err != nil {
 		p.log.WithError(err).Error("Failed to create producer at send PRODUCER request")
 		if errors.Is(err, internal.ErrRequestTimeOut) {
 			id := p.client.rpcClient.NewRequestID()
-			_, _ = p.client.rpcClient.Request(lr.LogicalAddr, lr.PhysicalAddr, id, pb.BaseCommand_CLOSE_PRODUCER,
+			_, _ = p.client.rpcClient.RequestOnCnx(res.Cnx, id, pb.BaseCommand_CLOSE_PRODUCER,
 				&pb.CommandCloseProducer{
 					ProducerId: &p.producerID,
 					RequestId:  &id,

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -294,6 +294,7 @@ func (p *partitionProducer) grabCnx(assignedBrokerURL string) error {
 
 	res, err := p.client.rpcClient.RequestOnCnx(cnx, id, pb.BaseCommand_PRODUCER, cmdProducer)
 	if err != nil {
+		p._getConn().UnregisterListener(p.producerID)
 		p.log.WithError(err).Error("Failed to create producer at send PRODUCER request")
 		if errors.Is(err, internal.ErrRequestTimeOut) {
 			id := p.client.rpcClient.NewRequestID()

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -284,12 +284,15 @@ func (p *partitionProducer) grabCnx(assignedBrokerURL string) error {
 
 	cnx, err := p.client.cnxPool.GetConnection(lr.LogicalAddr, lr.PhysicalAddr)
 	// registering the producer first in case broker sends commands in the middle
-	if err == nil {
-		p._setConn(cnx)
-		err = p._getConn().RegisterListener(p.producerID, p)
-		if err != nil {
-			p.log.WithError(err).Errorf("Failed to register listener: {%d}", p.producerID)
-		}
+	if err != nil {
+		p.log.Error("Failed to get connection")
+		return err
+	}
+
+	p._setConn(cnx)
+	err = p._getConn().RegisterListener(p.producerID, p)
+	if err != nil {
+		p.log.WithError(err).Errorf("Failed to register listener: {%d}", p.producerID)
 	}
 
 	res, err := p.client.rpcClient.RequestOnCnx(cnx, id, pb.BaseCommand_PRODUCER, cmdProducer)


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar-client-go/pull/1210 breaks the producer feature.

When the `MaxConnectionsPerBroker` is greater than 1, the client will create multiple connections, the producer cannot use the correct connect to send the message to the broker:

```
make build
./bin/pulsar-perf produce test01 -r 100 --profile  --max-connections 30 --profile --service-url pulsar://localhost:6650 -q 100 --batching-time 10

INFO[16:40:23.991] Connecting to broker                          remote_addr="pulsar://localhost:6650"
INFO[16:40:23.994] TCP connection established                    local_addr="[::1]:59230" remote_addr="pulsar://localhost:6650"
INFO[16:40:23.996] Connection is ready                           local_addr="[::1]:59230" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.002] Connecting to broker                          remote_addr="pulsar://localhost:6650"
INFO[16:40:24.003] TCP connection established                    local_addr="[::1]:59231" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.007] Connection is ready                           local_addr="[::1]:59231" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.009] Connecting to broker                          remote_addr="pulsar://localhost:6650"
INFO[16:40:24.010] TCP connection established                    local_addr="[::1]:59232" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.012] Connection is ready                           local_addr="[::1]:59232" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.012] Connecting to broker                          remote_addr="pulsar://localhost:6650"
INFO[16:40:24.012] TCP connection established                    local_addr="[::1]:59233" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.015] Connection is ready                           local_addr="[::1]:59233" remote_addr="pulsar://localhost:6650"
INFO[16:40:24.150] Connected producer                            cnx="[::1]:59233 -> [::1]:6650" epoch=0 topic="persistent://public/default/test01"
INFO[16:40:24.150] Created producer                              cnx="[::1]:59232 -> [::1]:6650" producerID=1 producer_name=standalone-37-3 topic="persistent://public/default/test01"
WARN[16:40:24.153] Connection was closed                         cnx="[::1]:59232 -> [::1]:6650" producerID=1 producer_name=standalone-37-3 topic="persistent://public/default/test01"
INFO[16:40:24.153] runEventsLoop will reconnect in producer      producerID=1 producer_name=standalone-37-3 topic="persistent://public/default/test01"
````

You can notice that there are two connections,  the producer was created by the `[::1]:59233` connection, not `[::1]:59232`.
```
INFO[16:40:24.150] Connected producer                            cnx="[::1]:59233 -> [::1]:6650" epoch=0 topic="persistent://public/default/test01"
INFO[16:40:24.150] Created producer                              cnx="[::1]:59232 -> [::1]:6650" producerID=1 producer_name=standalone-37-3 topic="persistent://public/default/test01"
```

When a message was sent to the broke by `[::1]:59232`, this connection will be closed, because the connection didn't create the producer. 

### Modifications

- Fix get connection error, if err is not nil, we must to return err, not ignore.
- Use `p.client.rpcClient.RequestOnCnx` instead of ` p.client.rpcClient.Request` to create the producer, when create fails, we need to remove the connection listener.
- The `rpcClient.Request` method should call the `rpcClient.RequestOnCnx`, and we need to handle the `roducerAccessModeWaitForExclusive` case.

### Verifying this change

Added test.