### PR TITLE
Improve message decompress error

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -2147,7 +2147,8 @@ func (pc *partitionConsumer) Decompress(msgMeta *pb.MessageMetadata, payload int
 
 	uncompressed, err := provider.Decompress(nil, payload.ReadableSlice(), int(msgMeta.GetUncompressedSize()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to decompress message: %w, compression type: %d, payload size: %d, uncompressed size: %d",
+		return nil, fmt.Errorf("failed to decompress message: %w, compression type: %d, payload size: %d, "+
+			"uncompressed size: %d",
 			err,
 			msgMeta.GetCompression(),
 			len(payload.ReadableSlice()),

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -2147,7 +2147,11 @@ func (pc *partitionConsumer) Decompress(msgMeta *pb.MessageMetadata, payload int
 
 	uncompressed, err := provider.Decompress(nil, payload.ReadableSlice(), int(msgMeta.GetUncompressedSize()))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decompress message: %w, compression type: %d, payload size: %d, uncompressed size: %d",
+			err,
+			msgMeta.GetCompression(),
+			len(payload.ReadableSlice()),
+			msgMeta.GetUncompressedSize())
 	}
 
 	return internal.NewBufferWrapper(uncompressed), nil


### PR DESCRIPTION
### Motivation

Improve the error for the message decompress to include more useful information.
The error log would be :
```
level=error msg="handle message Id: ledgerId:5  entryId:0  partition:-1" consumerID=1 error="failed to decompress message: some error, compression type: 1, payload size: 4, uncompressed size: 4" local_addr="127.0.0.1:49301" remote_addr="pulsar://localhost:6650"

```


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
