### PR TITLE
fix: failTimeoutMessages cannot delete outdated messages

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -813,7 +813,7 @@ func (p *partitionProducer) internalSingleSend(
 		return
 	}
 
-	p.writeData(buffer, sid, &[]interface{}{sr})
+	p.writeData(buffer, sid, []interface{}{sr})
 }
 
 type pendingItem struct {
@@ -862,17 +862,17 @@ func (p *partitionProducer) internalFlushCurrentBatch() {
 		return
 	}
 
-	p.writeData(batchData, sequenceID, &callbacks)
+	p.writeData(batchData, sequenceID, callbacks)
 }
 
-func (p *partitionProducer) writeData(buffer internal.Buffer, sequenceID uint64, callbacks *[]interface{}) {
+func (p *partitionProducer) writeData(buffer internal.Buffer, sequenceID uint64, callbacks []interface{}) {
 	now := time.Now()
 	p.pendingQueue.Put(&pendingItem{
 		createdAt:    now,
 		sentAt:       now,
 		buffer:       buffer,
 		sequenceID:   sequenceID,
-		sendRequests: *callbacks,
+		sendRequests: callbacks,
 	})
 	p._getConn().WriteData(buffer)
 }
@@ -995,7 +995,7 @@ func (p *partitionProducer) internalFlushCurrentBatches() {
 		if b.BatchData == nil {
 			continue
 		}
-		p.writeData(b.BatchData, b.SequenceID, &b.Callbacks)
+		p.writeData(b.BatchData, b.SequenceID, b.Callbacks)
 	}
 
 }


### PR DESCRIPTION
Fixes #1236 

### Motivation

When the producer reconnects to the broker, resending the pending messages, and changing the `sentAt`, this will break the `failTimeoutMessages` feature, which compares `sentAt` with the current time to determine if the message has the timeout.

### Modifications

1. Add `createdAt` to `pendingItem` struct.
2. Init the `sentAt` and `createdAt` when sending the message, and update `sentAt` when resending the message to the broker.

### Verifying this change

Use existing tests.