### PR TITLE
[Issue 1297][consumer] Fix DLQ producer name conflicts when there are same name consumers

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -1517,8 +1518,9 @@ func DLQWithProducerOptions(t *testing.T, prodOpt *ProducerOptions) {
 		expectMsg := fmt.Sprintf("hello-%d", expectedMsgIdx)
 		assert.Equal(t, []byte(expectMsg), msg.Payload())
 
-		// check dql produceName
-		assert.Equal(t, msg.ProducerName(), fmt.Sprintf("%s-%s-%s-DLQ", topic, sub, consumerName))
+		// check dlq produceName
+		regex := regexp.MustCompile(fmt.Sprintf("%s-%s-%s-[a-z]{5}-DLQ", topic, sub, consumerName))
+		assert.True(t, regex.MatchString(msg.ProducerName()))
 
 		// check original messageId
 		assert.NotEmpty(t, msg.Properties()[PropertyOriginMessageID])

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -172,7 +172,7 @@ func (r *dlqRouter) getProducer(schema Schema) Producer {
 		opt.Topic = r.policy.DeadLetterTopic
 		opt.Schema = schema
 		if opt.Name == "" {
-			opt.Name = fmt.Sprintf("%s-%s-%s-DLQ", r.topicName, r.subscriptionName, r.consumerName)
+			opt.Name = fmt.Sprintf("%s-%s-%s-%s-DLQ", r.topicName, r.subscriptionName, r.consumerName, generateRandomName())
 		}
 		opt.initialSubscriptionName = r.policy.InitialSubscriptionName
 


### PR DESCRIPTION
Fixes #1297
Master Issue: https://github.com/apache/pulsar/pull/21589

### Motivation
When multiple consumers with same name are using dlq policies at the same time, prompt will throw below exceptions:
`
ERRO[0069] Failed to create DLQ producer  dlq-topic="persistent://<tenant>/<namespace>/<topic>-<subscription>-DLQ" error="server error: ProducerBusy: org.apache.pulsar.broker.service.BrokerServiceException$NamingException: Producer with name '-<subscription>-<consumerName>-DLQ' is already connected to topic"
`

### Modifications
Add a random suffix in dlq producer name like: `opt.Name = fmt.Sprintf("%s-%s-%s-%s-DLQ", r.topicName, r.subscriptionName, r.consumerName, generateRandomName())`

### Verifying this change
- [x] Make sure that the change passes the CI checks.
This change is already covered by existing tests, such as `pulsar/consumer_test.go#TestDLQ(t *testing.T)`

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
  I will create a followup issue for adding the documentation later.
