### PR TITLE
[fix] [Issue 485]Fixed panic caused by memory not aligned in arm32 arch

### DIFF
--- a/pulsar/ack_grouping_tracker_test.go
+++ b/pulsar/ack_grouping_tracker_test.go
@@ -59,9 +59,9 @@ func TestNoCacheTracker(t *testing.T) {
 }
 
 type mockAcker struct {
-	sync.Mutex
-	ledgerIDs          []int64
 	cumulativeLedgerID int64
+	sync.Mutex
+	ledgerIDs []int64
 }
 
 func (a *mockAcker) ack(ids []*pb.MessageIdData) {

--- a/pulsar/default_router.go
+++ b/pulsar/default_router.go
@@ -24,11 +24,10 @@ import (
 )
 
 type defaultRouter struct {
+	lastBatchTimestamp     int64
 	currentPartitionCursor uint32
-
-	lastBatchTimestamp  int64
-	msgCounter          uint32
-	cumulativeBatchSize uint32
+	msgCounter             uint32
+	cumulativeBatchSize    uint32
 }
 
 // NewDefaultRouter set the message routing mode for the partitioned producer.

--- a/pulsar/internal/memory_limit_controller.go
+++ b/pulsar/internal/memory_limit_controller.go
@@ -35,9 +35,9 @@ type MemoryLimitController interface {
 }
 
 type memoryLimitController struct {
+	currentUsage int64
 	limit        int64
 	chCond       *chCond
-	currentUsage int64
 
 	triggers []*thresholdTrigger
 	// valid range is (0, 1.0)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -87,6 +87,8 @@ func init() {
 }
 
 type partitionProducer struct {
+	lastSequenceID int64
+
 	state  uAtomic.Int32
 	client *client
 	topic  string
@@ -110,7 +112,6 @@ type partitionProducer struct {
 	connectClosedCh      chan *connectionClosed
 	publishSemaphore     internal.Semaphore
 	pendingQueue         internal.BlockingQueue
-	lastSequenceID       int64
 	schemaInfo           *SchemaInfo
 	partitionIdx         int32
 	metrics              *internal.LeveledMetrics


### PR DESCRIPTION

### Motivation
Fixed panic caused by memory not aligned in arm32 arch.

### Modifications
Move variable that uses 64-bit atomic operations to the front of the structure so that it is 64-bit aligned.


### Verifying this change
- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
