### PR TITLE
[fix] [client] fix same producer/consumer use more than one connection per broker

### DIFF
--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -5058,11 +5058,11 @@ func TestSelectConnectionForSameConsumer(t *testing.T) {
 	defer _consumer.Close()
 
 	partitionConsumerImpl := _consumer.(*consumer).consumers[0]
-	conn := partitionConsumerImp._getConn()
+	conn := partitionConsumerImpl._getConn()
 
 	for i := 0; i < 5; i++ {
-		assert.NoError(t, partitionConsumerImp.grabConn(""))
-		assert.Equal(t, conn.ID(), partitionConsumerImp._getConn().ID(),
+		assert.NoError(t, partitionConsumerImpl.grabConn(""))
+		assert.Equal(t, conn.ID(), partitionConsumerImpl._getConn().ID(),
 			"The consumer uses a different connection when reconnecting")
 	}
 }

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -5057,11 +5057,11 @@ func TestSelectConnectionForSameConsumer(t *testing.T) {
 	assert.NoError(t, err)
 	defer _consumer.Close()
 
-	partitionConsumerImp := _consumer.(*consumer).consumers[0]
+	partitionConsumerImpl := _consumer.(*consumer).consumers[0]
 	conn := partitionConsumerImp._getConn()
 
 	for i := 0; i < 5; i++ {
-		partitionConsumerImp.grabConn("")
+		assert.NoError(t, partitionConsumerImp.grabConn(""))
 		assert.Equal(t, conn.ID(), partitionConsumerImp._getConn().ID(),
 			"The consumer uses a different connection when reconnecting")
 	}

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -38,7 +38,7 @@ type ConnectionPool interface {
 	GetConnections() map[string]Connection
 
 	// GenerateRoundRobinIndex generates a round-robin index.
-	GenerateRoundRobinIndex() int32
+	GenerateRoundRobinIndex() uint32
 
 	// Close all the connections in the pool
 	Close()
@@ -50,8 +50,8 @@ type connectionPool struct {
 	connectionTimeout     time.Duration
 	tlsOptions            *TLSOptions
 	auth                  auth.Provider
-	maxConnectionsPerHost int32
-	roundRobinCnt         int32
+	maxConnectionsPerHost uint32
+	roundRobinCnt         uint32
 	keepAliveInterval     time.Duration
 	closeCh               chan struct{}
 
@@ -76,7 +76,7 @@ func NewConnectionPool(
 		tlsOptions:            tlsOptions,
 		auth:                  auth,
 		connectionTimeout:     connectionTimeout,
-		maxConnectionsPerHost: int32(maxConnectionsPerHost),
+		maxConnectionsPerHost: uint32(maxConnectionsPerHost),
 		keepAliveInterval:     keepAliveInterval,
 		log:                   logger,
 		metrics:               metrics,
@@ -147,12 +147,8 @@ func (p *connectionPool) GetConnections() map[string]Connection {
 	return conns
 }
 
-func (p *connectionPool) GenerateRoundRobinIndex() int32 {
-	cnt := atomic.AddInt32(&p.roundRobinCnt, 1)
-	if cnt < 0 {
-		cnt = -cnt
-	}
-	return cnt % p.maxConnectionsPerHost
+func (p *connectionPool) GenerateRoundRobinIndex() uint32 {
+	return atomic.AddUint32(&p.roundRobinCnt, 1) % p.maxConnectionsPerHost
 }
 
 func (p *connectionPool) Close() {

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -38,7 +38,7 @@ type ConnectionPool interface {
 	GetConnections() map[string]Connection
 
 	// GenerateRoundRobinIndex generates a round-robin index.
-	GenerateRoundRobinIndex() uint32
+	GenerateRoundRobinIndex() int32
 
 	// Close all the connections in the pool
 	Close()
@@ -147,8 +147,8 @@ func (p *connectionPool) GetConnections() map[string]Connection {
 	return conns
 }
 
-func (p *connectionPool) GenerateRoundRobinIndex() uint32 {
-	return atomic.AddUint32(&p.roundRobinCnt, 1) % p.maxConnectionsPerHost
+func (p *connectionPool) GenerateRoundRobinIndex() int32 {
+	return int32(atomic.AddUint32(&p.roundRobinCnt, 1) % p.maxConnectionsPerHost)
 }
 
 func (p *connectionPool) Close() {

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -90,7 +90,8 @@ func NewConnectionPool(
 func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.URL,
 	keySuffix int32) (Connection, error) {
 	p.log.WithField("logicalAddr", logicalAddr).
-		WithField("physicalAddr", physicalAddr).Debug("Getting pooled connection")
+		WithField("physicalAddr", physicalAddr).
+		WithField("keySuffix", keySuffix).Debug("Getting pooled connection")
 	key := fmt.Sprint(logicalAddr.Host, "-", physicalAddr.Host, "-", keySuffix)
 
 	p.Lock()

--- a/pulsar/internal/lookup_service_test.go
+++ b/pulsar/internal/lookup_service_test.go
@@ -108,8 +108,8 @@ func (c *mockedLookupRPCClient) Request(logicalAddr *url.URL, physicalAddr *url.
 	}, nil
 }
 
-func (c *mockedLookupRPCClient) RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL,
-	cnxKeySuffix int32, _ uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
+func (c *mockedLookupRPCClient) RequestWithCnxKeySuffix(_ *url.URL, _ *url.URL,
+	_ int32, _ uint64, _ pb.BaseCommand_Type, _ proto.Message) (*RPCResult, error) {
 	assert.Fail(c.t, "Shouldn't be called")
 	return nil, nil
 }
@@ -498,8 +498,8 @@ func (m mockedPartitionedTopicMetadataRPCClient) Request(_ *url.URL, _ *url.URL,
 	return nil, nil
 }
 
-func (m *mockedPartitionedTopicMetadataRPCClient) RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL,
-	cnxKeySuffix int32, _ uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
+func (m *mockedPartitionedTopicMetadataRPCClient) RequestWithCnxKeySuffix(_ *url.URL, _ *url.URL,
+	_ int32, _ uint64, _ pb.BaseCommand_Type, _ proto.Message) (*RPCResult, error) {
 	assert.Fail(m.t, "Shouldn't be called")
 	return nil, nil
 }

--- a/pulsar/internal/lookup_service_test.go
+++ b/pulsar/internal/lookup_service_test.go
@@ -108,6 +108,12 @@ func (c *mockedLookupRPCClient) Request(logicalAddr *url.URL, physicalAddr *url.
 	}, nil
 }
 
+func (c *mockedLookupRPCClient) RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL,
+	cnxKeySuffix int32, _ uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
+	assert.Fail(c.t, "Shouldn't be called")
+	return nil, nil
+}
+
 func (c *mockedLookupRPCClient) RequestOnCnx(_ Connection, _ uint64, _ pb.BaseCommand_Type,
 	_ proto.Message) (*RPCResult, error) {
 	assert.Fail(c.t, "Shouldn't be called")
@@ -488,6 +494,12 @@ func (m mockedPartitionedTopicMetadataRPCClient) RequestToAnyBroker(requestID ui
 
 func (m mockedPartitionedTopicMetadataRPCClient) Request(_ *url.URL, _ *url.URL, _ uint64,
 	_ pb.BaseCommand_Type, _ proto.Message) (*RPCResult, error) {
+	assert.Fail(m.t, "Shouldn't be called")
+	return nil, nil
+}
+
+func (m *mockedPartitionedTopicMetadataRPCClient) RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL,
+	cnxKeySuffix int32, _ uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
 	assert.Fail(m.t, "Shouldn't be called")
 	return nil, nil
 }

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -64,6 +64,9 @@ type RPCClient interface {
 	RequestToHost(serviceNameResolver *ServiceNameResolver, requestID uint64,
 		cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
 
+	RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL, cnxKeySuffix int32, requestID uint64,
+		cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
+
 	Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
 		cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error)
 
@@ -154,7 +157,12 @@ func (c *rpcClient) RequestToHost(serviceNameResolver *ServiceNameResolver, requ
 
 func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
 	cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
-	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr)
+	return c.RequestWithCnxKeySuffix(logicalAddr, physicalAddr, c.pool.GenerateRoundRobinIndex(), requestID, cmdType, message)
+}
+
+func (c *rpcClient) RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL, cnxKeySuffix int32,
+	requestID uint64, cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
+	cnx, err := c.pool.GetConnection(logicalAddr, physicalAddr, cnxKeySuffix)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsar/internal/rpc_client.go
+++ b/pulsar/internal/rpc_client.go
@@ -157,7 +157,8 @@ func (c *rpcClient) RequestToHost(serviceNameResolver *ServiceNameResolver, requ
 
 func (c *rpcClient) Request(logicalAddr *url.URL, physicalAddr *url.URL, requestID uint64,
 	cmdType pb.BaseCommand_Type, message proto.Message) (*RPCResult, error) {
-	return c.RequestWithCnxKeySuffix(logicalAddr, physicalAddr, c.pool.GenerateRoundRobinIndex(), requestID, cmdType, message)
+	return c.RequestWithCnxKeySuffix(logicalAddr, physicalAddr, c.pool.GenerateRoundRobinIndex(),
+		requestID, cmdType, message)
 }
 
 func (c *rpcClient) RequestWithCnxKeySuffix(logicalAddr *url.URL, physicalAddr *url.URL, cnxKeySuffix int32,

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2574,3 +2574,36 @@ func TestProducerKeepReconnectingAndThenCallClose(t *testing.T) {
 		return true
 	}, 30*time.Second, 1*time.Second)
 }
+
+func TestSelectConnectionForSameProducer(t *testing.T) {
+	topicName := newTopicName()
+
+	client, err := NewClient(ClientOptions{
+		URL:                     serviceURL,
+		MaxConnectionsPerBroker: 10,
+	})
+	assert.NoError(t, err)
+	defer client.Close()
+
+	reconnectNum := uint(1)
+	_producer, err := client.CreateProducer(ProducerOptions{
+		Topic:                topicName,
+		MaxReconnectToBroker: &reconnectNum,
+	})
+	assert.NoError(t, err)
+	defer _producer.Close()
+
+	partitionProducerImp := _producer.(*producer).producers[0].(*partitionProducer)
+	conn, ok := partitionProducerImp.conn.Load().(internal.Connection)
+	assert.True(t, ok, "Failed to assert connection type")
+
+	for i := 0; i < 5; i++ {
+		partitionProducerImp.grabCnx("")
+		currentConn, ok := partitionProducerImp.conn.Load().(internal.Connection)
+		assert.True(t, ok, "Failed to assert connection type")
+		assert.Equal(t, conn.ID(), currentConn.ID(),
+			"The producer uses a different connection when reconnecting")
+	}
+
+	client.Close()
+}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2594,13 +2594,11 @@ func TestSelectConnectionForSameProducer(t *testing.T) {
 	defer _producer.Close()
 
 	partitionProducerImp := _producer.(*producer).producers[0].(*partitionProducer)
-	conn, ok := partitionProducerImp.conn.Load().(internal.Connection)
-	assert.True(t, ok, "Failed to assert connection type")
+	conn := partitionProducerImp._getConn()
 
 	for i := 0; i < 5; i++ {
 		partitionProducerImp.grabCnx("")
-		currentConn, ok := partitionProducerImp.conn.Load().(internal.Connection)
-		assert.True(t, ok, "Failed to assert connection type")
+		currentConn := partitionProducerImp._getConn()
 		assert.Equal(t, conn.ID(), currentConn.ID(),
 			"The producer uses a different connection when reconnecting")
 	}


### PR DESCRIPTION
### Motivation

This is a catch up for https://github.com/apache/pulsar/pull/21144

When a producer or consumer reconnects, a random number will be generated as the key suffix in `ConnectionPool` to create or get the `Connection` object from the pool.


https://github.com/apache/pulsar-client-go/blob/ffba2a8fd2781f536bc03ec1408f82f6e4ea4d3a/pulsar/internal/connection_pool.go#L159-L160

### Modifications
- Change GetConnection() of connection_pool and add params: keySuffix
- Generate once keySuffix for consumer/producer when create it.
- When reconnecting, use this keySuffix to ensure obtaining the same connection

### Verifying this change
- Add TestSelectConnectionForSameConsumer and TestSelectConnectionForSameProducer to cover this.

