### PR TITLE
Fix the staging release process

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,10 +51,10 @@ git push origin v0.X.0-candidate-1
 
 3. Build and inspect an artifact.
 
-Stage and sigh the release artifacts.
+Stage and sign the release artifacts.
 
 ```bash
-$ VERSION=0.x.0 ./scripts/stage-release.sh .
+$ ./scripts/stage-release.sh 0.X.0 .
 ```
 
 Checkout repo for uploading artifacts

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,19 +51,10 @@ git push origin v0.X.0-candidate-1
 
 3. Build and inspect an artifact.
 
-Generate a release candidate package.
+Stage and sigh the release artifacts.
 
 ```bash
-$ tar -zcvf apache-pulsar-client-go-0.X.0-src.tar.gz .
-```
-
-4. Sign and stage the artifacts 
-
-The src artifact need to be signed and uploaded to the dist SVN repository for staging.
-
-```
-$ gpg -b --armor apache-pulsar-client-go-0.X.0-src.tar.gz
-$ shasum -a 512 apache-pulsar-client-go-0.X.0-src.tar.gz > apache-pulsar-client-go-0.X.0-src.tar.gz.sha512 
+$ VERSION=0.x.0 ./scripts/stage-release.sh .
 ```
 
 Checkout repo for uploading artifacts

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e -x
+
+if [ $# -eq 0 ]; then
+    echo "Required argument with destination directory"
+    exit 1
+fi
+
+if [ -z "$VERSION" ]; then
+    echo "VERSION is not defined. Please set the VERSION environment variable."
+    exit 1
+fi
+
+
+DEST_PATH=$1
+DEST_PATH="$(cd "$DEST_PATH" && pwd)"
+
+pushd $(dirname "$0")
+REPO_PATH=$(git rev-parse --show-toplevel)
+popd
+
+pushd $REPO_PATH
+git archive --format=tar.gz --output="$DEST_PATH/apache-pulsar-client-go-$VERSION-src.tar.gz" HEAD
+popd
+
+# Sign all files
+cd $DEST_PATH
+gpg -b --armor apache-pulsar-client-go-$VERSION-src.tar.gz
+shasum -a 512 apache-pulsar-client-go-$VERSION-src.tar.gz > apache-pulsar-client-go-$VERSION-src.tar.gz.sha512
+

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-#
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
 
 set -e -x
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e -x
+set -euo pipefail -x
 
 if [ $# -ne 2 ]; then
     echo "Usage: $0 <version> <destination_directory>"
@@ -37,7 +37,7 @@ git archive --format=tar.gz --output="$DEST_PATH/apache-pulsar-client-go-$VERSIO
 popd
 
 # Sign all files
-cd $DEST_PATH
+cd "$DEST_PATH"
 gpg -b --armor apache-pulsar-client-go-$VERSION-src.tar.gz
 shasum -a 512 apache-pulsar-client-go-$VERSION-src.tar.gz > apache-pulsar-client-go-$VERSION-src.tar.gz.sha512
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -euo pipefail -x
+set -euo pipefail
 
 if [ $# -ne 2 ]; then
     echo "Usage: $0 <version> <destination_directory>"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -18,25 +18,21 @@
 
 set -e -x
 
-if [ $# -eq 0 ]; then
-    echo "Required argument with destination directory"
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <version> <destination_directory>"
     exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-    echo "VERSION is not defined. Please set the VERSION environment variable."
-    exit 1
-fi
+VERSION=$1
 
-
-DEST_PATH=$1
+DEST_PATH=$2
 DEST_PATH="$(cd "$DEST_PATH" && pwd)"
 
-pushd $(dirname "$0")
+pushd "$(dirname "$0")"
 REPO_PATH=$(git rev-parse --show-toplevel)
 popd
 
-pushd $REPO_PATH
+pushd "$REPO_PATH"
 git archive --format=tar.gz --output="$DEST_PATH/apache-pulsar-client-go-$VERSION-src.tar.gz" HEAD
 popd
 


### PR DESCRIPTION
### Motivation

The "Build and inspect an artifact." step in the [release process](https://github.com/apache/pulsar-client-go/blob/master/docs/release-process.md) would also include the `.git` folder.

https://lists.apache.org/thread/pndqy7lfb8nrsgjh0wfq1bsrs1g7ds3y


### Modifications

- Added a new script for staging the release artifact: `stag-release.sh`
- Updated the release process to exclude the `.git` folder from the release artifact


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
