### PR TITLE
fix: wrap errors using %w to preserve context

### DIFF
--- a/oauth2/auth.go
+++ b/oauth2/auth.go
@@ -112,7 +112,7 @@ func ExtractUserName(token oauth2.Token) (string, error) {
 	p := jwt.Parser{}
 	claims := jwt.MapClaims{}
 	if _, _, err := p.ParseUnverified(token.AccessToken, claims); err != nil {
-		return "", fmt.Errorf("unable to decode the access token: %v", err)
+		return "", fmt.Errorf("unable to decode the access token: %w", err)
 	}
 	username, ok := claims[ClaimNameUserName]
 	if !ok {

--- a/oauth2/cache/cache.go
+++ b/oauth2/cache/cache.go
@@ -80,7 +80,7 @@ func (t *tokenCache) Token() (*xoauth2.Token, error) {
 	// load from the store and use the access token if it isn't expired
 	grant, err := t.store.LoadGrant(t.audience)
 	if err != nil {
-		return nil, fmt.Errorf("LoadGrant: %v", err)
+		return nil, fmt.Errorf("LoadGrant: %w", err)
 	}
 	t.token = grant.Token
 	if t.token != nil && t.validateAccessToken(*t.token) {
@@ -90,13 +90,13 @@ func (t *tokenCache) Token() (*xoauth2.Token, error) {
 	// obtain and cache a fresh access token
 	grant, err = t.refresher.Refresh(grant)
 	if err != nil {
-		return nil, fmt.Errorf("RefreshGrant: %v", err)
+		return nil, fmt.Errorf("RefreshGrant: %w", err)
 	}
 	t.token = grant.Token
 	err = t.store.SaveGrant(t.audience, *grant)
 	if err != nil {
 		// TODO log rather than throw
-		return nil, fmt.Errorf("SaveGrant: %v", err)
+		return nil, fmt.Errorf("SaveGrant: %w", err)
 	}
 
 	return t.token, nil
@@ -117,14 +117,14 @@ func (t *tokenCache) InvalidateToken() error {
 	}
 	grant, err := t.store.LoadGrant(t.audience)
 	if err != nil {
-		return fmt.Errorf("LoadGrant: %v", err)
+		return fmt.Errorf("LoadGrant: %w", err)
 	}
 	if grant.Token != nil && grant.Token.AccessToken == previous.AccessToken {
 		grant.Token.Expiry = time.Unix(0, 0).Add(expiryDelta)
 		err = t.store.SaveGrant(t.audience, *grant)
 		if err != nil {
 			// TODO log rather than throw
-			return fmt.Errorf("SaveGrant: %v", err)
+			return fmt.Errorf("SaveGrant: %w", err)
 		}
 	}
 	return nil

--- a/oauth2/store/keyring.go
+++ b/oauth2/store/keyring.go
@@ -20,6 +20,7 @@ package store
 import (
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -92,7 +93,7 @@ func (f *KeyringStore) LoadGrant(audience string) (*oauth2.AuthorizationGrant, e
 
 	item, err := f.getItem(audience)
 	if err != nil {
-		if err == keyring.ErrKeyNotFound {
+		if errors.Is(err, keyring.ErrKeyNotFound) {
 			return nil, ErrNoAuthenticationData
 		}
 		return nil, err
@@ -119,10 +120,10 @@ func (f *KeyringStore) WhoAmI(audience string) (string, error) {
 	key := hashKeyringKey(audience)
 	authItem, err := f.kr.Get(key)
 	if err != nil {
-		if err == keyring.ErrKeyNotFound {
+		if errors.Is(err, keyring.ErrKeyNotFound) {
 			return "", ErrNoAuthenticationData
 		}
-		return "", fmt.Errorf("unable to get information from the keyring: %v", err)
+		return "", fmt.Errorf("unable to get information from the keyring: %w", err)
 	}
 	return authItem.Label, nil
 }
@@ -134,13 +135,13 @@ func (f *KeyringStore) Logout() error {
 	var err error
 	keys, err := f.kr.Keys()
 	if err != nil {
-		return fmt.Errorf("unable to get information from the keyring: %v", err)
+		return fmt.Errorf("unable to get information from the keyring: %w", err)
 	}
 	for _, key := range keys {
 		err = f.kr.Remove(key)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to update the keyring: %v", err)
+		return fmt.Errorf("unable to update the keyring: %w", err)
 	}
 	return nil
 }
@@ -180,7 +181,7 @@ func (f *KeyringStore) setItem(item storedItem) error {
 	}
 	err = f.kr.Set(i)
 	if err != nil {
-		return fmt.Errorf("unable to update the keyring: %v", err)
+		return fmt.Errorf("unable to update the keyring: %w", err)
 	}
 	return nil
 }

--- a/oauth2/store/store.go
+++ b/oauth2/store/store.go
@@ -26,7 +26,7 @@ import (
 // ErrNoAuthenticationData indicates that stored authentication data is not available
 var ErrNoAuthenticationData = errors.New("authentication data is not available")
 
-// ErrUnsupportedAuthData ndicates that stored authentication data is unusable
+// ErrUnsupportedAuthData indicates that stored authentication data is unusable
 var ErrUnsupportedAuthData = errors.New("authentication data is not usable")
 
 // Store is responsible for persisting authorization grants

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1158,21 +1158,21 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 	// error decrypting the payload
 	if err != nil {
 		// default crypto failure action
-		crypToFailureAction := crypto.ConsumerCryptoFailureActionFail
+		cryptoFailureAction := crypto.ConsumerCryptoFailureActionFail
 		if pc.options.decryption != nil {
-			crypToFailureAction = pc.options.decryption.ConsumerCryptoFailureAction
+			cryptoFailureAction = pc.options.decryption.ConsumerCryptoFailureAction
 		}
 
-		switch crypToFailureAction {
+		switch cryptoFailureAction {
 		case crypto.ConsumerCryptoFailureActionFail:
-			pc.log.Errorf("consuming message failed due to decryption err :%v", err)
+			pc.log.Errorf("consuming message failed due to decryption err: %v", err)
 			pc.NackID(newTrackingMessageID(int64(pbMsgID.GetLedgerId()), int64(pbMsgID.GetEntryId()), 0, 0, 0, nil))
 			return err
 		case crypto.ConsumerCryptoFailureActionDiscard:
 			pc.discardCorruptedMessage(pbMsgID, pb.CommandAck_DecryptionError)
-			return fmt.Errorf("discarding message on decryption error :%v", err)
+			return fmt.Errorf("discarding message on decryption error: %w", err)
 		case crypto.ConsumerCryptoFailureActionConsume:
-			pc.log.Warnf("consuming encrypted message due to error in decryption :%v", err)
+			pc.log.Warnf("consuming encrypted message due to error in decryption: %v", err)
 			messages := []*message{
 				{
 					publishTime:  timeFromUnixTimestampMillis(msgMeta.GetPublishTime()),
@@ -1769,14 +1769,6 @@ func (pc *partitionConsumer) internalClose(req *closeRequest) {
 	state := pc.getConsumerState()
 	if state != consumerReady {
 		// this might be redundant but to ensure nack tracker is closed
-		if pc.nackTracker != nil {
-			pc.nackTracker.Close()
-		}
-		return
-	}
-
-	if state == consumerClosed || state == consumerClosing {
-		pc.log.WithField("state", state).Error("Consumer is closing or has closed")
 		if pc.nackTracker != nil {
 			pc.nackTracker.Close()
 		}

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1767,6 +1767,14 @@ func (pc *partitionConsumer) runEventsLoop() {
 func (pc *partitionConsumer) internalClose(req *closeRequest) {
 	defer close(req.doneCh)
 	state := pc.getConsumerState()
+	if state == consumerClosed || state == consumerClosing {
+		pc.log.WithField("state", state).Error("Consumer is closing or has closed")
+		if pc.nackTracker != nil {
+			pc.nackTracker.Close()
+		}
+		return
+	}
+
 	if state != consumerReady {
 		// this might be redundant but to ensure nack tracker is closed
 		if pc.nackTracker != nil {

--- a/pulsar/crypto/default_message_crypto.go
+++ b/pulsar/crypto/default_message_crypto.go
@@ -95,7 +95,7 @@ func (d *DefaultMessageCrypto) addPublicKeyCipher(keyName string, keyReader KeyR
 	d.cipherLock.Lock()
 	defer d.cipherLock.Unlock()
 	if keyName == "" || keyReader == nil {
-		return fmt.Errorf("keyname or keyreader is null")
+		return fmt.Errorf("keyname or keyreader is nil")
 	}
 
 	// read the public key and its info using keyReader
@@ -212,7 +212,7 @@ func (d *DefaultMessageCrypto) Encrypt(encKeys []string,
 func (d *DefaultMessageCrypto) Decrypt(msgMetadata MessageMetadataSupplier,
 	payload []byte,
 	keyReader KeyReader) ([]byte, error) {
-	// if data key is present, attempt to derypt using the existing key
+	// if data key is present, attempt to decrypt using the existing key
 	if d.dataKey != nil {
 		decryptedData, err := d.getKeyAndDecryptData(msgMetadata, payload)
 		if err != nil {
@@ -342,20 +342,20 @@ func (d *DefaultMessageCrypto) loadPrivateKey(key []byte) (gocrypto.PrivateKey, 
 
 // read the public key into RSA key
 func (d *DefaultMessageCrypto) loadPublicKey(key []byte) (gocrypto.PublicKey, error) {
-	var publickKey gocrypto.PublicKey
+	var publicKey gocrypto.PublicKey
 
 	pubPem, _ := pem.Decode(key)
 	if pubPem == nil {
-		return publickKey, fmt.Errorf("failed to decode public key")
+		return publicKey, fmt.Errorf("failed to decode public key")
 	}
 
 	genericPublicKey, err := x509.ParsePKIXPublicKey(pubPem.Bytes)
 	if err != nil {
-		return publickKey, err
+		return publicKey, err
 	}
-	publickKey = genericPublicKey
+	publicKey = genericPublicKey
 
-	return publickKey, nil
+	return publicKey, nil
 }
 
 func generateDataKey() ([]byte, error) {

--- a/pulsar/internal/commands.go
+++ b/pulsar/internal/commands.go
@@ -272,7 +272,7 @@ func serializeMessage(wb Buffer,
 	encryptedPayload, err := encryptor.Encrypt(compressedPayload, msgMetadata)
 	if err != nil {
 		// error occurred while encrypting the payload, ProducerCryptoFailureAction is set to Fail
-		return fmt.Errorf("encryption of message failed, ProducerCryptoFailureAction is set to Fail. Error :%v", err)
+		return fmt.Errorf("encryption of message failed, ProducerCryptoFailureAction is set to Fail. Error: %w", err)
 	}
 
 	cmdSize := uint32(proto.Size(cmdSend))

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -947,7 +947,7 @@ func (c *connection) handleTopicMigrated(commandTopicMigrated *pb.CommandTopicMi
 	resourceID := commandTopicMigrated.GetResourceId()
 	migratedBrokerServiceURL := c.getMigratedBrokerServiceURL(commandTopicMigrated)
 	if migratedBrokerServiceURL == "" {
-		c.log.Warnf("Failed to find the migrated broker url for resource: %s, migratedBrokerUrl: %s, migratedBrokerUrlTls:%s",
+		c.log.Warnf("Failed to find the migrated broker url for resource: %d, migratedBrokerUrl: %s, migratedBrokerUrlTls:%s",
 			resourceID,
 			commandTopicMigrated.GetBrokerServiceUrl(),
 			commandTopicMigrated.GetBrokerServiceUrlTls())

--- a/pulsar/internal/crypto/producer_encryptor.go
+++ b/pulsar/internal/crypto/producer_encryptor.go
@@ -55,11 +55,11 @@ func (e *producerEncryptor) Encrypt(payload []byte, msgMetadata *pb.MessageMetad
 		crypto.NewMessageMetadataSupplier(msgMetadata),
 		payload)
 
-	// error encryping the payload
+	// error encrypting the payload
 	if err != nil {
 		// error occurred in encrypting the payload
 		// crypto ProducerCryptoFailureAction is set to send
-		// send unencrypted message
+		// unencrypted message
 		if e.producerCryptoFailureAction == crypto.ProducerCryptoFailureActionSend {
 			e.logger.
 				WithError(err).
@@ -67,7 +67,7 @@ func (e *producerEncryptor) Encrypt(payload []byte, msgMetadata *pb.MessageMetad
 			return payload, nil
 		}
 
-		return nil, fmt.Errorf("ProducerCryptoFailureAction is set to Fail and error occurred in encrypting payload :%v", err)
+		return nil, fmt.Errorf("ProducerCryptoFailureAction is set to Fail and error occurred in encrypting payload: %w", err)
 	}
 	return encryptedPayload, nil
 }

--- a/pulsar/primitiveSerDe.go
+++ b/pulsar/primitiveSerDe.go
@@ -100,14 +100,14 @@ func (b BinaryFreeList) Uint64(r io.Reader, byteOrder binary.ByteOrder) (uint64,
 
 func (b BinaryFreeList) Float64(buf []byte) (float64, error) {
 	if len(buf) < 8 {
-		return 0, fmt.Errorf("cannot decode binary double: %s", io.ErrShortBuffer)
+		return 0, fmt.Errorf("cannot decode binary double: %w", io.ErrShortBuffer)
 	}
 	return math.Float64frombits(binary.BigEndian.Uint64(buf[:8])), nil
 }
 
 func (b BinaryFreeList) Float32(buf []byte) (float32, error) {
 	if len(buf) < 4 {
-		return 0, fmt.Errorf("cannot decode binary float: %s", io.ErrShortBuffer)
+		return 0, fmt.Errorf("cannot decode binary float: %w", io.ErrShortBuffer)
 	}
 	return math.Float32frombits(binary.BigEndian.Uint32(buf[:4])), nil
 }

--- a/pulsar/producer_impl.go
+++ b/pulsar/producer_impl.go
@@ -143,7 +143,7 @@ func newProducer(client *client, options *ProducerOptions) (*producer, error) {
 				true,
 				client.log.SubLogger(log.Fields{"topic": p.topic}))
 			if err != nil {
-				return nil, fmt.Errorf("unable to get MessageCrypto instance. Producer creation is abandoned. %v", err)
+				return nil, fmt.Errorf("unable to get MessageCrypto instance. Producer creation is abandoned. %w", err)
 			}
 			p.options.Encryption.MessageCrypto = messageCrypto
 		}


### PR DESCRIPTION
### Motivation

This pull request wraps errors using `%w` to preserve the original error and provide more meaningful error messages.

### Modifications

* Wrap errors using `%w` to preserve context
* Handle errors using `errors.Is()`
* Remove unreachable code
* Fix typos

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API: (yes / **no**)
  - The schema: (yes / **no** / don't know)
  - The default values of configurations: (yes / **no**)
  - The wire protocol: (yes / **no**)

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
