### PR TITLE
Fix close blocked

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -491,12 +491,6 @@ func (p *partitionProducer) reconnectToBroker(connectionClosed *connectionClosed
 			return struct{}{}, nil
 		}
 
-		select {
-		case <-p.ctx.Done():
-			return struct{}{}, nil
-		default:
-		}
-
 		if p.getProducerState() != producerReady {
 			// Producer is already closing
 			p.log.Info("producer state not ready, exit reconnect")
@@ -552,7 +546,7 @@ func (p *partitionProducer) reconnectToBroker(connectionClosed *connectionClosed
 
 		return struct{}{}, err
 	}
-	_, _ = internal.Retry(context.Background(), opFn, func(_ error) time.Duration {
+	_, _ = internal.Retry(p.ctx, opFn, func(_ error) time.Duration {
 		delayReconnectTime := bo.Next()
 		p.log.WithFields(log.Fields{
 			"assignedBrokerURL":  assignedBrokerURL,


### PR DESCRIPTION
### Motivation

When a consumer or producer reconnects to the broker, the event loop handling the reconnection becomes occupied, preventing the execution of the `close` command. This can result in the inability to properly close the consumer or producer, leading to potential resource management issues.

### Modifications

- Introduce passing a `context` to the retry function. This ensures that when the `context` is completed or canceled, the retry logic is interrupted and stops further attempts.
- Modify the `producer.Close` and `consumer.Close` methods to call the associated `context.CancelFunc` to cancel the reconnection attempts.