### PR TITLE
Fix reader hanging when startMessageId is latest

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1986,6 +1986,7 @@ func (pc *partitionConsumer) grabConn(assignedBrokerURL string) error {
 
 	if seekMsgID := pc.seekMessageID.get(); seekMsgID != nil {
 		pc.startMessageID.set(seekMsgID)
+		pc.seekMessageID.set(nil) // Reset seekMessageID to nil to avoid persisting state across reconnects
 	} else {
 		pc.startMessageID.set(pc.clearReceiverQueue())
 	}

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -159,8 +159,11 @@ type partitionConsumer struct {
 	maxQueueSize    int32
 	queueCh         chan []*message
 	startMessageID  atomicMessageID
-	seekMessageID   atomicMessageID
 	lastDequeuedMsg *trackingMessageID
+
+	// This is used to track the seeking message id during the seek operation.
+	// It will be set to nil after seek completes and reconnected.
+	seekMessageID atomicMessageID
 
 	currentQueueSize       uAtomic.Int32
 	scaleReceiverQueueHint uAtomic.Bool

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1984,8 +1984,8 @@ func (pc *partitionConsumer) grabConn(assignedBrokerURL string) error {
 		KeySharedMeta:              keySharedMeta,
 	}
 
-	if seekMsgId := pc.seekMessageID.get(); seekMsgId != nil {
-		pc.startMessageID.set(seekMsgId)
+	if seekMsgID := pc.seekMessageID.get(); seekMsgID != nil {
+		pc.startMessageID.set(seekMsgID)
 	} else {
 		pc.startMessageID.set(pc.clearReceiverQueue())
 	}

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -1246,7 +1246,7 @@ func TestReaderReadFromLatest(t *testing.T) {
 		URL: lookupURL,
 	})
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	defer client.Close()
 
 	r, err := client.CreateReader(ReaderOptions{


### PR DESCRIPTION
### Motivation

The Go client version 0.15.0 introduced a regression bug. If the reader's `startMessageId` is set to the latest, it will hang while reading. This issue can be reproduced using the new test case: `TestReaderReadFromLatest`.

### Modifications

The root cause is a change in behavior from before version 0.15.0. Previously, the consumer would avoid discarding messages if `startMessageId` was set to Latest. This logic was altered in this pull request: https://github.com/apache/pulsar-client-go/pull/1340/files#diff-782cf41d23c24657ede53da5d028f05819b302305ed676c61322b4cfba4265e9L1454-L1457

The following logic was removed:

```go
// if we start at latest message, we should never discard
if pc.options.startMessageID != nil && pc.options.startMessageID.equal(latestMessageID) {
    return false
}
```

In version 0.15.0, if `startMessageId` is Latest, the reader won't receive any messages because all message IDs are before the latest and will be discarded. We need to reinstate this check.

For the seek operation, the correct approach is:

- When handling a seek request, the consumer should set the `seekMessageId` before reconnecting.
- After reconnecting, the consumer should check if `seekMessageId` exists. If it does, it indicates the consumer is seeking, and `seekMessageId` should be set as `startMessageId`. This ensures that even if the reader's `startMessageId` is Latest, it won't receive messages before the specified seek message ID, maintaining the correct behavior as intended in this [PR](https://github.com/apache/pulsar-client-go/pull/1340).


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
