### PR TITLE
Compatible the HTTP header properties with PIP-279

### DIFF
--- a/pulsaradmin/pkg/admin/subscription_test.go
+++ b/pulsaradmin/pkg/admin/subscription_test.go
@@ -144,6 +144,58 @@ func TestPeekMessageForPartitionedTopic(t *testing.T) {
 	}
 }
 
+func TestPeekMessageWithProperties(t *testing.T) {
+	randomName := newTopicName()
+	topic := "persistent://public/default/" + randomName
+	topicName, err := utils.GetTopicName(topic)
+	subName := "test-sub"
+
+	cfg := &config.Config{}
+	admin, err := New(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, admin)
+
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL: lookupURL,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	// Create a producer for non-batch messages
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.NoError(t, err)
+	defer producer.Close()
+
+	props := map[string]string{
+		"key1":        "value1",
+		"KEY2":        "VALUE2",
+		"KeY3":        "VaLuE3",
+		"details=man": "good at playing basketball",
+	}
+
+	_, err = producer.Send(context.Background(), &pulsar.ProducerMessage{
+		Payload:    []byte("test-message"),
+		Properties: props,
+	})
+	assert.NoError(t, err)
+
+	// Peek messages
+	messages, err := admin.Subscriptions().PeekMessages(*topicName, subName, 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, messages)
+
+	// Verify properties of messages
+	for _, msg := range messages {
+		assert.Equal(t, "value1", msg.Properties["key1"])
+		assert.Equal(t, "VALUE2", msg.Properties["KEY2"])
+		assert.Equal(t, "VaLuE3", msg.Properties["KeY3"])
+		assert.Equal(t, "good at playing basketball", msg.Properties["details=man"])
+	}
+}
+
 func TestGetMessageByID(t *testing.T) {
 	randomName := newTopicName()
 	topic := "persistent://public/default/" + randomName

--- a/pulsaradmin/pkg/admin/subscription_test.go
+++ b/pulsaradmin/pkg/admin/subscription_test.go
@@ -147,7 +147,7 @@ func TestPeekMessageForPartitionedTopic(t *testing.T) {
 func TestPeekMessageWithProperties(t *testing.T) {
 	randomName := newTopicName()
 	topic := "persistent://public/default/" + randomName
-	topicName, err := utils.GetTopicName(topic)
+	topicName, _ := utils.GetTopicName(topic)
 	subName := "test-sub"
 
 	cfg := &config.Config{}


### PR DESCRIPTION
### Motivation

After [pip-279](https://github.com/apache/pulsar/pull/20627), all properties keys and values use json string save to header: `X-Pulsar-Property`

This PR to compatible with this change when using subscription admin API.

Also, Using `pip-279` also avoids the issue where the Go HTTP client automatically formats HTTP headers: https://github.com/golang/go/issues/37834, This will impact the peek command, the previous method might retrieve `properties` with inconsistent casing compared to the user-defined.

### Modifications
- Compatible the HTTP header properties with PIP-279


### Verifying this change
- Add TestPeekMessageWithProperties to cover this.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
