### PR TITLE
[improve] Make ZTS proxy configurable in athenz auth plugin

### DIFF
--- a/pulsar/auth/athenz.go
+++ b/pulsar/auth/athenz.go
@@ -50,6 +50,7 @@ type athenzAuthProvider struct {
 	principalHeader         string
 	roleHeader              string
 	ztsURL                  string
+	ztsProxyURL             string
 	tokenBuilder            zms.TokenBuilder
 	roleToken               zts.RoleToken
 	zmsNewTokenBuilder      func(domain, name string, privateKeyPEM []byte, keyVersion string) (zms.TokenBuilder, error)
@@ -78,6 +79,7 @@ func NewAuthenticationAthenzWithParams(params map[string]string) (Provider, erro
 		params["principalHeader"],
 		params["roleHeader"],
 		params["ztsUrl"],
+		params["ztsProxyUrl"],
 	), nil
 }
 
@@ -91,7 +93,8 @@ func NewAuthenticationAthenz(
 	caCert string,
 	principalHeader string,
 	roleHeader string,
-	ztsURL string) Provider {
+	ztsURL string,
+	ztsProxyURL string) Provider {
 	fixedKeyID := defaultKeyID
 	if keyID != "" {
 		fixedKeyID = keyID
@@ -121,6 +124,7 @@ func NewAuthenticationAthenz(
 		principalHeader:         principalHeader,
 		roleHeader:              fixedRoleHeader,
 		ztsURL:                  strings.TrimSuffix(ztsURL, "/"),
+		ztsProxyURL:             ztsProxyURL,
 		zmsNewTokenBuilder:      zms.NewTokenBuilder,
 		ztsNewRoleToken:         ztsNewRoleToken,
 		ztsNewRoleTokenFromCert: ztsNewRoleTokenFromCert,
@@ -135,6 +139,7 @@ func (p *athenzAuthProvider) Init() error {
 	var roleToken zts.RoleToken
 	opts := zts.RoleTokenOptions{
 		BaseZTSURL:       p.ztsURL + "/zts/v1",
+		ProxyURL:         p.ztsProxyURL,
 		MinExpire:        minExpire,
 		MaxExpire:        maxExpire,
 		PrefetchInterval: prefetchInterval,


### PR DESCRIPTION
### Motivation

The Athenz auth plugin obtains a role token from the ZTS server to be used for authentication. Depending on the user's environment, it may be necessary to access ZTS through a proxy, but currently the proxy URL is not configurable via the auth plugin.

### Modifications

Modified the Athenz auth plugin to enable users to configure the proxy URL for ZTS. Proxy configuration is supported in v1.12.8 and later of the Athenz library.
https://github.com/AthenZ/athenz/pull/2841

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
  - If a feature is not applicable for documentation, explain why?
    - Once this PR is merged, I'm going to send a PR to https://github.com/apache/pulsar-site to update the documentation.