### PR TITLE
improve: use ctx and timer instead sleep

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -623,12 +623,9 @@ func (pc *partitionConsumer) getLastMessageID() (*trackingMessageID, error) {
 		return req.msgID, req.err
 	}
 
-	opFn := func() (*trackingMessageID, error) {
-		return request()
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), pc.client.operationTimeout)
 	defer cancel()
-	res, err := internal.Retry(ctx, opFn, func(err error) time.Duration {
+	res, err := internal.Retry(ctx, request, func(err error) time.Duration {
 		nextDelay := bo.Next()
 		pc.log.WithError(err).Errorf("Failed to get last message id from broker, retrying in %v...", nextDelay)
 		return nextDelay

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"container/list"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -612,7 +613,6 @@ func (pc *partitionConsumer) getLastMessageID() (*trackingMessageID, error) {
 		pc.log.WithField("state", state).Error("Failed to getLastMessageID for the closing or closed consumer")
 		return nil, errors.New("failed to getLastMessageID for the closing or closed consumer")
 	}
-	remainTime := pc.client.operationTimeout
 	bo := pc.backoffPolicyFunc()
 	request := func() (*trackingMessageID, error) {
 		req := &getLastMsgIDRequest{doneCh: make(chan struct{})}
@@ -622,23 +622,23 @@ func (pc *partitionConsumer) getLastMessageID() (*trackingMessageID, error) {
 		<-req.doneCh
 		return req.msgID, req.err
 	}
-	for {
-		msgID, err := request()
-		if err == nil {
-			return msgID, nil
-		}
-		if remainTime <= 0 {
-			pc.log.WithError(err).Error("Failed to getLastMessageID")
-			return nil, fmt.Errorf("failed to getLastMessageID due to %w", err)
-		}
-		nextDelay := bo.Next()
-		if nextDelay > remainTime {
-			nextDelay = remainTime
-		}
-		remainTime -= nextDelay
-		pc.log.WithError(err).Errorf("Failed to get last message id from broker, retrying in %v...", nextDelay)
-		time.Sleep(nextDelay)
+
+	opFn := func() (*trackingMessageID, error) {
+		return request()
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), pc.client.operationTimeout)
+	defer cancel()
+	res, err := internal.Retry(ctx, opFn, func(err error) time.Duration {
+		nextDelay := bo.Next()
+		pc.log.WithError(err).Errorf("Failed to get last message id from broker, retrying in %v...", nextDelay)
+		return nextDelay
+	})
+	if err != nil {
+		pc.log.WithError(err).Error("Failed to getLastMessageID")
+		return nil, fmt.Errorf("failed to getLastMessageID due to %w", err)
+	}
+
+	return res, nil
 }
 
 func (pc *partitionConsumer) internalGetLastMessageID(req *getLastMsgIDRequest) {
@@ -1805,8 +1805,7 @@ func (pc *partitionConsumer) reconnectToBroker(connectionClosed *connectionClose
 		pc.log.Debug("seek operation triggers reconnection, and reset isSeeking")
 	}
 	var (
-		maxRetry                                    int
-		delayReconnectTime, totalDelayReconnectTime time.Duration
+		maxRetry int
 	)
 
 	if pc.options.maxReconnectToBroker == nil {
@@ -1816,50 +1815,39 @@ func (pc *partitionConsumer) reconnectToBroker(connectionClosed *connectionClose
 	}
 	bo := pc.backoffPolicyFunc()
 
-	for maxRetry != 0 {
+	var assignedBrokerURL string
+	if connectionClosed != nil && connectionClosed.HasURL() {
+		assignedBrokerURL = connectionClosed.assignedBrokerURL
+	}
+
+	opFn := func() (struct{}, error) {
+		if maxRetry == 0 {
+			return struct{}{}, nil
+		}
+
 		if pc.getConsumerState() != consumerReady {
 			// Consumer is already closing
 			pc.log.Info("consumer state not ready, exit reconnect")
-			return
-		}
-
-		var assignedBrokerURL string
-
-		if connectionClosed != nil && connectionClosed.HasURL() {
-			delayReconnectTime = 0
-			assignedBrokerURL = connectionClosed.assignedBrokerURL
-			connectionClosed = nil // Attempt connecting to the assigned broker just once
-		} else {
-			delayReconnectTime = bo.Next()
-		}
-		totalDelayReconnectTime += delayReconnectTime
-
-		pc.log.WithFields(log.Fields{
-			"assignedBrokerURL":  assignedBrokerURL,
-			"delayReconnectTime": delayReconnectTime,
-		}).Info("Reconnecting to broker")
-		time.Sleep(delayReconnectTime)
-
-		// double check
-		if pc.getConsumerState() != consumerReady {
-			// Consumer is already closing
-			pc.log.Info("consumer state not ready, exit reconnect")
-			return
+			return struct{}{}, nil
 		}
 
 		err := pc.grabConn(assignedBrokerURL)
+		if assignedBrokerURL != "" {
+			// Attempt connecting to the assigned broker just once
+			assignedBrokerURL = ""
+		}
 		if err == nil {
 			// Successfully reconnected
 			pc.log.Info("Reconnected consumer to broker")
 			bo.Reset()
-			return
+			return struct{}{}, nil
 		}
 		pc.log.WithError(err).Error("Failed to create consumer at reconnect")
 		errMsg := err.Error()
 		if strings.Contains(errMsg, errMsgTopicNotFound) {
 			// when topic is deleted, we should give up reconnection.
 			pc.log.Warn("Topic Not Found.")
-			break
+			return struct{}{}, nil
 		}
 
 		if maxRetry > 0 {
@@ -1869,7 +1857,17 @@ func (pc *partitionConsumer) reconnectToBroker(connectionClosed *connectionClose
 		if maxRetry == 0 || bo.IsMaxBackoffReached() {
 			pc.metrics.ConsumersReconnectMaxRetry.Inc()
 		}
+
+		return struct{}{}, err
 	}
+	_, _ = internal.Retry(context.Background(), opFn, func(_ error) time.Duration {
+		delayReconnectTime := bo.Next()
+		pc.log.WithFields(log.Fields{
+			"assignedBrokerURL":  assignedBrokerURL,
+			"delayReconnectTime": delayReconnectTime,
+		}).Info("Reconnecting to broker")
+		return delayReconnectTime
+	})
 }
 
 func (pc *partitionConsumer) lookupTopic(brokerServiceURL string) (*internal.LookupResult, error) {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -129,7 +129,7 @@ func TestConsumerConnectError(t *testing.T) {
 	assert.Nil(t, consumer)
 	assert.NotNil(t, err)
 
-	assert.Equal(t, err.Error(), "connection error")
+	assert.ErrorContains(t, err, "connection error")
 }
 
 func TestBatchMessageReceive(t *testing.T) {

--- a/pulsar/internal/retry.go
+++ b/pulsar/internal/retry.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type OpFn[T any] func() (T, error)
+
+// Retry the given operation until the returned error is nil or the context is done.
+func Retry[T any](ctx context.Context, op OpFn[T], nextDuration func(error) time.Duration) (T, error) {
+	var (
+		timer *time.Timer
+		res   T
+		err   error
+	)
+
+	cleanTimer := func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}
+	defer cleanTimer()
+
+	for {
+		res, err = op()
+		if err == nil {
+			return res, nil
+		}
+
+		duration := nextDuration(err)
+		if timer == nil {
+			timer = time.NewTimer(duration)
+		} else {
+			timer.Reset(duration)
+		}
+
+		select {
+		case <-ctx.Done():
+			return res, errors.Join(ctx.Err(), err)
+		case <-timer.C:
+		}
+	}
+}

--- a/pulsar/internal/retry_test.go
+++ b/pulsar/internal/retry_test.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryWithCtxBackground(t *testing.T) {
+	ctx := context.Background()
+	i := 0
+	res, err := Retry(ctx, func() (string, error) {
+		if i == 2 {
+			return "ok", nil
+		}
+		i++
+		return "", errors.New("error")
+	}, func(_ error) time.Duration {
+		return 1 * time.Second
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", res)
+}
+
+func TestRetryWithCtxTimeout(t *testing.T) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelFn()
+	retryErr := errors.New("error")
+	res, err := Retry(ctx, func() (string, error) {
+		return "", retryErr
+	}, func(err error) time.Duration {
+		require.Equal(t, retryErr, err)
+		return 1 * time.Second
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, retryErr.Error())
+	require.Equal(t, "", res)
+}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -73,7 +73,7 @@ func TestProducerConnectError(t *testing.T) {
 	assert.Nil(t, producer)
 	assert.NotNil(t, err)
 
-	assert.Equal(t, err.Error(), "connection error")
+	assert.ErrorContains(t, err, "connection error")
 }
 
 func TestProducerNoTopic(t *testing.T) {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -221,7 +221,7 @@ func TestReaderConnectError(t *testing.T) {
 	assert.Nil(t, reader)
 	assert.NotNil(t, err)
 
-	assert.Equal(t, err.Error(), "connection error")
+	assert.ErrorContains(t, err, "connection error")
 }
 
 func TestReaderOnSpecificMessage(t *testing.T) {

--- a/pulsar/transaction_coordinator_client.go
+++ b/pulsar/transaction_coordinator_client.go
@@ -147,41 +147,37 @@ func (t *transactionHandler) reconnectToBroker() {
 	var delayReconnectTime time.Duration
 	var defaultBackoff = backoff.DefaultBackoff{}
 
-	for {
+	opFn := func() (struct{}, error) {
 		if t.getState() == txnHandlerClosed {
 			// The handler is already closing
 			t.log.Info("transaction handler is closed, exit reconnect")
-			return
-		}
-
-		delayReconnectTime = defaultBackoff.Next()
-
-		t.log.WithFields(log.Fields{
-			"delayReconnectTime": delayReconnectTime,
-		}).Info("Transaction handler will reconnect to the transaction coordinator")
-		time.Sleep(delayReconnectTime)
-
-		// double check
-		if t.getState() == txnHandlerClosed {
-			// Txn handler is already closing
-			t.log.Info("transaction handler is closed, exit reconnect")
-			return
+			return struct{}{}, nil
 		}
 
 		err := t.grabConn()
 		if err == nil {
 			// Successfully reconnected
 			t.log.Info("Reconnected transaction handler to broker")
-			return
+			return struct{}{}, nil
 		}
+
 		t.log.WithError(err).Error("Failed to create transaction handler at reconnect")
 		errMsg := err.Error()
 		if strings.Contains(errMsg, errMsgTopicNotFound) {
 			// when topic is deleted, we should give up reconnection.
 			t.log.Warn("Topic Not Found")
-			break
+			return struct{}{}, nil
 		}
+		return struct{}{}, err
 	}
+
+	_, _ = internal.Retry(context.Background(), opFn, func(_ error) time.Duration {
+		delayReconnectTime = defaultBackoff.Next()
+		t.log.WithFields(log.Fields{
+			"delayReconnectTime": delayReconnectTime,
+		}).Info("Transaction handler will reconnect to the transaction coordinator")
+		return delayReconnectTime
+	})
 }
 
 func (t *transactionHandler) checkRetriableError(err error, op any) bool {


### PR DESCRIPTION
### Motivation

We are using `time.Sleep` and `for` to execute the retry, which cannot be interrupted, this PR will use context and timer to improve this behavior.

The next improvement idea supports passing the context to interrupt the retry, when closing the producer or consumer, we need to do that.

### Modifications

- Add the `Retry` method to execute the try, and use `Retry` instead of `time.Sleep` and `for`.