### PR TITLE
fix: handle reconnection logic for zero queue consumer

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -473,6 +473,7 @@ func newPartitionConsumerOpts(topic, consumerName string, idx int, options Consu
 		enableBatchIndexAck:         options.EnableBatchIndexAcknowledgment,
 		ackGroupingOptions:          options.AckGroupingOptions,
 		autoReceiverQueueSize:       options.EnableAutoScaledReceiverQueueSize,
+		enableZeroQueueConsumer:     options.EnableZeroQueueConsumer,
 	}
 }
 

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -123,9 +123,10 @@ type partitionConsumerOpts struct {
 	expireTimeOfIncompleteChunk time.Duration
 	autoAckIncompleteChunk      bool
 	// in failover mode, this callback will be called when consumer change
-	consumerEventListener ConsumerEventListener
-	enableBatchIndexAck   bool
-	ackGroupingOptions    *AckGroupingOptions
+	consumerEventListener   ConsumerEventListener
+	enableBatchIndexAck     bool
+	ackGroupingOptions      *AckGroupingOptions
+	enableZeroQueueConsumer bool
 }
 
 type ConsumerEventListener interface {
@@ -1645,7 +1646,7 @@ func (pc *partitionConsumer) dispatcher() {
 
 			pc.log.Debugf("dispatcher requesting initial permits=%d", initialPermits)
 			// send initial permits
-			if err := pc.internalFlow(initialPermits); err != nil {
+			if err := pc.internalFlow(initialPermits); err != nil && !pc.options.enableZeroQueueConsumer {
 				pc.log.WithError(err).Error("unable to send initial permits to broker")
 			}
 
@@ -1902,6 +1903,10 @@ func (pc *partitionConsumer) reconnectToBroker(connectionClosed *connectionClose
 			// Successfully reconnected
 			pc.log.Info("Reconnected consumer to broker")
 			bo.Reset()
+			if pc.options.enableZeroQueueConsumer {
+				pc.log.Info("zeroQueueConsumer reconnect, reset availablePermits")
+				pc.availablePermits.inc()
+			}
 			return struct{}{}, nil
 		}
 		pc.log.WithError(err).Error("Failed to create consumer at reconnect")

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -149,8 +149,10 @@ func TestReconnectConsumer(t *testing.T) {
 		URL: endpoint,
 	})
 	assert.Nil(t, err)
+	adminEndpoint, err := c.PortEndpoint(context.Background(), "8080", "http")
+	assert.Nil(t, err)
 	admin, err := pulsaradmin.NewClient(&config.Config{
-		WebServiceURL: "http://localhost:8089",
+		WebServiceURL: adminEndpoint,
 	})
 	assert.Nil(t, err)
 

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -148,6 +148,7 @@ func TestReconnectConsumer(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: endpoint,
 	})
+	assert.Nil(t, err)
 	admin, err := pulsaradmin.NewClient(&config.Config{
 		WebServiceURL: "http://localhost:8089",
 	})

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -20,14 +20,15 @@ package pulsar
 import (
 	"context"
 	"fmt"
+	"log"
+	"testing"
+	"time"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"log"
-	"testing"
-	"time"
 
 	"github.com/apache/pulsar-client-go/pulsar/internal"
 	"github.com/apache/pulsar-client-go/pulsaradmin"


### PR DESCRIPTION

Fixes #1330 #398

### Motivation

`ZeroQueueConsumer` cannot consume messages when the broker restarts or unload topic.



### Modifications
- Increase `availablePermits` on reconnect for `ZeroQueueConsumer` 
- Add test case for zero queue consumer reconnection
- Suppress/Do not print the "unable to send initial permits to broker" error log when using `ZeroQueueConsumer`.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
