### PR TITLE
Change the pulsar_client_sending_buffers_count metric to client level

### DIFF
--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -267,7 +267,10 @@ func (bc *batchContainer) Flush() *FlushBatch {
 	uncompressedSize := bc.buffer.ReadableBytes()
 	bc.msgMetadata.UncompressedSize = &uncompressedSize
 
-	buffer := bc.buffersPool.GetBuffer(int(uncompressedSize*3/2), bc.metrics.SendingBuffersCount)
+	buffer := bc.buffersPool.GetBuffer(int(uncompressedSize * 3 / 2))
+	bufferCount := bc.metrics.SendingBuffersCount
+	bufferCount.Inc()
+	buffer.SetReleaseCallback(func() { bufferCount.Dec() })
 
 	sequenceID := uint64(0)
 	var err error

--- a/pulsar/internal/batch_builder.go
+++ b/pulsar/internal/batch_builder.go
@@ -33,7 +33,7 @@ import (
 type BatcherBuilderProvider func(
 	maxMessages uint, maxBatchSize uint, maxMessageSize uint32, producerName string, producerID uint64,
 	compressionType pb.CompressionType, level compression.Level,
-	bufferPool BuffersPool, logger log.Logger, encryptor crypto.Encryptor,
+	bufferPool BuffersPool, metrics *Metrics, logger log.Logger, encryptor crypto.Encryptor,
 ) (BatchBuilder, error)
 
 // BatchBuilder is a interface of batch builders
@@ -100,6 +100,7 @@ type batchContainer struct {
 
 	compressionProvider compression.Provider
 	buffersPool         BuffersPool
+	metrics             *Metrics
 
 	log log.Logger
 
@@ -110,7 +111,7 @@ type batchContainer struct {
 func newBatchContainer(
 	maxMessages uint, maxBatchSize uint, maxMessageSize uint32, producerName string, producerID uint64,
 	compressionType pb.CompressionType, level compression.Level,
-	bufferPool BuffersPool, logger log.Logger, encryptor crypto.Encryptor,
+	bufferPool BuffersPool, metrics *Metrics, logger log.Logger, encryptor crypto.Encryptor,
 ) batchContainer {
 
 	bc := batchContainer{
@@ -133,6 +134,7 @@ func newBatchContainer(
 		callbacks:           []interface{}{},
 		compressionProvider: GetCompressionProvider(compressionType, level),
 		buffersPool:         bufferPool,
+		metrics:             metrics,
 		log:                 logger,
 		encryptor:           encryptor,
 	}
@@ -148,12 +150,12 @@ func newBatchContainer(
 func NewBatchBuilder(
 	maxMessages uint, maxBatchSize uint, maxMessageSize uint32, producerName string, producerID uint64,
 	compressionType pb.CompressionType, level compression.Level,
-	bufferPool BuffersPool, logger log.Logger, encryptor crypto.Encryptor,
+	bufferPool BuffersPool, metrics *Metrics, logger log.Logger, encryptor crypto.Encryptor,
 ) (BatchBuilder, error) {
 
 	bc := newBatchContainer(
 		maxMessages, maxBatchSize, maxMessageSize, producerName, producerID, compressionType,
-		level, bufferPool, logger, encryptor,
+		level, bufferPool, metrics, logger, encryptor,
 	)
 
 	return &bc, nil
@@ -265,7 +267,7 @@ func (bc *batchContainer) Flush() *FlushBatch {
 	uncompressedSize := bc.buffer.ReadableBytes()
 	bc.msgMetadata.UncompressedSize = &uncompressedSize
 
-	buffer := bc.buffersPool.GetBuffer(int(uncompressedSize * 3 / 2))
+	buffer := bc.buffersPool.GetBuffer(int(uncompressedSize*3/2), bc.metrics.SendingBuffersCount)
 
 	sequenceID := uint64(0)
 	var err error

--- a/pulsar/internal/key_based_batch_builder.go
+++ b/pulsar/internal/key_based_batch_builder.go
@@ -86,14 +86,14 @@ func (h *keyBasedBatches) Val(key string) *batchContainer {
 func NewKeyBasedBatchBuilder(
 	maxMessages uint, maxBatchSize uint, maxMessageSize uint32, producerName string, producerID uint64,
 	compressionType pb.CompressionType, level compression.Level,
-	bufferPool BuffersPool, logger log.Logger, encryptor crypto.Encryptor,
+	bufferPool BuffersPool, metrics *Metrics, logger log.Logger, encryptor crypto.Encryptor,
 ) (BatchBuilder, error) {
 
 	bb := &keyBasedBatchContainer{
 		batches: newKeyBasedBatches(),
 		batchContainer: newBatchContainer(
 			maxMessages, maxBatchSize, maxMessageSize, producerName, producerID,
-			compressionType, level, bufferPool, logger, encryptor,
+			compressionType, level, bufferPool, metrics, logger, encryptor,
 		),
 		compressionType: compressionType,
 		level:           level,
@@ -155,7 +155,7 @@ func (bc *keyBasedBatchContainer) Add(
 		// create batchContainer for new key
 		t := newBatchContainer(
 			bc.maxMessages, bc.maxBatchSize, bc.maxMessageSize, bc.producerName, bc.producerID,
-			bc.compressionType, bc.level, bc.buffersPool, bc.log, bc.encryptor,
+			bc.compressionType, bc.level, bc.buffersPool, bc.metrics, bc.log, bc.encryptor,
 		)
 		batchPart = &t
 		bc.batches.Add(msgKey, &t)

--- a/pulsar/internal/key_based_batch_builder_test.go
+++ b/pulsar/internal/key_based_batch_builder_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/pulsar-client-go/pulsar/internal/compression"
 	pb "github.com/apache/pulsar-client-go/pulsar/internal/pulsar_proto"
 	"github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
@@ -47,6 +48,7 @@ func TestKeyBasedBatcherOrdering(t *testing.T) {
 		pb.CompressionType_NONE,
 		compression.Level(0),
 		&bufferPoolImpl{},
+		NewMetricsProvider(2, map[string]string{}, prometheus.DefaultRegisterer),
 		log.NewLoggerWithLogrus(logrus.StandardLogger()),
 		&mockEncryptor{},
 	)

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -798,7 +798,10 @@ func (p *partitionProducer) internalSingleSend(
 	payloadBuf := internal.NewBuffer(len(compressedPayload))
 	payloadBuf.Write(compressedPayload)
 
-	buffer := buffersPool.GetBuffer(int(payloadBuf.ReadableBytes()*3/2), p.client.metrics.SendingBuffersCount)
+	buffer := buffersPool.GetBuffer(int(payloadBuf.ReadableBytes() * 3 / 2))
+	bufferCount := p.client.metrics.SendingBuffersCount
+	bufferCount.Inc()
+	buffer.SetReleaseCallback(func() { bufferCount.Dec() })
 
 	sid := *mm.SequenceId
 	var useTxn bool

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -372,6 +372,7 @@ func (p *partitionProducer) grabCnx(assignedBrokerURL string) error {
 			maxMessageSize, p.producerName, p.producerID, pb.CompressionType(p.options.CompressionType),
 			compression.Level(p.options.CompressionLevel),
 			buffersPool,
+			p.client.metrics,
 			p.log,
 			p.encryptor)
 		if err != nil {
@@ -797,7 +798,7 @@ func (p *partitionProducer) internalSingleSend(
 	payloadBuf := internal.NewBuffer(len(compressedPayload))
 	payloadBuf.Write(compressedPayload)
 
-	buffer := buffersPool.GetBuffer(int(payloadBuf.ReadableBytes() * 3 / 2))
+	buffer := buffersPool.GetBuffer(int(payloadBuf.ReadableBytes()*3/2), p.client.metrics.SendingBuffersCount)
 
 	sid := *mm.SequenceId
 	var useTxn bool

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2354,12 +2354,12 @@ func TestProducerSendWithContext(t *testing.T) {
 }
 
 func TestFailPendingMessageWithClose(t *testing.T) {
-	client, err := NewClient(ClientOptions{
+	c, err := NewClient(ClientOptions{
 		URL: lookupURL,
 	})
 	assert.NoError(t, err)
-	defer client.Close()
-	testProducer, err := client.CreateProducer(ProducerOptions{
+	defer c.Close()
+	testProducer, err := c.CreateProducer(ProducerOptions{
 		Topic:                   newTopicName(),
 		DisableBlockIfQueueFull: false,
 		BatchingMaxPublishDelay: 100000,
@@ -2379,7 +2379,7 @@ func TestFailPendingMessageWithClose(t *testing.T) {
 	}
 	partitionProducerImp := testProducer.(*producer).producers[0].(*partitionProducer)
 	partitionProducerImp.pendingQueue.Put(&pendingItem{
-		buffer: buffersPool.GetBuffer(0),
+		buffer: buffersPool.GetBuffer(0, c.(*client).metrics.SendingBuffersCount),
 	})
 	testProducer.Close()
 	assert.Equal(t, 0, partitionProducerImp.pendingQueue.Size())

--- a/pulsar/producer_test.go
+++ b/pulsar/producer_test.go
@@ -2354,12 +2354,12 @@ func TestProducerSendWithContext(t *testing.T) {
 }
 
 func TestFailPendingMessageWithClose(t *testing.T) {
-	c, err := NewClient(ClientOptions{
+	client, err := NewClient(ClientOptions{
 		URL: lookupURL,
 	})
 	assert.NoError(t, err)
-	defer c.Close()
-	testProducer, err := c.CreateProducer(ProducerOptions{
+	defer client.Close()
+	testProducer, err := client.CreateProducer(ProducerOptions{
 		Topic:                   newTopicName(),
 		DisableBlockIfQueueFull: false,
 		BatchingMaxPublishDelay: 100000,
@@ -2379,7 +2379,7 @@ func TestFailPendingMessageWithClose(t *testing.T) {
 	}
 	partitionProducerImp := testProducer.(*producer).producers[0].(*partitionProducer)
 	partitionProducerImp.pendingQueue.Put(&pendingItem{
-		buffer: buffersPool.GetBuffer(0, c.(*client).metrics.SendingBuffersCount),
+		buffer: buffersPool.GetBuffer(0),
 	})
 	testProducer.Close()
 	assert.Equal(t, 0, partitionProducerImp.pendingQueue.Size())


### PR DESCRIPTION
#1394 introduces the `pulsar_client_sending_buffers_count` metric to track how many buffers are allocated for send purpose and not put back to the pool. However, unlike other metrics, this metric is not client level, so it cannot be attached with `CustomMetricsLabels` in client options.

When a send buffer was not put back to the pool, it means the `Release` method is not called due to some reason. Changing this metric to client level could help locate which client has triggered this bug in an application that has many client instances from different businesses.

Here is an example metric when I configured `CustomMetricsLabels: map[string]string{"key": "value"}` after this change

```
pulsar_client_sending_buffers_count{client="go",key="value"} 1
```