### PR TITLE
fix pulsar admin revoke subscription permission endpoint

### DIFF
--- a/pulsaradmin/pkg/admin/namespace.go
+++ b/pulsaradmin/pkg/admin/namespace.go
@@ -750,7 +750,7 @@ func (n *namespaces) GrantSubPermission(namespace utils.NameSpaceName, sName str
 
 func (n *namespaces) RevokeSubPermission(namespace utils.NameSpaceName, sName, role string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions",
-		"subscription", sName, role)
+		sName, role)
 	return n.pulsar.Client.Delete(endpoint)
 }
 


### PR DESCRIPTION
### Motivation

The endpoint of RevokeSubPermission does't contain `subscription`

wrong endpoint: /{property}/{namespace}/permissions/subscription/{subscription}/{role}

correct endpoint: /{property}/{namespace}/permissions/{subscription}/{role}

https://github.com/apache/pulsar/blob/88ebe785dbdab239104981453a9bd0e4a7e896d3/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java#L366

### Modifications

delete subscription