### PR TITLE
Fix missing topic in dlq producer name when using RetryEnable option

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -181,7 +181,15 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		}
 	}
 
-	dlq, err := newDlqRouter(client, options.DLQ, options.Topic, options.SubscriptionName, options.Name,
+	var sourceTopic string
+	if options.RetryEnable && len(options.Topics) == 2 && options.Topics[1] == options.DLQ.RetryLetterTopic {
+		//	when RetryEnable=true, options.Topic and RetryLetterTopic will be appended to the options.Topics
+		//	we need to try to find previous options.Topic from options.Topics
+		sourceTopic = options.Topics[0]
+	} else {
+		sourceTopic = options.Topic
+	}
+	dlq, err := newDlqRouter(client, options.DLQ, sourceTopic, options.SubscriptionName, options.Name,
 		options.BackOffPolicyFunc, client.log)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/pull/1314
Master Issue: https://github.com/apache/pulsar/pull/21589

### Motivation
When creating a consumer with `option.RetryEnable` option, consumer initialization needs to subscribe both `option.Topic` and `options.DLQ.RetryLetterTopic`, it will set `option.Topic` to empty string and move this topic to `option.Topics` for subscribing. Codes below:
https://github.com/apache/pulsar-client-go/blob/7a9a33c178fb4bac6488469865a2ac07c466b554/pulsar/consumer_impl.go#L176
```
	if options.RetryEnable {
		... omit code

		if options.Topic != "" && len(options.Topics) == 0 {
			options.Topics = []string{options.Topic, options.DLQ.RetryLetterTopic} # move options.Topic to options.Topics 
			options.Topic = ""
		} else if options.Topic == "" && len(options.Topics) > 0 {
			options.Topics = append(options.Topics, options.DLQ.RetryLetterTopic)  # move options.Topic to options.Topics 
		}
	}
```

But `newDlqRouter()` function use `option.Topic` when generating default producer name, when we set `option.RetryEnable` to true, default producer name will become to `-<subscriptionName>-<consumerName>-<randomString>-DLQ` (lose topicName part).
https://github.com/apache/pulsar-client-go/blob/7a9a33c178fb4bac6488469865a2ac07c466b554/pulsar/consumer_impl.go#L184

### Modifications
Modify `pulsar/consumer_impl.go#newDlqRouter()` initialization, when enable `option.RetryEnable` option, we try to find source topic in `option.Topics`. And if we set `option.RetryEnable` to false or there are multiple source topics, keep consistent with previous strategy(i.e. empty string).

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as 
`pulsar/consumer_test.go#TestRLQ`
`pulsar/consumer_test.go#TestRLQMultiTopics`

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
