### PR TITLE
Add support for subscription expiration time namespace settings

### DIFF
--- a/pulsaradmin/pkg/admin/namespace.go
+++ b/pulsaradmin/pkg/admin/namespace.go
@@ -286,7 +286,8 @@ type Namespaces interface {
 	// SetSubscriptionExpirationTime sets the subscription expiration time on a namespace
 	SetSubscriptionExpirationTime(namespace utils.NameSpaceName, expirationTimeInMinutes int) error
 
-	// RemoveSubscriptionExpirationTime removes subscription expiration time from a namespace, defaulting to broker settings
+	// RemoveSubscriptionExpirationTime removes subscription expiration time from a namespace,
+	// defaulting to broker settings
 	RemoveSubscriptionExpirationTime(namespace utils.NameSpaceName) error
 }
 
@@ -911,7 +912,8 @@ func (n *namespaces) GetSubscriptionExpirationTime(namespace utils.NameSpaceName
 	return result, err
 }
 
-func (n *namespaces) SetSubscriptionExpirationTime(namespace utils.NameSpaceName, subscriptionExpirationTimeInMinutes int) error {
+func (n *namespaces) SetSubscriptionExpirationTime(namespace utils.NameSpaceName,
+	subscriptionExpirationTimeInMinutes int) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
 	return n.pulsar.Client.Post(endpoint, &subscriptionExpirationTimeInMinutes)
 }

--- a/pulsaradmin/pkg/admin/namespace.go
+++ b/pulsaradmin/pkg/admin/namespace.go
@@ -276,6 +276,15 @@ type Namespaces interface {
 
 	// SetInactiveTopicPolicies sets the inactive topic policies on a namespace
 	SetInactiveTopicPolicies(namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error
+
+	// GetSubscriptionExpirationTime gets the subscription expiration time on a namespace. Returns -1 if not set
+	GetSubscriptionExpirationTime(namespace utils.NameSpaceName) (int, error)
+
+	// SetSubscriptionExpirationTime sets the subscription expiration time on a namespace
+	SetSubscriptionExpirationTime(namespace utils.NameSpaceName, expirationTimeInMinutes int) error
+
+	// RemoveSubscriptionExpirationTime removes subscription expiration time from a namespace, defaulting to broker settings
+	RemoveSubscriptionExpirationTime(namespace utils.NameSpaceName) error
 }
 
 type namespaces struct {
@@ -882,4 +891,22 @@ func (n *namespaces) RemoveInactiveTopicPolicies(namespace utils.NameSpaceName) 
 func (n *namespaces) SetInactiveTopicPolicies(namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
 	return n.pulsar.Client.Post(endpoint, data)
+}
+
+func (n *namespaces) GetSubscriptionExpirationTime(namespace utils.NameSpaceName) (int, error) {
+	var result int = -1
+
+	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
+	err := n.pulsar.Client.Get(endpoint, &result)
+	return result, err
+}
+
+func (n *namespaces) SetSubscriptionExpirationTime(namespace utils.NameSpaceName, subscriptionExpirationTimeInMinutes int) error {
+	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
+	return n.pulsar.Client.Post(endpoint, &subscriptionExpirationTimeInMinutes)
+}
+
+func (n *namespaces) RemoveSubscriptionExpirationTime(namespace utils.NameSpaceName) error {
+	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
+	return n.pulsar.Client.Delete(endpoint)
 }

--- a/pulsaradmin/pkg/admin/namespace.go
+++ b/pulsaradmin/pkg/admin/namespace.go
@@ -904,7 +904,7 @@ func (n *namespaces) SetInactiveTopicPolicies(namespace utils.NameSpaceName, dat
 }
 
 func (n *namespaces) GetSubscriptionExpirationTime(namespace utils.NameSpaceName) (int, error) {
-	var result int = -1
+	var result = -1
 
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
 	err := n.pulsar.Client.Get(endpoint, &result)

--- a/pulsaradmin/pkg/admin/namespace_test.go
+++ b/pulsaradmin/pkg/admin/namespace_test.go
@@ -173,3 +173,79 @@ func TestGetTopicAutoCreation(t *testing.T) {
 	}
 	assert.Equal(t, expected, *topicAutoCreation)
 }
+
+func TestNamespaces_SetSubscriptionExpirationTime(t *testing.T) {
+	config := &config.Config{}
+	admin, err := New(config)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+
+	tests := []struct {
+		name                       string
+		namespace                  string
+		subscriptionExpirationTime int
+		errReason                  string
+	}{
+		{
+			name:                       "Set valid subscription expiration time",
+			namespace:                  "public/default",
+			subscriptionExpirationTime: 60,
+			errReason:                  "",
+		},
+		{
+			name:                       "Set invalid subscription expiration time",
+			namespace:                  "public/default",
+			subscriptionExpirationTime: -60,
+			errReason:                  "Invalid value for subscription expiration time",
+		},
+		{
+			name:                       "Set valid subscription expiration time: 0",
+			namespace:                  "public/default",
+			subscriptionExpirationTime: 0,
+			errReason:                  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, _ := utils.GetNamespaceName(tt.namespace)
+			err := admin.Namespaces().SetSubscriptionExpirationTime(*namespace, tt.subscriptionExpirationTime)
+			if tt.errReason == "" {
+				assert.Equal(t, nil, err)
+
+				err = admin.Namespaces().RemoveSubscriptionExpirationTime(*namespace)
+				assert.Equal(t, nil, err)
+			}
+			if err != nil {
+				restError := err.(rest.Error)
+				assert.Equal(t, tt.errReason, restError.Reason)
+			}
+		})
+	}
+}
+
+func TestNamespaces_GetSubscriptionExpirationTime(t *testing.T) {
+	config := &config.Config{}
+	admin, err := New(config)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+
+	namespace, _ := utils.GetNamespaceName("public/default")
+
+	// set the subscription expiration time and get it
+	err = admin.Namespaces().SetSubscriptionExpirationTime(*namespace,
+		60)
+	assert.Equal(t, nil, err)
+	subscriptionExpirationTime, err := admin.Namespaces().GetSubscriptionExpirationTime(*namespace)
+	assert.Equal(t, nil, err)
+	expected := 60
+	assert.Equal(t, expected, subscriptionExpirationTime)
+
+	// remove the subscription expiration time and get it
+	err = admin.Namespaces().RemoveSubscriptionExpirationTime(*namespace)
+	assert.Equal(t, nil, err)
+
+	subscriptionExpirationTime, err = admin.Namespaces().GetSubscriptionExpirationTime(*namespace)
+	assert.Equal(t, nil, err)
+	expected = -1
+	assert.Equal(t, expected, subscriptionExpirationTime)
+}

--- a/pulsaradmin/pkg/admin/namespace_test.go
+++ b/pulsaradmin/pkg/admin/namespace_test.go
@@ -203,6 +203,11 @@ func TestRevokeSubPermission(t *testing.T) {
 }
 
 func TestNamespaces_SetSubscriptionExpirationTime(t *testing.T) {
+	config := &config.Config{}
+	admin, err := New(config)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+
 	tests := []struct {
 		name                       string
 		namespace                  string

--- a/pulsaradmin/pkg/admin/namespace_test.go
+++ b/pulsaradmin/pkg/admin/namespace_test.go
@@ -179,7 +179,7 @@ func TestRevokeSubPermission(t *testing.T) {
 	admin, err := New(config)
 	require.NoError(t, err)
 	require.NotNil(t, admin)
-  
+
 	namespace, err := utils.GetNamespaceName("public/default")
 	require.NoError(t, err)
 	require.NotNil(t, namespace)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #1253 

### Motivation

Adds support for the get / set / delete `subscriptionExpirationTime` namespace settings.

### Modifications

Created new functions in `namespace.go` that implement support for `subscriptionExpirationTime` settings

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

  - *Added integration tests for new client functions*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (**yes** / no)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **GoDocs** / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
