### PR TITLE
Fix wrong result of reader.hasNext/Next after seeking by id or time

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -261,6 +261,7 @@ type ConsumerOptions struct {
 	SubscriptionMode SubscriptionMode
 
 	// StartMessageIDInclusive, if true, the consumer will start at the `StartMessageID`, included.
+	// Note: This configuration also affects the seek operation.
 	// Default is `false` and the consumer will start from the "next" message
 	StartMessageIDInclusive bool
 

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -88,7 +88,6 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 
 	if options.EnableZeroQueueConsumer {
 		options.ReceiverQueueSize = 0
-		options.StartMessageIDInclusive = true
 	}
 
 	if options.Interceptors == nil {

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -88,6 +88,7 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 
 	if options.EnableZeroQueueConsumer {
 		options.ReceiverQueueSize = 0
+		options.StartMessageIDInclusive = true
 	}
 
 	if options.Interceptors == nil {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -2230,7 +2230,7 @@ func (pc *partitionConsumer) hasNext() bool {
 	// If a seek by time has been performed, then the `startMessageId` becomes irrelevant.
 	// We need to compare `markDeletePosition` and `lastMessageId`,
 	// and then reset `startMessageID` to `markDeletePosition`.
-	if pc.hasSoughtByTime.CompareAndSwap(true, false) {
+	if pc.lastDequeuedMsg == nil && pc.hasSoughtByTime.CompareAndSwap(true, false) {
 		res, err := pc.getLastMessageIDAndMarkDeletePosition()
 		if err != nil {
 			pc.log.WithError(err).Error("Failed to get last message id")

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -2234,6 +2234,7 @@ func (pc *partitionConsumer) hasNext() bool {
 		res, err := pc.getLastMessageIDAndMarkDeletePosition()
 		if err != nil {
 			pc.log.WithError(err).Error("Failed to get last message id")
+			pc.hasSoughtByTime.CompareAndSwap(false, true)
 			return false
 		}
 		pc.lastMessageInBroker = res.msgID

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -190,9 +190,13 @@ type partitionConsumer struct {
 	backoffPolicyFunc    func() backoff.Policy
 
 	dispatcherSeekingControlCh chan struct{}
-	isSeeking                  atomic.Bool
-	ctx                        context.Context
-	cancelFunc                 context.CancelFunc
+	// handle to the dispatcher goroutine
+	isSeeking atomic.Bool
+	// After executing seekByTime, the client is unaware of the startMessageId.
+	// Use this flag to compare markDeletePosition with BrokerLastMessageId when checking hasMoreMessages.
+	hasSoughtByTime atomic.Bool
+	ctx             context.Context
+	cancelFunc      context.CancelFunc
 }
 
 // pauseDispatchMessage used to discard the message in the dispatcher goroutine.
@@ -429,11 +433,12 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 
 	startingMessageID := pc.startMessageID.get()
 	if pc.options.startMessageIDInclusive && startingMessageID != nil && startingMessageID.equal(latestMessageID) {
-		msgID, err := pc.requestGetLastMessageID()
+		msgIDResp, err := pc.requestGetLastMessageID()
 		if err != nil {
 			pc.Close()
 			return nil, err
 		}
+		msgID := convertToMessageID(msgIDResp.GetLastMessageId())
 		if msgID.entryID != noMessageEntry {
 			pc.startMessageID.set(msgID)
 
@@ -616,18 +621,27 @@ func (pc *partitionConsumer) internalUnsubscribe(unsub *unsubscribeRequest) {
 }
 
 func (pc *partitionConsumer) getLastMessageID() (*trackingMessageID, error) {
+	res, err := pc.getLastMessageIDAndMarkDeletePosition()
+	if err != nil {
+		return nil, err
+	}
+	return res.msgID, err
+}
+
+func (pc *partitionConsumer) getLastMessageIDAndMarkDeletePosition() (*getLastMsgResult, error) {
 	if state := pc.getConsumerState(); state == consumerClosed || state == consumerClosing {
 		pc.log.WithField("state", state).Error("Failed to getLastMessageID for the closing or closed consumer")
 		return nil, errors.New("failed to getLastMessageID for the closing or closed consumer")
 	}
 	bo := pc.backoffPolicyFunc()
-	request := func() (*trackingMessageID, error) {
+	request := func() (*getLastMsgResult, error) {
 		req := &getLastMsgIDRequest{doneCh: make(chan struct{})}
 		pc.eventsCh <- req
 
 		// wait for the request to complete
 		<-req.doneCh
-		return req.msgID, req.err
+		res := &getLastMsgResult{req.msgID, req.markDeletePosition}
+		return res, req.err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), pc.client.operationTimeout)
@@ -647,10 +661,16 @@ func (pc *partitionConsumer) getLastMessageID() (*trackingMessageID, error) {
 
 func (pc *partitionConsumer) internalGetLastMessageID(req *getLastMsgIDRequest) {
 	defer close(req.doneCh)
-	req.msgID, req.err = pc.requestGetLastMessageID()
+	rsp, err := pc.requestGetLastMessageID()
+	if err != nil {
+		req.err = err
+		return
+	}
+	req.msgID = convertToMessageID(rsp.GetLastMessageId())
+	req.markDeletePosition = convertToMessageID(rsp.GetConsumerMarkDeletePosition())
 }
 
-func (pc *partitionConsumer) requestGetLastMessageID() (*trackingMessageID, error) {
+func (pc *partitionConsumer) requestGetLastMessageID() (*pb.CommandGetLastMessageIdResponse, error) {
 	if state := pc.getConsumerState(); state == consumerClosed || state == consumerClosing {
 		pc.log.WithField("state", state).Error("Failed to getLastMessageID closing or closed consumer")
 		return nil, errors.New("failed to getLastMessageID closing or closed consumer")
@@ -667,8 +687,7 @@ func (pc *partitionConsumer) requestGetLastMessageID() (*trackingMessageID, erro
 		pc.log.WithError(err).Error("Failed to get last message id")
 		return nil, err
 	}
-	id := res.Response.GetLastMessageIdResponse.GetLastMessageId()
-	return convertToMessageID(id), nil
+	return res.Response.GetLastMessageIdResponse, nil
 }
 
 func (pc *partitionConsumer) sendIndividualAck(msgID MessageID) *ackRequest {
@@ -997,7 +1016,15 @@ func (pc *partitionConsumer) requestSeek(msgID *messageID) error {
 	if err := pc.requestSeekWithoutClear(msgID); err != nil {
 		return err
 	}
-	pc.clearReceiverQueue()
+	// When the seek operation is successful, it indicates:
+	// 1. The broker has reset the cursor and sent a request to close the consumer on the client side.
+	//    Since this method is in the same goroutine as the reconnectToBroker,
+	//    we can safely clear the messages in the queue (at this point, it won't contain messages after the seek).
+	// 2. The startMessageID is reset to ensure accurate judgment when calling hasNext next time.
+	//    Since the messages in the queue are cleared here reconnection won't reset startMessageId.
+	pc.lastDequeuedMsg = nil
+	pc.startMessageID.set(toTrackingMessageID(msgID))
+	pc.clearQueueAndGetNextMessage()
 	return nil
 }
 
@@ -1069,7 +1096,9 @@ func (pc *partitionConsumer) internalSeekByTime(seek *seekByTimeRequest) {
 		seek.err = err
 		return
 	}
-	pc.clearReceiverQueue()
+	pc.lastDequeuedMsg = nil
+	pc.hasSoughtByTime.Store(true)
+	pc.clearQueueAndGetNextMessage()
 }
 
 func (pc *partitionConsumer) internalAck(req *ackRequest) {
@@ -1451,10 +1480,6 @@ func (pc *partitionConsumer) messageShouldBeDiscarded(msgID *trackingMessageID) 
 	if pc.startMessageID.get() == nil {
 		return false
 	}
-	// if we start at latest message, we should never discard
-	if pc.options.startMessageID != nil && pc.options.startMessageID.equal(latestMessageID) {
-		return false
-	}
 
 	if pc.options.startMessageIDInclusive {
 		return pc.startMessageID.get().greater(msgID.messageID)
@@ -1709,9 +1734,15 @@ type redeliveryRequest struct {
 }
 
 type getLastMsgIDRequest struct {
-	doneCh chan struct{}
-	msgID  *trackingMessageID
-	err    error
+	doneCh             chan struct{}
+	msgID              *trackingMessageID
+	markDeletePosition *trackingMessageID
+	err                error
+}
+
+type getLastMsgResult struct {
+	msgID              *trackingMessageID
+	markDeletePosition *trackingMessageID
 }
 
 type seekRequest struct {
@@ -2195,6 +2226,24 @@ func (pc *partitionConsumer) discardCorruptedMessage(msgID *pb.MessageIdData,
 }
 
 func (pc *partitionConsumer) hasNext() bool {
+
+	// If a seek by time has been performed, then the `startMessageId` becomes irrelevant.
+	// We need to compare `markDeletePosition` and `lastMessageId`,
+	// and then reset `startMessageID` to `markDeletePosition`.
+	if pc.hasSoughtByTime.CompareAndSwap(true, false) {
+		res, err := pc.getLastMessageIDAndMarkDeletePosition()
+		if err != nil {
+			pc.log.WithError(err).Error("Failed to get last message id")
+			return false
+		}
+		pc.lastMessageInBroker = res.msgID
+		pc.startMessageID.set(res.markDeletePosition)
+		// We only care about comparing ledger ids and entry ids as mark delete position
+		// doesn't have other ids such as batch index
+		compareResult := pc.lastMessageInBroker.messageID.compareLedgerAndEntryID(pc.startMessageID.get().messageID)
+		return compareResult > 0 || (pc.options.startMessageIDInclusive && compareResult == 0)
+	}
+
 	if pc.lastMessageInBroker != nil && pc.hasMoreMessages() {
 		return true
 	}
@@ -2256,12 +2305,14 @@ func convertToMessageID(id *pb.MessageIdData) *trackingMessageID {
 
 	msgID := &trackingMessageID{
 		messageID: &messageID{
-			ledgerID: int64(*id.LedgerId),
-			entryID:  int64(*id.EntryId),
+			ledgerID:  int64(id.GetLedgerId()),
+			entryID:   int64(id.GetEntryId()),
+			batchIdx:  -1,
+			batchSize: id.GetBatchSize(),
 		},
 	}
-	if id.BatchIndex != nil {
-		msgID.batchIdx = *id.BatchIndex
+	if id.GetBatchSize() > 1 {
+		msgID.batchIdx = id.GetBatchIndex()
 	}
 
 	return msgID

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -1262,8 +1262,9 @@ func TestConsumerSeek(t *testing.T) {
 	defer producer.Close()
 
 	consumer, err := client.Subscribe(ConsumerOptions{
-		Topic:            topicName,
-		SubscriptionName: "sub-1",
+		Topic:                   topicName,
+		SubscriptionName:        "sub-1",
+		StartMessageIDInclusive: true,
 	})
 	assert.Nil(t, err)
 	defer consumer.Close()

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -474,6 +474,7 @@ func TestZeroQueueConsumer_Seek(t *testing.T) {
 		Topic:                   topicName,
 		EnableZeroQueueConsumer: true,
 		SubscriptionName:        "sub-1",
+		StartMessageIDInclusive: true,
 	})
 	assert.Nil(t, err)
 	_, ok := consumer.(*zeroQueueConsumer)

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -212,9 +212,6 @@ func deserializeMessageID(data []byte) (MessageID, error) {
 }
 
 func newMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32, batchSize int32) MessageID {
-	if batchSize <= 1 {
-		batchIdx = -1
-	}
 	return &messageID{
 		ledgerID:     ledgerID,
 		entryID:      entryID,
@@ -236,9 +233,6 @@ func fromMessageID(msgID MessageID) *messageID {
 
 func newTrackingMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32, batchSize int32,
 	tracker *ackTracker) *trackingMessageID {
-	if batchSize <= 1 {
-		batchIdx = -1
-	}
 	return &trackingMessageID{
 		messageID: &messageID{
 			ledgerID:     ledgerID,

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"math"
@@ -147,6 +148,13 @@ func (id *messageID) equal(other *messageID) bool {
 		id.batchIdx == other.batchIdx
 }
 
+func (id *messageID) compareLedgerAndEntryID(other *messageID) int {
+	if result := cmp.Compare(id.ledgerID, other.ledgerID); result != 0 {
+		return result
+	}
+	return cmp.Compare(id.entryID, other.entryID)
+}
+
 func (id *messageID) greaterEqual(other *messageID) bool {
 	return id.equal(other) || id.greater(other)
 }
@@ -204,6 +212,9 @@ func deserializeMessageID(data []byte) (MessageID, error) {
 }
 
 func newMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32, batchSize int32) MessageID {
+	if batchSize <= 1 {
+		batchIdx = -1
+	}
 	return &messageID{
 		ledgerID:     ledgerID,
 		entryID:      entryID,
@@ -225,6 +236,9 @@ func fromMessageID(msgID MessageID) *messageID {
 
 func newTrackingMessageID(ledgerID int64, entryID int64, batchIdx int32, partitionIdx int32, batchSize int32,
 	tracker *ackTracker) *trackingMessageID {
+	if batchSize <= 1 {
+		batchIdx = -1
+	}
 	return &trackingMessageID{
 		messageID: &messageID{
 			ledgerID:     ledgerID,

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -53,6 +53,7 @@ type ReaderOptions struct {
 	StartMessageID MessageID
 
 	// StartMessageIDInclusive, if true, the reader will start at the `StartMessageID`, included.
+	// Note: This configuration also affects the seek operation.
 	// Default is `false` and the reader will start from the "next" message
 	StartMessageIDInclusive bool
 

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -1096,7 +1096,6 @@ func testReaderSeekByIDWithHasNext(t *testing.T, startMessageID MessageID, start
 		lastMsgID, err = producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		})
-		fmt.Println(lastMsgID.String())
 		assert.NoError(t, err)
 		assert.NotNil(t, lastMsgID)
 	}
@@ -1133,10 +1132,22 @@ func testReaderSeekByIDWithHasNext(t *testing.T, startMessageID MessageID, start
 }
 
 func TestReaderWithSeekByID(t *testing.T) {
-	testReaderSeekByIDWithHasNext(t, EarliestMessageID(), false)
-	testReaderSeekByIDWithHasNext(t, EarliestMessageID(), true)
-	testReaderSeekByIDWithHasNext(t, LatestMessageID(), false)
-	testReaderSeekByIDWithHasNext(t, LatestMessageID(), true)
+	params := []struct {
+		messageID               MessageID
+		startMessageIDInclusive bool
+	}{
+		{EarliestMessageID(), false},
+		{EarliestMessageID(), true},
+		{LatestMessageID(), false},
+		{LatestMessageID(), true},
+	}
+
+	for _, c := range params {
+		t.Run(fmt.Sprintf("TestReaderSeekByID_%v_%v", c.messageID, c.startMessageIDInclusive),
+			func(t *testing.T) {
+				testReaderSeekByIDWithHasNext(t, c.messageID, c.startMessageIDInclusive)
+			})
+	}
 }
 
 func testReaderSeekByTimeWithHasNext(t *testing.T, startMessageID MessageID) {
@@ -1164,7 +1175,6 @@ func testReaderSeekByTimeWithHasNext(t *testing.T, startMessageID MessageID) {
 		lastMsgID, err = producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		})
-		fmt.Println(lastMsgID.String())
 		assert.NoError(t, err)
 
 		assert.NotNil(t, lastMsgID)
@@ -1197,7 +1207,6 @@ func testReaderSeekByTimeWithHasNext(t *testing.T, startMessageID MessageID) {
 		lastMsgID, err = producer.Send(ctx, &ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello2-%d", i)),
 		})
-		fmt.Println(lastMsgID.String())
 		assert.NoError(t, err)
 		assert.NotNil(t, lastMsgID)
 	}
@@ -1221,8 +1230,10 @@ func testReaderSeekByTimeWithHasNext(t *testing.T, startMessageID MessageID) {
 	}
 }
 func TestReaderWithSeekByTime(t *testing.T) {
-	testReaderSeekByTimeWithHasNext(t, EarliestMessageID())
-	testReaderSeekByTimeWithHasNext(t, EarliestMessageID())
-	testReaderSeekByTimeWithHasNext(t, LatestMessageID())
-	testReaderSeekByTimeWithHasNext(t, LatestMessageID())
+	startMessageIDs := []MessageID{EarliestMessageID(), LatestMessageID()}
+	for _, startMsgID := range startMessageIDs {
+		t.Run(fmt.Sprintf("TestReaderSeekByTime_%v", startMsgID), func(t *testing.T) {
+			testReaderSeekByTimeWithHasNext(t, startMsgID)
+		})
+	}
 }

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -1070,3 +1070,159 @@ func TestReaderNextReturnsOnClosedConsumer(t *testing.T) {
 	assert.ErrorAs(t, err, &e)
 	assert.Equal(t, ConsumerClosed, e.Result())
 }
+
+func testReaderSeekByIDWithHasNext(t *testing.T, startMessageID MessageID, startMessageIDInclusive bool) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	ctx := context.Background()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// send 100 messages
+	var lastMsgID MessageID
+	for i := 0; i < 10; i++ {
+		lastMsgID, err = producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		})
+		fmt.Println(lastMsgID.String())
+		assert.NoError(t, err)
+		assert.NotNil(t, lastMsgID)
+	}
+
+	reader, err := client.CreateReader(ReaderOptions{
+		Topic:                   topic,
+		StartMessageID:          startMessageID,
+		StartMessageIDInclusive: startMessageIDInclusive,
+	})
+	assert.Nil(t, err)
+	defer reader.Close()
+
+	// Seek to last message ID
+	err = reader.Seek(lastMsgID)
+	assert.NoError(t, err)
+
+	if startMessageIDInclusive {
+		assert.True(t, reader.HasNext())
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		msg, err := reader.Next(ctx)
+		assert.NoError(t, err)
+		assert.NotNil(t, msg)
+		assert.True(t, messageIDCompare(lastMsgID, msg.ID()) == 0)
+		cancel()
+	} else {
+		assert.False(t, reader.HasNext())
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		msg, err := reader.Next(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, msg)
+		cancel()
+	}
+
+}
+
+func TestReaderWithSeekByID(t *testing.T) {
+	testReaderSeekByIDWithHasNext(t, EarliestMessageID(), false)
+	testReaderSeekByIDWithHasNext(t, EarliestMessageID(), true)
+	testReaderSeekByIDWithHasNext(t, LatestMessageID(), false)
+	testReaderSeekByIDWithHasNext(t, LatestMessageID(), true)
+}
+
+func testReaderSeekByTimeWithHasNext(t *testing.T, startMessageID MessageID) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	ctx := context.Background()
+
+	// create producer
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	// 1. send 10 messages
+	var lastMsgID MessageID
+	for i := 0; i < 10; i++ {
+		lastMsgID, err = producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		})
+		fmt.Println(lastMsgID.String())
+		assert.NoError(t, err)
+
+		assert.NotNil(t, lastMsgID)
+	}
+
+	// 2. create reader
+	reader, err := client.CreateReader(ReaderOptions{
+		Topic:                   topic,
+		StartMessageID:          startMessageID,
+		StartMessageIDInclusive: false,
+	})
+	assert.Nil(t, err)
+	defer reader.Close()
+
+	// 3. Seek time to now
+	reader.SeekByTime(time.Now())
+
+	// 4. Should not receive msg
+	{
+		assert.False(t, reader.HasNext())
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		msg, err := reader.Next(timeoutCtx)
+		assert.Error(t, err)
+		assert.Nil(t, msg)
+		cancel()
+	}
+
+	// 5. send more 10 messages
+	for i := 0; i < 10; i++ {
+		lastMsgID, err = producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello2-%d", i)),
+		})
+		fmt.Println(lastMsgID.String())
+		assert.NoError(t, err)
+		assert.NotNil(t, lastMsgID)
+	}
+
+	// 6. Assert these messages are received
+	for i := 0; i < 10; i++ {
+		assert.True(t, reader.HasNext())
+		msg, err := reader.Next(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("hello2-%d", i), string(msg.Payload()))
+	}
+
+	// assert not more msg
+	{
+		assert.False(t, reader.HasNext())
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		msg, err := reader.Next(timeoutCtx)
+		assert.Error(t, err)
+		assert.Nil(t, msg)
+		cancel()
+	}
+}
+func TestReaderWithSeekByTime(t *testing.T) {
+	testReaderSeekByTimeWithHasNext(t, EarliestMessageID())
+	testReaderSeekByTimeWithHasNext(t, EarliestMessageID())
+	testReaderSeekByTimeWithHasNext(t, LatestMessageID())
+	testReaderSeekByTimeWithHasNext(t, LatestMessageID())
+}


### PR DESCRIPTION
There are **three attributes** to handle seek/filter/subscribe for Reader.

1. `startMessageID`: The start message ID, which can be specified by the user when creating the reader. It can be set to a specific position, or to the `earliest` or `latest`. When creating a consumer, this is [set in the request](https://github.com/apache/pulsar-client-go/blob/9aeeb4e7bbfcaa4039d66ab2857888be2d6fcaf3/pulsar/consumer_partition.go#L1979), and the broker uses it to set mark delete position.
2. `lastDequeuedMsg`: The most recent message dispatched from the consumer's internal queue to the user. **If it's nil, it means no messages have been delivered to the user. If there is a value, it indicates the user has consumed up to this point.**
3. `lastMessageInBroker`: The ID of the last message in the topic on the broker.

### Question-1: How to determine hasNext?

[Refer to this code](https://github.com/apache/pulsar-client-go/blob/9aeeb4e7bbfcaa4039d66ab2857888be2d6fcaf3/pulsar/consumer_partition.go#L2224)

In simple terms, to minimize interaction with the broker:

1. If `lastDequeuedMsg` has a value, it clearly indicates consumption up to this position. Compare this `lastDequeuedMsg with lastMessageInBroker`.
2. If there is no value, compare `startMessageID with lastMessageInBroker`.

The final comparison result, **if true**, indicates there really are messages. **If false**, it doesn’t necessarily mean there are no messages, because `lastMessageInBroker` is a cache, and the topic may have more messages already written. Therefore, **lastMessageInBroker is updated from the broker again for reevaluation**

### Question-2: What happens when the consumer reconnects?

When the consumer reconnects, it clears all messages in the `receive queue` and **updates startMessageId with the first message in the queue**. This indicates that the user has been consumed up to this position.



### !!! The above logic works well without a seek operation, but once the user calls a seek operation, the situation becomes special.

### Question-3: How does the seek operation work?

**For the broker:**
When the client sends a seek request to the broker, the broker will do the following:
1. Rewind the cursor to the seek position (ID or time).
2. Send a close request to the consumer.
3. Send a respond that the seek operation is complete.

**For the client:**
1. Send a seek request. Wait for the broker to respond that the seek is complete
2. Set `lastDequeuedMsg` to null because after seeking, this value will be invalid. **(Tip: Currently missing, this PR fixes it.)**
3. Clear the queue to avoid resetting `startMessageId` to the first position of the queue upon reconnection. **(Tip: Currently missing, this PR fixes it.)**
4. If seekByID:
    - If the passed ID is a specific position or earliest, set startMessageId to seek Id. **(Tip: Currently missing, this PR fixes it.)**
    - If the passed ID is latest, obtain the topic `lastMessageId` and set startMessageId to it. **(Tip: Currently missing, a separate PR will fix this later as it [currently doesn’t support directly passing latest id](https://github.com/apache/pulsar-client-go/blob/9aeeb4e7bbfcaa4039d66ab2857888be2d6fcaf3/pulsar/reader_impl.go#L210-L214).)**
5. If seekByTime, the client doesn’t know the messageId corresponding to the time during the seek, it needs to call getLastMessageId and set markdeleteposition to startMessageId. **(Tip: Currently missing, this PR fixes it.)**
6. Seek complete, then return to the user.
7. BTW: Actually, this is just the completion of the seek operation. The real completion requires waiting for the consumer to successfully reconnect to the broker, but this happens in the background and the user doesn't need to be concerned about it. Also, **note that we don't need to wait for the consumer to reconnect to the broker before returning the seek completion to the client**, because when the broker responds that the seek is complete, **it has already reset the cursor.** After the client receives the response, it has cleared the queue, so no previous messages will come in. In extremely rare cases (**where data from the old connection's buffer re-enters the queue after clearing**), [we will filter these messages using startMessageId to filter message ID](https://github.com/apache/pulsar-client-go/blob/9aeeb4e7bbfcaa4039d66ab2857888be2d6fcaf3/pulsar/consumer_partition.go#L1475-L1486).


### Modifications

You can run tests `TestReaderWithSeekByID` and `TestReaderWithSeekByTime` to understand the user-side issues fixed by this PR. Simply put, after seeking, calling `hasNext`, `Next` again should meet expectations.



### Verifying this change
1. Add TestReaderWithSeekByID and TestReaderWithSeekByTime to cover this change.
2. I did not change any other test, other tests passed mean not introducing any break change.


### Does this pull request potentially affect one of the following parts:
- No

### Documentation
- No