### PR TITLE
fix: Connection use minConnMaxIdleTime

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -66,8 +66,10 @@ func newClient(options ClientOptions) (Client, error) {
 	if connectionMaxIdleTime == 0 {
 		connectionMaxIdleTime = defaultConnMaxIdleTime
 	} else if connectionMaxIdleTime > 0 && connectionMaxIdleTime < minConnMaxIdleTime {
-		return nil, newError(InvalidConfiguration, fmt.Sprintf("Connection max idle time should be at least %f "+
-			"seconds", minConnMaxIdleTime.Seconds()))
+		logger.Warnf("Connection idle detect interval seconds default same as max idle seconds, but max idle"+
+			" seconds less than %d, to avoid checking"+
+			" connection status too much, use default value : %d", minConnMaxIdleTime.Minutes(), minConnMaxIdleTime.Minutes())
+		connectionMaxIdleTime = minConnMaxIdleTime
 	} else {
 		logger.Debugf("Disable auto release idle connections")
 	}

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1076,7 +1076,7 @@ func TestConfigureConnectionMaxIdleTime(t *testing.T) {
 		ConnectionMaxIdleTime: 1 * time.Second,
 	})
 
-	assert.Error(t, err, "Should be failed when the connectionMaxIdleTime is less than minConnMaxIdleTime")
+	assert.Nil(t, err)
 
 	cli, err := NewClient(ClientOptions{
 		URL:                   serviceURL,


### PR DESCRIPTION


### Motivation

Keep consistent with [Java client](https://github.com/apache/pulsar/blob/6b2938223cf45a9298f9d40ab6ae108bea9a5a6d/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java#L152-L156).


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
