### PR TITLE
ci: validate multiple version builds and use golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '1.20'
       - name: Check license header
         run: docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 check
       - name: Run golangci-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,25 +20,35 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.20', '1.21', '1.22' ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
       - run: make build
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
       - name: Check license header
         run: docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 check
       - name: Run golangci-lint
-        run: make lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.51.2
 
   integration-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.20', '1.21.0', '1.22.0']
+        go-version: [ '1.20', '1.21', '1.22' ]
     steps:
       - uses: actions/checkout@v3
       - name: clean docker cache


### PR DESCRIPTION
### Motivation

Improve CI.

### Modifications

- build and test uses the `go-version: [ '1.20', '1.21', '1.22' ]` matrix.
- lint uses the go 1.20(golangci-lint@1.51.2 doesn't work on go 1.21 or later version) version and `golangci/golangci-lint-action@v6`, the lint result will be reported on the pr.