### PR TITLE
Fix sending buffer race by using proper reference counting

### DIFF
--- a/pulsar/consumer_multitopic_test.go
+++ b/pulsar/consumer_multitopic_test.go
@@ -354,7 +354,7 @@ func (dummyConnection) ID() string {
 }
 
 func (dummyConnection) GetMaxMessageSize() int32 {
-	return 0
+	return 5 * 1024 * 1024 // 5MB
 }
 
 func (dummyConnection) Close() {

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -19,7 +19,6 @@ package internal
 
 import (
 	"bytes"
-	"sync/atomic"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -28,10 +27,6 @@ import (
 	"github.com/apache/pulsar-client-go/pulsar/internal/crypto"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/apache/pulsar-client-go/pulsar/log"
-)
-
-var (
-	DebugGetBufferFromBatchBuilder = atomic.Int64{}
 )
 
 // BatcherBuilderProvider defines func which returns the BatchBuilder.

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -19,9 +19,16 @@ package internal
 
 import (
 	"encoding/binary"
+	"sync"
+	"sync/atomic"
 
 	log "github.com/sirupsen/logrus"
 )
+
+type BuffersPool interface {
+	GetBuffer(initSize int) Buffer
+	Put(buf Buffer)
+}
 
 // Buffer is a variable-sized buffer of bytes with Read and Write methods.
 // The zero value for Buffer is an empty buffer ready to use.
@@ -69,8 +76,46 @@ type Buffer interface {
 	Resize(newSize uint32)
 	ResizeIfNeeded(spaceNeeded uint32)
 
+	Retain()
+	Release()
+	RefCnt() int64
+
 	// Clear will clear the current buffer data.
 	Clear()
+}
+
+type bufferPoolImpl struct {
+	sync.Pool
+}
+
+func NewBufferPool() BuffersPool {
+	return &bufferPoolImpl{
+		Pool: sync.Pool{},
+	}
+}
+
+func (p *bufferPoolImpl) GetBuffer(initSize int) Buffer {
+	SendingBuffersCount.Inc()
+	b, ok := p.Get().(*buffer)
+	if ok {
+		b.Clear()
+	} else {
+		b = &buffer{
+			data:      make([]byte, initSize),
+			readerIdx: 0,
+			writerIdx: 0,
+		}
+	}
+	b.pool = p
+	b.Retain()
+	return b
+}
+
+func (p *bufferPoolImpl) Put(buf Buffer) {
+	SendingBuffersCount.Dec()
+	if b, ok := buf.(*buffer); ok {
+		p.Pool.Put(b)
+	}
 }
 
 type buffer struct {
@@ -78,6 +123,9 @@ type buffer struct {
 
 	readerIdx uint32
 	writerIdx uint32
+
+	refCnt atomic.Int64
+	pool   BuffersPool
 }
 
 // NewBuffer creates and initializes a new Buffer using buf as its initial contents.
@@ -213,7 +261,24 @@ func (b *buffer) Put(writerIdx uint32, s []byte) {
 	copy(b.data[writerIdx:], s)
 }
 
+func (b *buffer) Retain() {
+	b.refCnt.Add(1)
+}
+
+func (b *buffer) Release() {
+	if b.refCnt.Add(-1) == 0 {
+		if b.pool != nil {
+			b.pool.Put(b)
+		}
+	}
+}
+
+func (b *buffer) RefCnt() int64 {
+	return b.refCnt.Load()
+}
+
 func (b *buffer) Clear() {
 	b.readerIdx = 0
 	b.writerIdx = 0
+	b.refCnt.Store(0)
 }

--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -95,7 +95,7 @@ func NewBufferPool() BuffersPool {
 }
 
 func (p *bufferPoolImpl) GetBuffer(initSize int) Buffer {
-	SendingBuffersCount.Inc()
+	sendingBuffersCount.Inc()
 	b, ok := p.Get().(*buffer)
 	if ok {
 		b.Clear()
@@ -112,7 +112,7 @@ func (p *bufferPoolImpl) GetBuffer(initSize int) Buffer {
 }
 
 func (p *bufferPoolImpl) Put(buf Buffer) {
-	SendingBuffersCount.Dec()
+	sendingBuffersCount.Dec()
 	if b, ok := buf.(*buffer); ok {
 		p.Pool.Put(b)
 	}

--- a/pulsar/internal/key_based_batch_builder_test.go
+++ b/pulsar/internal/key_based_batch_builder_test.go
@@ -30,13 +30,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-type mockBufferPool struct {
-}
-
-func (m *mockBufferPool) GetBuffer() Buffer {
-	return nil
-}
-
 type mockEncryptor struct {
 }
 
@@ -53,7 +46,7 @@ func TestKeyBasedBatcherOrdering(t *testing.T) {
 		1,
 		pb.CompressionType_NONE,
 		compression.Level(0),
-		&mockBufferPool{},
+		&bufferPoolImpl{},
 		log.NewLoggerWithLogrus(logrus.StandardLogger()),
 		&mockEncryptor{},
 	)

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -26,7 +26,7 @@ var (
 		"client": "go",
 	}
 
-	SendingBuffersCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	sendingBuffersCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:        "pulsar_client_sending_buffers_count",
 		Help:        "Number of sending buffers",
 		ConstLabels: defaultConstLabels,
@@ -548,7 +548,7 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 			metrics.RPCRequestCount = are.ExistingCollector.(prometheus.Counter)
 		}
 	}
-	_ = registerer.Register(SendingBuffersCount)
+	_ = registerer.Register(sendingBuffersCount)
 	return metrics
 }
 

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -21,6 +21,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	defaultConstLabels = map[string]string{
+		"client": "go",
+	}
+
+	SendingBuffersCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "pulsar_client_sending_buffers_count",
+		Help:        "Number of sending buffers",
+		ConstLabels: defaultConstLabels,
+	})
+)
+
 type Metrics struct {
 	metricsLevel      int
 	messagesPublished *prometheus.CounterVec
@@ -99,8 +111,9 @@ type LeveledMetrics struct {
 // NewMetricsProvider returns metrics registered to registerer.
 func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]string,
 	registerer prometheus.Registerer) *Metrics {
-	constLabels := map[string]string{
-		"client": "go",
+	constLabels := make(map[string]string)
+	for k, v := range defaultConstLabels {
+		constLabels[k] = v
 	}
 	for k, v := range userDefinedLabels {
 		constLabels[k] = v
@@ -535,6 +548,7 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 			metrics.RPCRequestCount = are.ExistingCollector.(prometheus.Counter)
 		}
 	}
+	_ = registerer.Register(SendingBuffersCount)
 	return metrics
 }
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1737,7 +1737,9 @@ func (i *pendingItem) done(err error) {
 
 	i.isDone = true
 	// return the buffer to the pool after all callbacks have been called.
-	defer i.buffer.Release()
+	if i.buffer != nil {
+		defer i.buffer.Release()
+	}
 	if i.flushCallback != nil {
 		i.flushCallback(err)
 	}

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -888,6 +888,7 @@ func (p *partitionProducer) internalFlushCurrentBatch() {
 func (p *partitionProducer) writeData(buffer internal.Buffer, sequenceID uint64, callbacks []interface{}) {
 	select {
 	case <-p.ctx.Done():
+		buffer.Release()
 		for _, cb := range callbacks {
 			if sr, ok := cb.(*sendRequest); ok {
 				sr.done(nil, ErrProducerClosed)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -1737,9 +1737,7 @@ func (i *pendingItem) done(err error) {
 
 	i.isDone = true
 	// return the buffer to the pool after all callbacks have been called.
-	if i.buffer != nil {
-		defer i.buffer.Release()
-	}
+	defer i.buffer.Release()
 	if i.flushCallback != nil {
 		i.flushCallback(err)
 	}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -46,8 +46,6 @@ import (
 
 	"github.com/apache/pulsar-client-go/pulsar/crypto"
 	plog "github.com/apache/pulsar-client-go/pulsar/log"
-
-	_ "net/http/pprof"
 )
 
 func TestInvalidURL(t *testing.T) {
@@ -2634,16 +2632,13 @@ func TestSendBufferRetainWhenConnectionStuck(t *testing.T) {
 	topicName := newTopicName()
 
 	client, err := NewClient(ClientOptions{
-		URL:                     serviceURL,
-		MaxConnectionsPerBroker: 10,
+		URL: serviceURL,
 	})
 	assert.NoError(t, err)
 	defer client.Close()
 
-	reconnectNum := uint(1)
 	p, err := client.CreateProducer(ProducerOptions{
-		Topic:                topicName,
-		MaxReconnectToBroker: &reconnectNum,
+		Topic: topicName,
 	})
 	assert.NoError(t, err)
 	pp := p.(*producer).producers[0].(*partitionProducer)
@@ -2657,8 +2652,7 @@ func TestSendBufferRetainWhenConnectionStuck(t *testing.T) {
 
 	pp._setConn(conn)
 
-	ctx := context.Background()
-	pp.SendAsync(ctx, &ProducerMessage{
+	pp.SendAsync(context.Background(), &ProducerMessage{
 		Payload: []byte("test"),
 	}, nil)
 

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2383,7 +2383,9 @@ func TestFailPendingMessageWithClose(t *testing.T) {
 		})
 	}
 	partitionProducerImp := testProducer.(*producer).producers[0].(*partitionProducer)
-	partitionProducerImp.pendingQueue.Put(&pendingItem{})
+	partitionProducerImp.pendingQueue.Put(&pendingItem{
+		buffer: buffersPool.GetBuffer(0),
+	})
 	testProducer.Close()
 	assert.Equal(t, 0, partitionProducerImp.pendingQueue.Size())
 }

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -18,7 +18,6 @@
 package pulsar
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2675,31 +2675,3 @@ func TestSendBufferRetainWhenConnectionStuck(t *testing.T) {
 	b := conn.buffers[0]
 	assert.Equal(t, int64(1), b.RefCnt(), "Expected buffer to have a reference count of 1 after sending")
 }
-
-func getSendingBuffersCount() (float64, error) {
-	resp, err := http.Get("http://localhost:8801/metrics")
-	if err != nil {
-		return 0, fmt.Errorf("failed to fetch metrics: %v", err)
-	}
-	defer resp.Body.Close()
-
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "pulsar_client_sending_buffers_count{client=\"go\"}") {
-			// Parse the metric line to extract the value
-			// Format: pulsar_client_sending_buffers_count{client="go"} 5
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				var value float64
-				_, err := fmt.Sscanf(parts[len(parts)-1], "%f", &value)
-				if err != nil {
-					return 0, fmt.Errorf("failed to parse metric value: %v", err)
-				}
-				return value, nil
-			}
-		}
-	}
-
-	return 0, fmt.Errorf("sending_buffers_count metric not found")
-}

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2734,7 +2734,7 @@ func TestSendingBuffersCleanupAfterMultipleReconnections(t *testing.T) {
 		// Send many messages asynchronously without waiting for completion
 		// This generates a lot of sending buffers that need to be cleaned up
 		for j := 0; j < 1000; j++ {
-			p.SendAsync(t.Context(), &ProducerMessage{
+			p.SendAsync(context.Background(), &ProducerMessage{
 				Payload: []byte("test"),
 			}, nil)
 		}


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/1371

### Motivation

The issue is that the buffer is sent to the connection when the data is flushed at this line: https://github.com/apache/pulsar-client-go/blob/0ab28c229e4dab2adb505a135325b6ede6e0e4f4/pulsar/producer_partition.go#L910

Because of this, both the data request in the connection and the pending item hold onto this buffer.

However, if the pending item fails due to a timeout or the producer closing, the buffer is returned to the buffer pool at this line: https://github.com/apache/pulsar-client-go/blob/0ab28c229e4dab2adb505a135325b6ede6e0e4f4/pulsar/producer_partition.go#L1747

Yet, the connection still has this buffer. When the connection tries to handle the data request, it will try to use a buffer that has already been returned. This causes a data race.

This fix implements proper reference counting to ensure buffers are only returned to the pool when all references are released, preventing the data race.

### Modifications

  - Added `Retain()` and `Release()` methods to the `Buffer` interface
  - Implemented atomic reference counting using `atomic.Int64`
  - Buffers are only returned to the pool when reference count reaches zero
  - Add new metric `pulsar_client_sending_buffers_count` to show the sending buffers count.
  - This PR also fixes serval minor issues like data/request cleanup when closing the connection 

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
