### PR TITLE
[improve] Add detailed message when connection failed

### DIFF
--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1244,5 +1244,6 @@ func TestConnectionClosedError(t *testing.T) {
 		Topic: "my-topic",
 	})
 	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "failed to connect to broker: dial tcp [::1]:1234: connect: connection refused"), "error-message", err.Error())
+	assert.True(t, strings.Contains(err.Error(), "failed to connect to broker: dial tcp [::1]:1234: connect:"+
+		" connection refused"), "error-message", err.Error())
 }

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1231,3 +1231,18 @@ func TestMultipleCloseClient(t *testing.T) {
 	client.Close()
 	client.Close()
 }
+
+func TestConnectionClosedError(t *testing.T) {
+	c, err := NewClient(ClientOptions{
+		URL:               "pulsar://localhost:1234", // fake address
+		ConnectionTimeout: 1 * time.Second,
+		OperationTimeout:  1 * time.Second,
+	})
+	assert.NoError(t, err)
+
+	_, err = c.CreateProducer(ProducerOptions{
+		Topic: "my-topic",
+	})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "failed to connect to broker: dial tcp [::1]:1234: connect: connection refused"), "error-message", err.Error())
+}

--- a/pulsar/consumer_multitopic_test.go
+++ b/pulsar/consumer_multitopic_test.go
@@ -358,12 +358,16 @@ func (dummyConnection) GetMaxMessageSize() int32 {
 func (dummyConnection) Close() {
 }
 
-func (dummyConnection) WaitForClose() <-chan struct{} {
+func (dummyConnection) WaitForClose() <-chan error {
 	return nil
 }
 
 func (dummyConnection) IsProxied() bool {
 	return false
+}
+
+func (dummyConnection) CloseWithErr(_ error) {
+
 }
 
 func TestMultiTopicAckIDListTimeout(t *testing.T) {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -121,7 +121,8 @@ func TestProducerConsumer(t *testing.T) {
 
 func TestConsumerConnectError(t *testing.T) {
 	client, err := NewClient(ClientOptions{
-		URL: "pulsar://invalid-hostname:6650",
+		URL:              "pulsar://invalid-hostname:6650",
+		OperationTimeout: 5 * time.Second,
 	})
 
 	assert.Nil(t, err)
@@ -137,7 +138,7 @@ func TestConsumerConnectError(t *testing.T) {
 	assert.Nil(t, consumer)
 	assert.NotNil(t, err)
 
-	assert.ErrorContains(t, err, "connection error")
+	assert.ErrorContains(t, err, "failed to connect to broker")
 }
 
 func TestBatchMessageReceive(t *testing.T) {

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -58,7 +58,8 @@ func TestInvalidURL(t *testing.T) {
 
 func TestProducerConnectError(t *testing.T) {
 	client, err := NewClient(ClientOptions{
-		URL: "pulsar://invalid-hostname:6650",
+		URL:              "pulsar://invalid-hostname:6650",
+		OperationTimeout: 5 * time.Second,
 	})
 
 	assert.Nil(t, err)
@@ -73,7 +74,7 @@ func TestProducerConnectError(t *testing.T) {
 	assert.Nil(t, producer)
 	assert.NotNil(t, err)
 
-	assert.ErrorContains(t, err, "connection error")
+	assert.ErrorContains(t, err, "failed to connect to broker")
 }
 
 func TestProducerNoTopic(t *testing.T) {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -205,7 +205,8 @@ func TestReaderOnPartitionedTopic(t *testing.T) {
 
 func TestReaderConnectError(t *testing.T) {
 	client, err := NewClient(ClientOptions{
-		URL: "pulsar://invalid-hostname:6650",
+		URL:              "pulsar://invalid-hostname:6650",
+		OperationTimeout: 5 * time.Second,
 	})
 
 	assert.Nil(t, err)
@@ -221,7 +222,7 @@ func TestReaderConnectError(t *testing.T) {
 	assert.Nil(t, reader)
 	assert.NotNil(t, err)
 
-	assert.ErrorContains(t, err, "connection error")
+	assert.ErrorContains(t, err, "failed to connect to broker")
 }
 
 func TestReaderOnSpecificMessage(t *testing.T) {


### PR DESCRIPTION
Fixes #1315

### Motivation

Currently the go client will only throw an error without any detailed information when connection failed:

```
connection error
```

### Modifications

- Add detailed message when connection failed

### Verifying this change

With this PR, the error message would be like:

```
failed to connect to broker: dial tcp [::1]:1234: connect: connection refused
```
### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
