### PR TITLE
[improve] Add testcase to test using keyShared subscription and delayed messages at the same time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ bin/golangci-lint:
 # use golangCi-lint docker to avoid local golang env issues
 # https://golangci-lint.run/welcome/install/
 lint-docker:
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.51.2 golangci-lint run -v
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.61.0 golangci-lint run -v
 
 container:
 	docker build -t ${IMAGE_NAME} \


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar/issues/23968 
Related pr: https://github.com/apache/pulsar-client-go/pull/1339

### Motivation
Refered to pr [comment](https://github.com/apache/pulsar-client-go/pull/1339#issuecomment-2712819343), there is no test cases about using keyShared subscription mode to consume delayed messages, so that maybe we need to add one.


### Modifications
Add `pulsar/consumer_test/TestConsumerKeySharedWithDelayedMessages` test case.

### Verifying this change
- [x] Make sure that the change passes the CI checks.
This change added tests and can be verified.

### Does this pull request potentially affect one of the following parts:
*If `yes` was chosen, please highlight the changes*
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
