### PR TITLE
[issue #1357][producer] fix: allow multiples callbacks with concurrent producer flushes (async publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check for Docker images
         id: check_images
-        run: echo "::set-output name=images::$(docker images -q | wc -l)"
+        run: echo "{name}={images::$(docker images -q | wc -l)}" >> $GITHUB_OUTPUT
       - name: Clean Docker cache if images exist
         if: ${{ steps.check_images.outputs.images > 0 }}
         run: docker rmi $(docker images -q) -f && df -h        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check for Docker images
         id: check_images
-        run: echo "{name}={images::$(docker images -q | wc -l)}" >> $GITHUB_OUTPUT
+        run: echo "images=$(docker images -q | wc -l)" >> $GITHUB_OUTPUT
       - name: Clean Docker cache if images exist
         if: ${{ steps.check_images.outputs.images > 0 }}
         run: docker rmi $(docker images -q) -f && df -h        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,7 @@ jobs:
       matrix:
         go-version: [ '1.23', '1.24' ]
     steps:
-      - uses: actions/checkout@v3
-      - name: Check for Docker images
-        id: check_images
-        run: echo "images=$(docker images -q | wc -l)" >> $GITHUB_OUTPUT
-      - name: Clean Docker cache if images exist
-        if: ${{ steps.check_images.outputs.images > 0 }}
-        run: docker rmi $(docker images -q) -f && df -h        
+      - uses: actions/checkout@v3      
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pulsar-perf
 bin
 
 vendor/
+logs/

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -5230,7 +5230,7 @@ func sendMessages(t *testing.T, client Client, topic string, startIndex int, num
 			}
 		}
 	}
-	assert.Nil(t, producer.Flush())
+	assert.Nil(t, producer.FlushWithCtx(ctx))
 }
 
 func receiveMessages(t *testing.T, consumer Consumer, numMessages int) []Message {
@@ -5276,10 +5276,10 @@ func TestAckResponseNotBlocked(t *testing.T) {
 			}
 		})
 		if i%100 == 99 {
-			assert.Nil(t, producer.Flush())
+			assert.Nil(t, producer.FlushWithCtx(ctx))
 		}
 	}
-	producer.Flush()
+	producer.FlushWithCtx(ctx)
 	producer.Close()
 
 	// Set a small receiver queue size to trigger ack response blocking if the internal `queueCh`

--- a/pulsaradmin/pkg/admin/subscription_test.go
+++ b/pulsaradmin/pkg/admin/subscription_test.go
@@ -126,7 +126,7 @@ func TestPeekMessageForPartitionedTopic(t *testing.T) {
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}, nil)
 	}
-	err = producer.Flush()
+	err = producer.FlushWithCtx(ctx)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fixes #1357

### Motivation

When flushing concurrently with the same producer, the producer potentially creates a deadlock when the callback is only called once but the client waits for the flush request to be done in all `FlushWithCtx()`.

### Modifications

Change the callback function for to a list of callbacks.

### Verifying this change

Testcase `TestConcurrentFlushInProducer` added in the producer test suite.
