### PR TITLE
[Fix] PulsarCtl 1266  Oauth2 Client credentials flow use scopes from the keyfile as well

### DIFF
--- a/oauth2/client_credentials_flow.go
+++ b/oauth2/client_credentials_flow.go
@@ -18,11 +18,11 @@
 package oauth2
 
 import (
-	"github.com/apache/pulsar-client-go/oauth2/clock"
-
 	"net/http"
-	
+
 	"strings"
+
+	"github.com/apache/pulsar-client-go/oauth2/clock"
 
 	"github.com/pkg/errors"
 )

--- a/oauth2/client_credentials_flow.go
+++ b/oauth2/client_credentials_flow.go
@@ -84,16 +84,12 @@ func NewDefaultClientCredentialsFlow(options ClientCredentialsFlowOptions) (*Cli
 	// Merge the scopes of the options AdditionalScopes with the scopes read from the keyFile config
 	var scopesToAdd []string
 	if len(options.AdditionalScopes) > 0 {
-		for _, scope := range options.AdditionalScopes {
-			scopesToAdd = append(scopesToAdd, scope)
-		}
+		scopesToAdd = append(scopesToAdd, options.AdditionalScopes...)
 	}
 
 	if keyFile.Scope != "" {
 		scopesSplit := strings.Split(keyFile.Scope, " ")
-		for _, scope := range scopesSplit {
-			scopesToAdd = append(scopesToAdd, scope)
-		}
+		scopesToAdd = append(scopesToAdd, scopesSplit...)
 	}
 	options.AdditionalScopes = scopesToAdd
 

--- a/oauth2/client_credentials_flow.go
+++ b/oauth2/client_credentials_flow.go
@@ -19,7 +19,9 @@ package oauth2
 
 import (
 	"github.com/apache/pulsar-client-go/oauth2/clock"
+
 	"net/http"
+	
 	"strings"
 
 	"github.com/pkg/errors"

--- a/oauth2/client_credentials_flow_test.go
+++ b/oauth2/client_credentials_flow_test.go
@@ -19,7 +19,6 @@ package oauth2
 
 import (
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/apache/pulsar-client-go/oauth2/clock"
@@ -66,9 +65,11 @@ var _ = Describe("ClientCredentialsFlow", func() {
 		})
 
 		It("invokes TokenExchanger with credentials", func() {
+			additionalScope := "additional_scope"
 			provider := newClientCredentialsFlow(
 				ClientCredentialsFlowOptions{
-					KeyFile: "test_keyfile",
+					KeyFile:          "test_keyfile",
+					AdditionalScopes: []string{additionalScope},
 				},
 				&clientCredentials,
 				oidcEndpoints,
@@ -83,7 +84,7 @@ var _ = Describe("ClientCredentialsFlow", func() {
 				ClientID:      clientCredentials.ClientID,
 				ClientSecret:  clientCredentials.ClientSecret,
 				Audience:      "test_audience",
-				Scopes:        strings.Split(clientCredentials.Scope, " "),
+				Scopes:        []string{additionalScope, clientCredentials.Scope},
 			}))
 		})
 

--- a/oauth2/client_credentials_flow_test.go
+++ b/oauth2/client_credentials_flow_test.go
@@ -19,6 +19,7 @@ package oauth2
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/apache/pulsar-client-go/oauth2/clock"
@@ -47,6 +48,7 @@ var clientCredentials = KeyFile{
 	ClientSecret: "test_clientSecret",
 	ClientEmail:  "test_clientEmail",
 	IssuerURL:    "http://issuer",
+	Scope:        "test_scope",
 }
 
 var _ = Describe("ClientCredentialsFlow", func() {
@@ -81,6 +83,7 @@ var _ = Describe("ClientCredentialsFlow", func() {
 				ClientID:      clientCredentials.ClientID,
 				ClientSecret:  clientCredentials.ClientSecret,
 				Audience:      "test_audience",
+				Scopes:        strings.Split(clientCredentials.Scope, " "),
 			}))
 		})
 

--- a/oauth2/client_credentials_provider.go
+++ b/oauth2/client_credentials_provider.go
@@ -38,6 +38,7 @@ type KeyFile struct {
 	ClientSecret string `json:"client_secret"`
 	ClientEmail  string `json:"client_email"`
 	IssuerURL    string `json:"issuer_url"`
+	Scope        string `json:"scope"`
 }
 
 func NewClientCredentialsProviderFromKeyFile(keyFile string) *KeyFileProvider {

--- a/oauth2/client_credentials_provider_test.go
+++ b/oauth2/client_credentials_provider_test.go
@@ -34,12 +34,14 @@ func TestNewClientCredentialsProviderFromKeyFile(t *testing.T) {
 	ClientSecret := "CLIENT_SECRET"
 	ClientEmail := "CLIENT_EMAIL"
 	IssuerURL := "ISSUER_URL"
+	Scope := "SCOPE"
 	keyFile := &KeyFile{
 		Type:         oauthType,
 		ClientID:     clientID,
 		ClientSecret: ClientSecret,
 		ClientEmail:  ClientEmail,
 		IssuerURL:    IssuerURL,
+		Scope:        Scope,
 	}
 
 	b, err := json.Marshal(keyFile)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes https://github.com/streamnative/pulsarctl/issues/1266 which uses the code being touched here.

### Motivation

As the issue shows when using Pulsarctl which works with a context as configuration style, Oauth2 is used under the hood.

However the library does not expose any way to inject the context configuration `scope` value, and then relies on reading that from the `keyFile` for `client_credentials flow`.

However that is not being utilized in the current code as the scope value is not read from from the file.

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*
To allow the usage of oauth2 with a keyfile in Pulsarctl 3+ which it doesn't right now

### Modifications
*Describe the modifications you've done.*

Alters so reading the keyFile for client credentials also returns the `scope` value.

The value is then split on spaces, and added to a temporary slice. 
After that the value of any additionalScopes that was already in the options is then added to the temp slice as well.
In the end the additionalScopes property on the options is set to the temp slice containing values from previous additionalScopes and the ones from the keyFile.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
