### PR TITLE
[improve] Support ClientVersion in 2.x pulsar broker

### DIFF
--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -246,8 +246,9 @@ func TestTokenAuthWithClientVersion(t *testing.T) {
 	topicState, err := admin.Topics().GetStats(*topicName)
 	assert.Nil(t, err)
 	publisher := topicState.Publishers[0]
-	assert.True(t, strings.HasPrefix(publisher.ClientVersion, "Pulsar Go version"))
+	assert.True(t, strings.HasPrefix(publisher.ClientVersion, "Pulsar-Go-version"))
 	assert.True(t, strings.HasSuffix(publisher.ClientVersion, "-test-client"))
+	assert.NotContains(t, publisher.ClientVersion, " ")
 }
 
 func TestTokenAuthWithSupplier(t *testing.T) {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -5027,7 +5027,8 @@ func TestClientVersion(t *testing.T) {
 	topicState, err := admin.Topics().GetStats(*topicName)
 	assert.Nil(t, err)
 	publisher := topicState.Publishers[0]
-	assert.True(t, strings.HasPrefix(publisher.ClientVersion, "Pulsar Go version"))
+	assert.True(t, strings.HasPrefix(publisher.ClientVersion, "Pulsar-Go-version"))
+	assert.NotContains(t, publisher.ClientVersion, " ")
 
 	topic = newTopicName()
 	client, err = NewClient(ClientOptions{
@@ -5045,9 +5046,9 @@ func TestClientVersion(t *testing.T) {
 	topicState, err = admin.Topics().GetStats(*topicName)
 	assert.Nil(t, err)
 	publisher = topicState.Publishers[0]
-	assert.True(t, strings.HasPrefix(publisher.ClientVersion, "Pulsar Go version"))
+	assert.True(t, strings.HasPrefix(publisher.ClientVersion, "Pulsar-Go-version"))
 	assert.True(t, strings.HasSuffix(publisher.ClientVersion, "-test-client"))
-
+	assert.NotContains(t, publisher.ClientVersion, " ")
 }
 
 func TestSelectConnectionForSameConsumer(t *testing.T) {

--- a/pulsar/internal/version.go
+++ b/pulsar/internal/version.go
@@ -40,11 +40,11 @@ func init() {
 		for _, dep := range buildInfo.Deps {
 			if dep.Path == pulsarClientGoModulePath {
 				Version = semver.Canonical(dep.Version)
-				ClientVersionString = "Pulsar Go " + Version
+				ClientVersionString = "Pulsar-Go-" + Version
 				return
 			}
 		}
 	}
 	Version = "unknown"
-	ClientVersionString = "Pulsar Go version unknown"
+	ClientVersionString = "Pulsar-Go-version-unknown"
 }

--- a/pulsar/internal/version_test.go
+++ b/pulsar/internal/version_test.go
@@ -26,3 +26,7 @@ import (
 func TestInitVersion(t *testing.T) {
 	assert.NotEmpty(t, Version, "version string should not be empty")
 }
+
+func TestVersionHasNoSpaces(t *testing.T) {
+	assert.NotContains(t, Version, " ", "version string should not contain any white space")
+}

--- a/pulsaradmin/pkg/admin/topic_test.go
+++ b/pulsaradmin/pkg/admin/topic_test.go
@@ -212,7 +212,8 @@ func TestPartitionState(t *testing.T) {
 	assert.Equal(t, publisher.IsSupportsPartialProducer, false)
 	assert.Equal(t, publisher.ProducerName, producerName)
 	assert.Contains(t, publisher.Address, "127.0.0.1")
-	assert.Contains(t, publisher.ClientVersion, "Pulsar Go version")
+	assert.Contains(t, publisher.ClientVersion, "Pulsar-Go-version")
+	assert.NotContains(t, publisher.ClientVersion, " ")
 
 	sub := topicState.Subscriptions[subName]
 	assert.Equal(t, sub.BytesOutCounter, int64(0))
@@ -244,7 +245,8 @@ func TestPartitionState(t *testing.T) {
 	assert.Equal(t, consumerState.ChunkedMessageRate, float64(0))
 	assert.Equal(t, consumerState.AvgMessagesPerEntry, int(0))
 	assert.Contains(t, consumerState.Address, "127.0.0.1")
-	assert.Contains(t, consumerState.ClientVersion, "Pulsar Go version")
+	assert.Contains(t, consumerState.ClientVersion, "Pulsar-Go-version")
+	assert.NotContains(t, consumerState.ClientVersion, " ")
 	assert.Equal(t, consumerState.LastAckedTimestamp, int64(0))
 	assert.Equal(t, consumerState.LastConsumedTimestamp, int64(0))
 	assert.True(t, consumerState.LastConsumedFlowTimestamp > 0)


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar-client-go/issues/1379

### Motivation
Replace pulsar go client version format `Pulsar Go <version>` with `Pulsar-Go-<version>` to support 2.x pulsar broker stats command.

### Modifications
Update client version format in pulsar/internal/version.go.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change added tests and can be verified as follows:
`pulsar/internal/version_test.go#TestVersionHasNoSpaces`

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
