### PR TITLE
chore: replace deprecated api rand.Seed

### DIFF
--- a/pulsar/internal/service_name_resolver.go
+++ b/pulsar/internal/service_name_resolver.go
@@ -43,15 +43,12 @@ type pulsarServiceNameResolver struct {
 	CurrentIndex int32
 	AddressList  []*url.URL
 
+	rnd   *rand.Rand
 	mutex sync.Mutex
 }
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 func NewPulsarServiceNameResolver(url *url.URL) ServiceNameResolver {
-	r := &pulsarServiceNameResolver{}
+	r := &pulsarServiceNameResolver{rnd: rand.New(rand.NewSource(time.Now().UnixNano()))}
 	err := r.UpdateServiceURL(url)
 	if err != nil {
 		log.Errorf("create pulsar service name resolver failed : %v", err)
@@ -94,7 +91,7 @@ func (r *pulsarServiceNameResolver) UpdateServiceURL(u *url.URL) error {
 	}
 
 	hosts := uri.ServiceHosts
-	addresses := []*url.URL{}
+	var addresses []*url.URL
 	for _, host := range hosts {
 		hostURL := uri.URL.Scheme + "://" + host
 		u, err := url.Parse(hostURL)
@@ -111,7 +108,7 @@ func (r *pulsarServiceNameResolver) UpdateServiceURL(u *url.URL) error {
 	r.AddressList = addresses
 	r.ServiceURL = u
 	r.ServiceURI = uri
-	r.CurrentIndex = int32(rand.Intn(len(addresses)))
+	r.CurrentIndex = int32(r.rnd.Intn(len(addresses)))
 	return nil
 }
 

--- a/pulsar/internal/service_name_resolver.go
+++ b/pulsar/internal/service_name_resolver.go
@@ -91,7 +91,7 @@ func (r *pulsarServiceNameResolver) UpdateServiceURL(u *url.URL) error {
 	}
 
 	hosts := uri.ServiceHosts
-	var addresses []*url.URL
+	addresses := []*url.URL{}
 	for _, host := range hosts {
 		hostURL := uri.URL.Scheme + "://" + host
 		u, err := url.Parse(hostURL)


### PR DESCRIPTION
### Motivation
The Go 1.20 release deprecated the `rand.Seed` function, noting that programs should use the `rand.New(rand.NewSource(seed))` method instead. This change was made because using `rand.Seed` affects the global random number generator, which can lead to unexpected behavior in concurrent programs. By updating to the recommended API, we improve the code's forward compatibility and follow Go's best practices for random number generation.

### Modifications
Replaced all occurrences of `rand.Seed(time.Now().UnixNano())` with `rand.New(rand.NewSource(time.Now().UnixNano()))`

Updated variable assignments to use the new random generator instance where applicable

Maintained the same seed behavior (using current nanosecond time) but now with proper instance isolation

Verifying this change
Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. The modification doesn't change the logical behavior of the code, only updates it to use the non-deprecated API.
