### PR TITLE
[Issue 1371][producer] Put buffer back in pool only when safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 *.out
 coverage.html
 
-perf/perf
-pulsar-perf
-bin
-
+perf/perf/
+pulsar-perf/
+bin/
+logs/
 vendor/

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1743,14 +1743,21 @@ func (i *pendingItem) done(err error) {
 	}
 
 	i.isDone = true
-	// return the buffer to the pool after all callbacks have been called.
-	defer buffersPool.Put(i.buffer)
+
 	if i.flushCallback != nil {
 		i.flushCallback(err)
 	}
 
 	if i.cancel != nil {
 		i.cancel()
+	}
+
+	if err == nil {
+		// Buffer is returned after executing all the callbacks and only if the
+		// pending item is successful because that is the only state that ensure
+		// a finality of the buffer at that time (an erroneuous item might still
+		// be in the connection sending queue).
+		buffersPool.Put(i.buffer)
 	}
 }
 


### PR DESCRIPTION
Fixes #1371 

### Motivation

Some buffer ends up in two go routines, one reading to write to the connection and another one that writes a new message. This happens because the buffer is released without any guarantee that the connection is done with it.

### Modifications

This adds a check to reuse the buffer only when the sending request is successful which means that a receipt has been received and thus that the buffer has been already read. Any error when finalizing the pending item is a risk of the buffer being not completely done.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
