### PR TITLE
fix: support json token file format authentication

### DIFF
--- a/pulsaradmin/pkg/admin/auth/token.go
+++ b/pulsaradmin/pkg/admin/auth/token.go
@@ -36,6 +36,7 @@ const (
 
 type Token struct {
 	Token string `json:"token"`
+	File string `json:"file"`
 }
 
 type TokenAuthProvider struct {
@@ -78,7 +79,13 @@ func NewAuthenticationTokenFromAuthParams(encodedAuthParam string,
 			tokenAuthProvider, err = NewAuthenticationToken(encodedAuthParam, transport)
 		}
 	} else {
-		tokenAuthProvider, err = NewAuthenticationToken(tokenJSON.Token, transport)
+		if tokenJSON.File != "" {
+			tokenAuthProvider, err = NewAuthenticationTokenFromFile(tokenJSON.File, transport)
+		} else if tokenJSON.Token != "" {
+			tokenAuthProvider, err = NewAuthenticationToken(tokenJSON.Token, transport)
+		} else {
+			return nil, errors.New("unsupported token json auth param")
+		}
 	}
 	return tokenAuthProvider, err
 }

--- a/pulsaradmin/pkg/admin/auth/token.go
+++ b/pulsaradmin/pkg/admin/auth/token.go
@@ -36,7 +36,7 @@ const (
 
 type Token struct {
 	Token string `json:"token"`
-	File string `json:"file"`
+	File  string `json:"file"`
 }
 
 type TokenAuthProvider struct {


### PR DESCRIPTION
### Motivation


Support JSON token file format authentication for Pulsar Admin.
E.g: 
```
{"file": "./mnt/token"}
```

### Modifications

- Add token file format for json.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

