### PR TITLE
[improve] Update deliverAfter and deliverAt api comment

### DIFF
--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -56,14 +56,14 @@ type ProducerMessage struct {
 
 	// DeliverAfter requests to deliver the message only after the specified relative delay.
 	// Note: messages are only delivered with delay when a consumer is consuming
-	//     through a `SubscriptionType=Shared` subscription. With other subscription
-	//     types, the messages will still be delivered immediately.
+	//     through a `SubscriptionType=Shared` or `SubscriptionType=KeyShared` subscription.
+	//     With other subscription types, the messages will still be delivered immediately.
 	DeliverAfter time.Duration
 
 	// DeliverAt delivers the message only at or after the specified absolute timestamp.
 	// Note: messages are only delivered with delay when a consumer is consuming
-	//     through a `SubscriptionType=Shared` subscription. With other subscription
-	//     types, the messages will still be delivered immediately.
+	//     through a `SubscriptionType=Shared` or `SubscriptionType=KeyShared` subscription.
+	//     With other subscription types, the messages will still be delivered immediately.
 	DeliverAt time.Time
 
 	//Schema assign to the current message


### PR DESCRIPTION

### Contribution Checklist
Master Issue: https://github.com/apache/pulsar/issues/23968

### Motivation
Related Issue: https://github.com/apache/pulsar-site/pull/507

We now support consuming delayed messages with shared and Key-shared type subscriptions, which has been corrected since [pulsar 3.x doc](https://pulsar.apache.org/docs/3.0.x/concepts-messaging/#delayed-message-delivery) in above pr.

But Golang code `deliverAt` and `deliverAfter` comment says we can only support Shared type subscription, so that maybe we need to fix them.

### Modifications
Replace `SubscriptionType=Shared` comment with `SubscriptionType=Shared or SubscriptionType=KeyShared` in deliverAt and deliverAfter api.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
