### PR TITLE
[fix] peek message will return -1 for partitionIndex

### DIFF
--- a/pulsaradmin/pkg/admin/subscription.go
+++ b/pulsaradmin/pkg/admin/subscription.go
@@ -234,8 +234,9 @@ const (
 )
 
 func handleResp(topic utils.TopicName, resp *http.Response) ([]*utils.Message, error) {
+
 	msgID := resp.Header.Get("X-Pulsar-Message-ID")
-	ID, err := utils.ParseMessageID(msgID)
+	ID, err := utils.ParseMessageIDWithPartitionIndex(msgID, topic.GetPartitionIndex())
 	if err != nil {
 		return nil, err
 	}

--- a/pulsaradmin/pkg/utils/message_id.go
+++ b/pulsaradmin/pkg/utils/message_id.go
@@ -34,6 +34,15 @@ type MessageID struct {
 var Latest = MessageID{0x7fffffffffffffff, 0x7fffffffffffffff, -1, -1}
 var Earliest = MessageID{-1, -1, -1, -1}
 
+func ParseMessageIDWithPartitionIndex(str string, index int) (*MessageID, error) {
+	id, err := ParseMessageID(str)
+	if err != nil {
+		return nil, err
+	}
+	id.PartitionIndex = index
+	return id, nil
+}
+
 func ParseMessageID(str string) (*MessageID, error) {
 	s := strings.Split(str, ":")
 

--- a/pulsaradmin/pkg/utils/topic_name.go
+++ b/pulsaradmin/pkg/utils/topic_name.go
@@ -143,6 +143,10 @@ func (t *TopicName) GetPartition(index int) (*TopicName, error) {
 	return GetTopicName(topicNameWithPartition)
 }
 
+func (t *TopicName) GetPartitionIndex() int {
+	return t.partitionIndex
+}
+
 func getPartitionIndex(topic string) int {
 	if strings.Contains(topic, PARTITIONEDTOPICSUFFIX) {
 		parts := strings.Split(topic, "-")


### PR DESCRIPTION
### Motivation
If peek a partitioned topic, will see a message id: `7316:0:-1:-1`, the parititonIndex should not be -1.

```
pulsarctl subscription peek --count 10 persistent://public/default/my-topic-partition-0 test-sub
Message ID : 7316:0:-1:-1
Properties :
{
    "publish-time": "2024-08-08T17:50:39.476+08:00"
}
Message :
00000000  68 65 6c 6c 6f 2d 31                              |hello-1|
```

### Modifications
- Set partition index on peek message.

### Verifying this change
Add `TestPeekMessageForPartitionedTopic` to cover it.


### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
