### PR TITLE
improve: install golang by image in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,18 @@
 # Explicit version of Pulsar and Golang images should be
 # set via the Makefile or CLI
 ARG PULSAR_IMAGE=apachepulsar/pulsar:latest
+
+ARG GO_VERSION=1.20
+FROM golang:$GO_VERSION as golang
+
 FROM $PULSAR_IMAGE
 USER root
-ARG GO_VERSION=1.18
-ARG ARCH=amd64
 
-RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -o golang.tar.gz && \
-    mkdir -p /pulsar/go && tar -C /pulsar -xzf golang.tar.gz
+COPY --from=golang /usr/local/go /pulsar/go
 
 ENV PATH /pulsar/go/bin:$PATH
 
-RUN apt-get update && apt-get install -y git && apt-get install -y gcc
-
+RUN apt-get update && apt-get install -y git gcc
 
 ### Add pulsar config
 COPY integration-tests/certs /pulsar/certs


### PR DESCRIPTION
### Motivation

The Dockerfile looks unsupport the ARM arch, which always downloads the golang of the AMD arch.

### Modifications

- Use golang image to install the golang in the Dockerfile
- Switch golang from 1.18 to 1.20 in the Dockerfile, #1230 requires golang@1.20