### PR TITLE
ZeroQueueConsumer is not supported with RetryEnable

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -74,6 +74,11 @@ type consumer struct {
 }
 
 func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
+
+	if options.RetryEnable && options.EnableZeroQueueConsumer {
+		return nil, newError(InvalidConfiguration, "ZeroQueueConsumer is not supported with RetryEnable")
+	}
+
 	if options.Topic == "" && options.Topics == nil && options.TopicsPattern == "" {
 		return nil, newError(TopicNotFound, "topic is required")
 	}

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -31,6 +31,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRetryEnableZeroQueueConsumer(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+
+	// create consumer
+	_, err = client.Subscribe(ConsumerOptions{
+		Topic:                   topic,
+		SubscriptionName:        "my-sub",
+		RetryEnable:             true,
+		EnableZeroQueueConsumer: true,
+	})
+	assert.Error(t, err, "ZeroQueueConsumer is not supported with RetryEnable")
+}
+
 func TestNormalZeroQueueConsumer(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION


*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #1319


### Modifications

https://github.com/apache/pulsar/blob/89167308709cf72d3f2731bad1bb30384f80abb4/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java#L148-L149

We need to be consistent with the Java Client; `ZeroQueueConsumer` does not support use with `RetryEnable`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
