### PR TITLE
Improve perf with level guard in slogWrapper calls

### DIFF
--- a/pulsar/log/wrapper_slog.go
+++ b/pulsar/log/wrapper_slog.go
@@ -20,6 +20,7 @@
 package log
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 )
@@ -29,39 +30,55 @@ type slogWrapper struct {
 }
 
 func (s *slogWrapper) Debug(args ...any) {
-	message := s.tryDetermineMessage(args...)
-	s.logger.Debug(message)
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		message := s.tryDetermineMessage(args...)
+		s.logger.Debug(message)
+	}
 }
 
 func (s *slogWrapper) Info(args ...any) {
-	message := s.tryDetermineMessage(args...)
-	s.logger.Info(message)
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelInfo) {
+		message := s.tryDetermineMessage(args...)
+		s.logger.Info(message)
+	}
 }
 
 func (s *slogWrapper) Error(args ...any) {
-	message := s.tryDetermineMessage(args...)
-	s.logger.Error(message)
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelError) {
+		message := s.tryDetermineMessage(args...)
+		s.logger.Error(message)
+	}
 }
 
 func (s *slogWrapper) Warn(args ...any) {
-	message := s.tryDetermineMessage(args...)
-	s.logger.Warn(message)
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelWarn) {
+		message := s.tryDetermineMessage(args...)
+		s.logger.Warn(message)
+	}
 }
 
 func (s *slogWrapper) Debugf(format string, args ...any) {
-	s.logger.Debug(fmt.Sprintf(format, args...))
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelDebug) {
+		s.logger.Debug(fmt.Sprintf(format, args...))
+	}
 }
 
 func (s *slogWrapper) Infof(format string, args ...any) {
-	s.logger.Info(fmt.Sprintf(format, args...))
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelInfo) {
+		s.logger.Info(fmt.Sprintf(format, args...))
+	}
 }
 
 func (s *slogWrapper) Warnf(format string, args ...any) {
-	s.logger.Warn(fmt.Sprintf(format, args...))
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelWarn) {
+		s.logger.Warn(fmt.Sprintf(format, args...))
+	}
 }
 
 func (s *slogWrapper) Errorf(format string, args ...any) {
-	s.logger.Error(fmt.Sprintf(format, args...))
+	if s.logger.Handler().Enabled(context.Background(), slog.LevelError) {
+		s.logger.Error(fmt.Sprintf(format, args...))
+	}
 }
 
 func (s *slogWrapper) SubLogger(fields Fields) Logger {


### PR DESCRIPTION
### Motivation

Previously, calls to methods such as `(*slogWrapper).Debug` and `(*slogWrapper).Debugf` always resulted in calls to `fmt.Sprint` and `fmt.Sprintf` respectively, regardless of whether the log level in question was even enabled. Calls to `fmt.Sprintf` in particular can be costly from a performance standpoint.

We saw this resulting in significant performance impact in production instances, due to calls to `(*slogWrapper).Debug` even though debug logging was disabled.

### Modifications

This change prevents such calls unless the log level in question is currently enabled. Benchmarks on an Apple M3 Max result in a ~7x speed improvement in 'f' method variants when the log level in question is disabled:

    BenchmarkDebugfNoLvlCheckWritten-14      	 1755528	       676.3 ns/op	     232 B/op	       5 allocs/op
    BenchmarkDebugfLvlCheckWritten-14        	 1789832	       668.6 ns/op	     232 B/op	       5 allocs/op
    BenchmarkDebugfNoLvlCheckUnwritten-14    	 3885044	       307.9 ns/op	     232 B/op	       5 allocs/op
    BenchmarkDebugfLvlCheckUnwritten-14      	29590905	        41.72 ns/op	      24 B/op	       1 allocs/op
    BenchmarkDebugNoLvlCheckWritten-14       	 1808078	       667.2 ns/op	     232 B/op	       5 allocs/op
    BenchmarkDebugLvlCheckWritten-14         	 1777320	       670.4 ns/op	     232 B/op	       5 allocs/op
    BenchmarkDebugNoLvlCheckUnwritten-14     	29176137	        41.18 ns/op	      24 B/op	       1 allocs/op
    BenchmarkDebugLvlCheckUnwritten-14       	29249030	        41.43 ns/op	      24 B/op	       1 allocs/op

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as those in `pulsar/log/wrapper_slog_test.go` which confirm logs are output when the corresponding log level is enabled.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no