### PR TITLE
[Fix] DLQ Messages will lose system properties when sent from reconsumeLater()

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -632,17 +632,21 @@ func (c *consumer) ReconsumeLaterWithCustomProperties(msg Message, customPropert
 	} else {
 		props[SysPropertyRealTopic] = msg.Topic()
 		props[SysPropertyOriginMessageID] = msgID.messageID.String()
+		props[PropertyOriginMessageID] = msgID.messageID.String()
 	}
 	props[SysPropertyReconsumeTimes] = strconv.Itoa(reconsumeTimes)
 	props[SysPropertyDelayTime] = fmt.Sprintf("%d", int64(delay)/1e6)
 
 	consumerMsg := ConsumerMessage{
 		Consumer: c,
+		// Copy msgID so that dlq/rlq router can ack this msg after successfully sent to new topic
 		Message: &message{
-			payLoad:    msg.Payload(),
-			properties: props,
-			msgID:      msgID,
-			eventTime:  msg.EventTime(),
+			payLoad:     msg.Payload(),
+			key:         msg.Key(),
+			orderingKey: msg.OrderingKey(),
+			properties:  props,
+			eventTime:   msg.EventTime(),
+			msgID:       msgID,
 		},
 	}
 	if uint32(reconsumeTimes) > c.dlq.policy.MaxDeliveries {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1606,6 +1606,26 @@ func (pc *partitionConsumer) dispatcher() {
 			if !pc.isSeeking.Load() {
 				if pc.dlq.shouldSendToDlq(&nextMessage) {
 					// pass the message to the DLQ router
+					// we need to create a new ConsumerMessage and add dlq related metadata properties
+					properties := make(map[string]string)
+					properties[SysPropertyRealTopic] = messages[0].Topic()
+					properties[SysPropertyOriginMessageID] = messages[0].msgID.String()
+					properties[PropertyOriginMessageID] = messages[0].msgID.String()
+					for key, value := range messages[0].properties {
+						properties[key] = value
+					}
+					nextMessage = ConsumerMessage{
+						Consumer: pc.parentConsumer,
+						// Copy msgID so that dlq/rlq router can ack this msg after successfully sent to new topic
+						Message: &message{
+							payLoad:     messages[0].Payload(),
+							key:         messages[0].Key(),
+							orderingKey: messages[0].OrderingKey(),
+							properties:  properties,
+							eventTime:   messages[0].EventTime(),
+							msgID:       messages[0].msgID,
+						},
+					}
 					pc.metrics.DlqCounter.Inc()
 					messageCh = pc.dlq.Chan()
 				} else {

--- a/pulsar/dlq_router.go
+++ b/pulsar/dlq_router.go
@@ -111,21 +111,11 @@ func (r *dlqRouter) run() {
 			producer := r.getProducer(cm.Consumer.(*consumer).options.Schema)
 			msg := cm.Message.(*message)
 			msgID := msg.ID()
-
-			// properties associated with original message
-			properties := msg.Properties()
-
-			// include orinal message id in string format in properties
-			properties[PropertyOriginMessageID] = msgID.String()
-
-			// include original topic name of the message in properties
-			properties[SysPropertyRealTopic] = msg.Topic()
-
 			producer.SendAsync(context.Background(), &ProducerMessage{
 				Payload:             msg.Payload(),
 				Key:                 msg.Key(),
 				OrderingKey:         msg.OrderingKey(),
-				Properties:          properties,
+				Properties:          msg.Properties(),
 				EventTime:           msg.EventTime(),
 				ReplicationClusters: msg.replicationClusters,
 			}, func(_ MessageID, _ *ProducerMessage, err error) {

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -40,7 +40,7 @@ type ProducerMessage struct {
 
 	// EventTime set the event time for a given message
 	// By default, messages don't have an event time associated, while the publish
-	// time will be be always present.
+	// time will be always present.
 	// Set the event time to a non-zero timestamp to explicitly declare the time
 	// that the event "happened", as opposed to when the message is being published.
 	EventTime time.Time


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/1388
Master Issue: https://github.com/apache/pulsar-client-go/pull/907, https://github.com/apache/pulsar/pull/23182

### Motivation
Since pulsar sdk does not support `AckTimeout()` method, we can only use `Nack()` or `ReconsumeLater()` to trigger dlq policy and send messages to dlq. We can find system properties(e.g. `REAL_TOPIC` and `ORIGIN_MESSAGE_ID`) in these dlq messages.

Refer to issue https://github.com/apache/pulsar-client-go/issues/1388, before pr https://github.com/apache/pulsar-client-go/pull/907 `dlq_router#run()` will directly copy properties to create a new dlq message when receiving a message from `dlq.Chan()`. But we only define message properties in ReconsumeLater's `ReconsumeLaterWithCustomProperties()` and not in Nack's `dispatcher()` before send to this `dlq.Chan()`, which lead to only dlq messages created by `ReconsumeLater()` can have these properties.

The above pr replaced this behavior with just adding system properties as soon as creating dlq messages in `dlq_router#run()`, which use `message.topic` as `REAL_TOPIC` property value. But messages sent from `ReconsumeLater() ReconsumeLaterWithCustomProperties()` do not contain related `message.topic` fields, in case it will override defined `REAL_TOPIC` to empty string.

### Modifications
- Add `REAL_TOPIC`, `ORIGIN_MESSAGE_IDY_TIME`, `ORIGIN_MESSAGE_ID` system properties both in ReconsumeLater's `ReconsumeLaterWithCustomProperties()` and Nack's `dispatcher()` functions.
- Add `Key`, `OrderingKey`, `EventTime` message fields both in `ReconsumeLater() ReconsumeLaterWithCustomProperties()` and `dlq_router run()` functions to keep consistent with [Java realization](https://github.com/apache/pulsar/pull/23182), so that dlq messages can preserve source message info.
- Remove adding system properties strategy in `dlq_router#run()`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change updated tests and can be verified as follows:
DLQWithProducerOptions
TestRLQ

### Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation
  - Does this pull request introduce a new feature? (no)
