### PR TITLE
Fix:The producer is sometimes blocked when calling producer.SendAsync

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1476,7 +1476,8 @@ func (p *partitionProducer) failPendingMessages(err error) {
 		return
 	}
 
-	//fixbug: don't repeated call cb when producer is closed
+	// fixbug: don't repeated call cb when producer is closed
+	// the cb funciton is calling by pi.sendRequests.done
 	state := p.getProducerState()
 	if state == producerClosing || state == producerClosed {
 		return

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1475,6 +1475,13 @@ func (p *partitionProducer) failPendingMessages(err error) {
 	if viewSize <= 0 {
 		return
 	}
+
+	//fixbug: don't repeated call cb when producer is closed
+	state := p.getProducerState()
+	if state == producerClosing || state == producerClosed {
+		return
+	}
+
 	p.log.Infof("Failing %d messages on closing producer", viewSize)
 	lastViewItem := curViewItems[viewSize-1].(*pendingItem)
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Fixes #1365 


### Motivation
Go version: 1.23
pulsar-client-go verson: 0.14

When calling producer.SendAsync  is blocked.

### Modifications

When calling producer.SendAsync to produce a message, an error occurs. The producer.Close is called in the callback of SendAsync.

In the SendAsync function, the failed messages are traversed and a callback is called for each message, which will cause a deadlock with the close producer call.

```
	state := p.getProducerState()
	if state == producerClosing || state == producerClosed {
		return
	}
```

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
