### PR TITLE
[fix] fix flaky test `TestCloseFlushWithTimer`

### DIFF
--- a/pulsar/ack_grouping_tracker_test.go
+++ b/pulsar/ack_grouping_tracker_test.go
@@ -243,7 +243,7 @@ func TestCloseFlushWithoutTimer(t *testing.T) {
 func TestCloseFlushWithTimer(t *testing.T) {
 	var acker mockAcker
 	tracker := newAckGroupingTracker(
-		&AckGroupingOptions{MaxSize: 1000, MaxTime: 10 * 1000},
+		&AckGroupingOptions{MaxSize: 1000, MaxTime: 10 * time.Second},
 		nil,
 		func(id MessageID) { acker.ackCumulative(id) },
 		func(ids []*pb.MessageIdData) { acker.ack(ids) },


### PR DESCRIPTION

Fixes #1291

### Motivation

The `MaxTime` setting for AckGroupingTracker is too short at only 10,000 nanoseconds.
This causes the test very flaky.

### Modifications

- Change the `MaxTime` to 10 seconds

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
