### PR TITLE
fix: use sha instead of tag for golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check license header
         run: docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 check
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
           version: v1.61.0
 


### PR DESCRIPTION
### Motivation

Because of the ASF policy, the CI cannot use `golangci/golangci-lint-action@v6`, it has been fixed by https://github.com/apache/infrastructure-actions/pull/142.

```
golangci/golangci-lint-action@v6 is not allowed to be used in apache/pulsar-client-go. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: 1Password/load-secrets-action@*, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8, DavidAnson/markdownlint-cli2-action@v16, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29, JamesIves/github-pages-deploy-action@v4.6.8, JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d, JustinBeckwith/linkinator-action@v1.11.0, Kesin11/actions-timeline@427ee2cf860166e404d0d69b4f2b24012bb7af4f, Madrapps/jacoco-report@fd4800e8a81e21bdf373438e5918b975df041d15, PyO3/maturin-action@*, TobKed/label-when-approved-action@*, VirtusLab/scala-cli-setup@ef3764b372549ee...Show less
```

### Modifications

- Use sha instead of tag for golangci/golangci-lint-action.