### PR TITLE
[Fix] Fix backoff unit tests

### DIFF
--- a/pulsar/backoff/backoff.go
+++ b/pulsar/backoff/backoff.go
@@ -43,10 +43,15 @@ type DefaultBackoff struct {
 }
 
 func NewDefaultBackoff() Policy {
-	return &DefaultBackoff{rnd: rand.New(rand.NewSource(time.Now().UnixNano()))}
+	return &DefaultBackoff{
+		rnd: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
 }
 func NewDefaultBackoffWithInitialBackOff(backoff time.Duration) Policy {
-	return &DefaultBackoff{backoff: backoff / 2}
+	return &DefaultBackoff{
+		rnd:     rand.New(rand.NewSource(time.Now().UnixNano())),
+		backoff: backoff / 2,
+	}
 }
 
 const maxBackoff = 60 * time.Second

--- a/pulsar/backoff/backoff_test.go
+++ b/pulsar/backoff/backoff_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 func TestBackoff_NextMinValue(t *testing.T) {
-	backoff := &DefaultBackoff{}
+	backoff := NewDefaultBackoff()
 	delay := backoff.Next()
 	assert.GreaterOrEqual(t, int64(delay), int64(100*time.Millisecond))
 	assert.LessOrEqual(t, int64(delay), int64(120*time.Millisecond))
 }
 
 func TestBackoff_NextExponentialBackoff(t *testing.T) {
-	backoff := &DefaultBackoff{}
+	backoff := NewDefaultBackoff()
 	previousDelay := backoff.Next()
 	// the last value before capping to the max value is 51.2 s (.1, .2, .4, .8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
 	for previousDelay < 51*time.Second {
@@ -47,7 +47,7 @@ func TestBackoff_NextExponentialBackoff(t *testing.T) {
 }
 
 func TestBackoff_NextMaxValue(t *testing.T) {
-	backoff := &DefaultBackoff{}
+	backoff := NewDefaultBackoff()
 	var delay time.Duration
 	for delay < maxBackoff {
 		delay = backoff.Next()

--- a/pulsar/transaction_coordinator_client.go
+++ b/pulsar/transaction_coordinator_client.go
@@ -147,7 +147,7 @@ func (t *transactionHandler) runEventsLoop() {
 
 func (t *transactionHandler) reconnectToBroker() {
 	var delayReconnectTime time.Duration
-	var defaultBackoff = backoff.DefaultBackoff{}
+	var defaultBackoff = backoff.NewDefaultBackoff()
 
 	opFn := func() (struct{}, error) {
 		if t.getState() == txnHandlerClosed {


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/pull/1363

### Motivation
Above pr removed backoff init() strategy, which initialized a rand seed when package loaded, so that other functions can import  `DefaultBackoff{}` directly.
After pr changes, there is no rand initilization by default, and we need to manually call `NewDefaultBackoff()` instead of `DefaultBackoff{}` to avoid nil issue, example output below:
```
=== RUN   TestTLSConnectionCAError
time="2025-07-02T12:08:20+08:00" level=info msg="Connecting to broker" remote_addr="pulsar+ssl://localhost:6651"
time="2025-07-02T12:08:20+08:00" level=warning msg="Failed to connect to broker." error="tls: failed to verify certificate: x509: certificate is not valid for any names, but wanted to match localhost" remote_addr="pulsar+ssl://localhost:6651"
--- FAIL: TestTLSConnectionCAError (2054.87s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5d5c3c]

goroutine 20 [running]:
testing.tRunner.func1.2({0x1780420, 0x22e2fc0})
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1632 +0x49e
testing.tRunner.func1()
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1635 +0x669
panic({0x1780420?, 0x22e2fc0?})
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/runtime/panic.go:785 +0x136
math/rand.(*Rand).Int63(0x0)
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/math/rand/rand.go:96 +0x1c
math/rand.(*Rand).Float64(0x0)
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/math/rand/rand.go:207 +0x28
github.com/apache/pulsar-client-go/pulsar/backoff.(*DefaultBackoff).Next(0xc0001299e0)
	/data/code/dev/pulsar-client-go/pulsar/backoff/backoff.go:66 +0xed
github.com/apache/pulsar-client-go/pulsar/internal.(*rpcClient).requestToHost.func2({0x1a17d60, 0xc0002b40d0})
	/data/code/dev/pulsar-client-go/pulsar/internal/rpc_client.go:140 +0x62
github.com/apache/pulsar-client-go/pulsar/internal.Retry[...]({0x1a245d8, 0xc0000f13b0}, 0xc000059118, 0xc000059180)
	/data/code/dev/pulsar-client-go/pulsar/internal/retry.go:49 +0x219
github.com/apache/pulsar-client-go/pulsar/internal.(*rpcClient).requestToHost(0xc000000300, 0xc0000f12e0, 0x1, 0x15, {0x1a18560, 0xc00012cff0})
	/data/code/dev/pulsar-client-go/pulsar/internal/rpc_client.go:139 +0x3e5
github.com/apache/pulsar-client-go/pulsar/internal.(*rpcClient).RequestToAnyBroker(0xc000000300, 0x1, 0x15, {0x1a18560, 0xc00012cff0})
	/data/code/dev/pulsar-client-go/pulsar/internal/rpc_client.go:150 +0xac
github.com/apache/pulsar-client-go/pulsar/internal.(*lookupService).GetPartitionedTopicMetadata(0xc0000f12d0, {0xc00032e378, 0x11})
	/data/code/dev/pulsar-client-go/pulsar/internal/lookup_service.go:236 +0x28d
github.com/apache/pulsar-client-go/pulsar.(*client).TopicPartitions(0xc00033c2d0, {0xc00032e378, 0x11})
	/data/code/dev/pulsar-client-go/pulsar/client_impl.go:241 +0x170
github.com/apache/pulsar-client-go/pulsar.(*producer).internalCreatePartitionsProducers(0xc0001446e0)
	/data/code/dev/pulsar-client-go/pulsar/producer_impl.go:190 +0x91
github.com/apache/pulsar-client-go/pulsar.newProducer(0xc00033c2d0, 0xc000421000)
	/data/code/dev/pulsar-client-go/pulsar/producer_impl.go:152 +0xd39
github.com/apache/pulsar-client-go/pulsar.(*client).CreateProducer(_, {{0xc00032e378, 0x11}, {0x0, 0x0}, 0x0, 0x0, 0x0, 0x0, 0x0, ...})
	/data/code/dev/pulsar-client-go/pulsar/client_impl.go:201 +0xba
github.com/apache/pulsar-client-go/pulsar.TestTLSConnectionCAError(0xc000390b60)
	/data/code/dev/pulsar-client-go/pulsar/client_impl_test.go:56 +0x1c2
testing.tRunner(0xc000390b60, 0x196b2a0)
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1690 +0x1da
created by testing.(*T).Run in goroutine 1
	/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/testing/testing.go:1743 +0x7d3

```

### Modifications
Fix unit test code, replace `NewDefaultBackoff()` with `DefaultBackoff{}`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `TestTLSConnectionCAError` `TestBackoff_NextMinValue`.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

