### PR TITLE
feat: add WithContext() admin client methods

### DIFF
--- a/pulsaradmin/pkg/admin/broker_stats.go
+++ b/pulsaradmin/pkg/admin/broker_stats.go
@@ -18,6 +18,8 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 )
 
@@ -26,17 +28,32 @@ type BrokerStats interface {
 	// GetMetrics returns Monitoring metrics
 	GetMetrics() ([]utils.Metrics, error)
 
+	// GetMetricsWithContext returns Monitoring metrics
+	GetMetricsWithContext(context.Context) ([]utils.Metrics, error)
+
 	// GetMBeans requests JSON string server mbean dump
 	GetMBeans() ([]utils.Metrics, error)
+
+	// GetMBeansWithContext requests JSON string server mbean dump
+	GetMBeansWithContext(context.Context) ([]utils.Metrics, error)
 
 	// GetTopics returns JSON string topics stats
 	GetTopics() (string, error)
 
+	// GetTopicsWithContext returns JSON string topics stats
+	GetTopicsWithContext(context.Context) (string, error)
+
 	// GetLoadReport returns load report of broker
 	GetLoadReport() (*utils.LocalBrokerData, error)
 
+	// GetLoadReport returns load report of broker
+	GetLoadReportWithContext(context.Context) (*utils.LocalBrokerData, error)
+
 	// GetAllocatorStats returns stats from broker
 	GetAllocatorStats(allocatorName string) (*utils.AllocatorStats, error)
+
+	// GetAllocatorStatsWithContext returns stats from broker
+	GetAllocatorStatsWithContext(ctx context.Context, allocatorName string) (*utils.AllocatorStats, error)
 }
 
 type brokerStats struct {
@@ -53,9 +70,13 @@ func (c *pulsarClient) BrokerStats() BrokerStats {
 }
 
 func (bs *brokerStats) GetMetrics() ([]utils.Metrics, error) {
+	return bs.GetMetricsWithContext(context.Background())
+}
+
+func (bs *brokerStats) GetMetricsWithContext(ctx context.Context) ([]utils.Metrics, error) {
 	endpoint := bs.pulsar.endpoint(bs.basePath, "/metrics")
 	var response []utils.Metrics
-	err := bs.pulsar.Client.Get(endpoint, &response)
+	err := bs.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -64,9 +85,13 @@ func (bs *brokerStats) GetMetrics() ([]utils.Metrics, error) {
 }
 
 func (bs *brokerStats) GetMBeans() ([]utils.Metrics, error) {
+	return bs.GetMBeansWithContext(context.Background())
+}
+
+func (bs *brokerStats) GetMBeansWithContext(ctx context.Context) ([]utils.Metrics, error) {
 	endpoint := bs.pulsar.endpoint(bs.basePath, "/mbeans")
 	var response []utils.Metrics
-	err := bs.pulsar.Client.Get(endpoint, &response)
+	err := bs.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +100,12 @@ func (bs *brokerStats) GetMBeans() ([]utils.Metrics, error) {
 }
 
 func (bs *brokerStats) GetTopics() (string, error) {
+	return bs.GetTopicsWithContext(context.Background())
+}
+
+func (bs *brokerStats) GetTopicsWithContext(ctx context.Context) (string, error) {
 	endpoint := bs.pulsar.endpoint(bs.basePath, "/topics")
-	buf, err := bs.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
+	buf, err := bs.pulsar.Client.GetWithQueryParams(ctx, endpoint, nil, nil, false)
 	if err != nil {
 		return "", err
 	}
@@ -85,9 +114,13 @@ func (bs *brokerStats) GetTopics() (string, error) {
 }
 
 func (bs *brokerStats) GetLoadReport() (*utils.LocalBrokerData, error) {
+	return bs.GetLoadReportWithContext(context.Background())
+}
+
+func (bs *brokerStats) GetLoadReportWithContext(ctx context.Context) (*utils.LocalBrokerData, error) {
 	endpoint := bs.pulsar.endpoint(bs.basePath, "/load-report")
 	response := utils.NewLocalBrokerData()
-	err := bs.pulsar.Client.Get(endpoint, &response)
+	err := bs.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		return nil, nil
 	}
@@ -95,9 +128,13 @@ func (bs *brokerStats) GetLoadReport() (*utils.LocalBrokerData, error) {
 }
 
 func (bs *brokerStats) GetAllocatorStats(allocatorName string) (*utils.AllocatorStats, error) {
+	return bs.GetAllocatorStatsWithContext(context.Background(), allocatorName)
+}
+
+func (bs *brokerStats) GetAllocatorStatsWithContext(ctx context.Context, allocatorName string) (*utils.AllocatorStats, error) {
 	endpoint := bs.pulsar.endpoint(bs.basePath, "/allocator-stats", allocatorName)
 	var allocatorStats utils.AllocatorStats
-	err := bs.pulsar.Client.Get(endpoint, &allocatorStats)
+	err := bs.pulsar.Client.Get(ctx, endpoint, &allocatorStats)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -27,42 +28,81 @@ import (
 // Brokers is admin interface for brokers management
 type Brokers interface {
 
-	// GetListActiveBrokers Get the list of active brokers in the local cluster.
+	// GetListActiveBrokers returns the list of active brokers in the local cluster.
 	GetListActiveBrokers() ([]string, error)
+
+	// GetListActiveBrokersWithContext returns the list of active brokers in the local cluster.
+	GetListActiveBrokersWithContext(context.Context) ([]string, error)
+
 	// GetActiveBrokers returns the list of active brokers in the cluster.
 	GetActiveBrokers(cluster string) ([]string, error)
+
+	// GetActiveBrokersWithContext returns the list of active brokers in the cluster.
+	GetActiveBrokersWithContext(ctx context.Context, cluster string) ([]string, error)
 
 	// GetDynamicConfigurationNames returns list of updatable configuration name
 	GetDynamicConfigurationNames() ([]string, error)
 
+	// GetDynamicConfigurationNamesWithContext returns list of updatable configuration name
+	GetDynamicConfigurationNamesWithContext(context.Context) ([]string, error)
+
 	// GetOwnedNamespaces returns the map of owned namespaces and their status from a single broker in the cluster
 	GetOwnedNamespaces(cluster, brokerURL string) (map[string]utils.NamespaceOwnershipStatus, error)
+
+	// GetOwnedNamespaces returns the map of owned namespaces and their status from a single broker in the cluster
+	GetOwnedNamespacesWithContext(ctx context.Context, cluster, brokerURL string) (map[string]utils.NamespaceOwnershipStatus, error)
 
 	// UpdateDynamicConfiguration updates dynamic configuration value in to Zk that triggers watch on
 	// brokers and all brokers can update {@link ServiceConfiguration} value locally
 	UpdateDynamicConfiguration(configName, configValue string) error
 
+	// UpdateDynamicConfigurationWithContext updates dynamic configuration value in to Zk that triggers watch on
+	// brokers and all brokers can update {@link ServiceConfiguration} value locally
+	UpdateDynamicConfigurationWithContext(ctx context.Context, configName, configValue string) error
+
 	// DeleteDynamicConfiguration deletes dynamic configuration value in to Zk. It will not impact current value
 	// in broker but next time when broker restarts, it applies value from configuration file only.
 	DeleteDynamicConfiguration(configName string) error
 
+	// DeleteDynamicConfigurationWithContext deletes dynamic configuration value in to Zk. It will not impact current value
+	// in broker but next time when broker restarts, it applies value from configuration file only.
+	DeleteDynamicConfigurationWithContext(ctx context.Context, configName string) error
+
 	// GetRuntimeConfigurations returns values of runtime configuration
 	GetRuntimeConfigurations() (map[string]string, error)
+
+	// GetRuntimeConfigurationsWithContext returns values of runtime configuration
+	GetRuntimeConfigurationsWithContext(context.Context) (map[string]string, error)
 
 	// GetInternalConfigurationData returns the internal configuration data
 	GetInternalConfigurationData() (*utils.InternalConfigurationData, error)
 
+	// GetInternalConfigurationDataWithContext returns the internal configuration data
+	GetInternalConfigurationDataWithContext(context.Context) (*utils.InternalConfigurationData, error)
+
 	// GetAllDynamicConfigurations returns values of all overridden dynamic-configs
 	GetAllDynamicConfigurations() (map[string]string, error)
+
+	// GetAllDynamicConfigurationsWithContext returns values of all overridden dynamic-configs
+	GetAllDynamicConfigurationsWithContext(context.Context) (map[string]string, error)
 
 	// Deprecated: Use HealthCheckWithTopicVersion instead
 	HealthCheck() error
 
-	// HealthCheckWithTopicVersion run a health check on the broker
+	// Deprecated: Use HealthCheckWithTopicVersionWithContext instead
+	HealthCheckWithContext(context.Context) error
+
+	// HealthCheckWithTopicVersion runs a health check on the broker
 	HealthCheckWithTopicVersion(utils.TopicVersion) error
+
+	// HealthCheckWithTopicVersionWithContext runs a health check on the broker
+	HealthCheckWithTopicVersionWithContext(context.Context, utils.TopicVersion) error
 
 	// GetLeaderBroker get the information of the leader broker.
 	GetLeaderBroker() (utils.BrokerInfo, error)
+
+	// GetLeaderBrokerWithContext returns the information of the leader broker.
+	GetLeaderBrokerWithContext(context.Context) (utils.BrokerInfo, error)
 }
 
 type broker struct {
@@ -79,9 +119,13 @@ func (c *pulsarClient) Brokers() Brokers {
 }
 
 func (b *broker) GetActiveBrokers(cluster string) ([]string, error) {
+	return b.GetActiveBrokersWithContext(context.Background(), cluster)
+}
+
+func (b *broker) GetActiveBrokersWithContext(ctx context.Context, cluster string) ([]string, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, cluster)
 	var res []string
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -89,9 +133,13 @@ func (b *broker) GetActiveBrokers(cluster string) ([]string, error) {
 }
 
 func (b *broker) GetListActiveBrokers() ([]string, error) {
+	return b.GetListActiveBrokersWithContext(context.Background())
+}
+
+func (b *broker) GetListActiveBrokersWithContext(ctx context.Context) ([]string, error) {
 	endpoint := b.pulsar.endpoint(b.basePath)
 	var res []string
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -99,9 +147,13 @@ func (b *broker) GetListActiveBrokers() ([]string, error) {
 }
 
 func (b *broker) GetDynamicConfigurationNames() ([]string, error) {
+	return b.GetDynamicConfigurationNamesWithContext(context.Background())
+}
+
+func (b *broker) GetDynamicConfigurationNamesWithContext(ctx context.Context) ([]string, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, "/configuration/")
 	var res []string
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -109,9 +161,13 @@ func (b *broker) GetDynamicConfigurationNames() ([]string, error) {
 }
 
 func (b *broker) GetOwnedNamespaces(cluster, brokerURL string) (map[string]utils.NamespaceOwnershipStatus, error) {
+	return b.GetOwnedNamespacesWithContext(context.TODO(), cluster, brokerURL)
+}
+
+func (b *broker) GetOwnedNamespacesWithContext(ctx context.Context, cluster, brokerURL string) (map[string]utils.NamespaceOwnershipStatus, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, cluster, brokerURL, "ownedNamespaces")
 	var res map[string]utils.NamespaceOwnershipStatus
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -119,20 +175,32 @@ func (b *broker) GetOwnedNamespaces(cluster, brokerURL string) (map[string]utils
 }
 
 func (b *broker) UpdateDynamicConfiguration(configName, configValue string) error {
+	return b.UpdateDynamicConfigurationWithContext(context.Background(), configName, configValue)
+}
+
+func (b *broker) UpdateDynamicConfigurationWithContext(ctx context.Context, configName, configValue string) error {
 	value := fmt.Sprintf("/configuration/%s/%s", configName, configValue)
 	endpoint := b.pulsar.endpointWithFullPath(b.basePath, value)
-	return b.pulsar.Client.Post(endpoint, nil)
+	return b.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (b *broker) DeleteDynamicConfiguration(configName string) error {
+	return b.DeleteDynamicConfigurationWithContext(context.Background(), configName)
+}
+
+func (b *broker) DeleteDynamicConfigurationWithContext(ctx context.Context, configName string) error {
 	endpoint := b.pulsar.endpoint(b.basePath, "/configuration/", configName)
-	return b.pulsar.Client.Delete(endpoint)
+	return b.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (b *broker) GetRuntimeConfigurations() (map[string]string, error) {
+	return b.GetRuntimeConfigurationsWithContext(context.Background())
+}
+
+func (b *broker) GetRuntimeConfigurationsWithContext(ctx context.Context) (map[string]string, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, "/configuration/", "runtime")
 	var res map[string]string
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -140,9 +208,13 @@ func (b *broker) GetRuntimeConfigurations() (map[string]string, error) {
 }
 
 func (b *broker) GetInternalConfigurationData() (*utils.InternalConfigurationData, error) {
+	return b.GetInternalConfigurationDataWithContext(context.Background())
+}
+
+func (b *broker) GetInternalConfigurationDataWithContext(ctx context.Context) (*utils.InternalConfigurationData, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, "/internal-configuration")
 	var res utils.InternalConfigurationData
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -150,9 +222,13 @@ func (b *broker) GetInternalConfigurationData() (*utils.InternalConfigurationDat
 }
 
 func (b *broker) GetAllDynamicConfigurations() (map[string]string, error) {
+	return b.GetAllDynamicConfigurationsWithContext(context.Background())
+}
+
+func (b *broker) GetAllDynamicConfigurationsWithContext(ctx context.Context) (map[string]string, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, "/configuration/", "values")
 	var res map[string]string
-	err := b.pulsar.Client.Get(endpoint, &res)
+	err := b.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -160,12 +236,21 @@ func (b *broker) GetAllDynamicConfigurations() (map[string]string, error) {
 }
 
 func (b *broker) HealthCheck() error {
-	return b.HealthCheckWithTopicVersion(utils.TopicVersionV1)
+	return b.HealthCheckWithContext(context.Background())
 }
+
+func (b *broker) HealthCheckWithContext(ctx context.Context) error {
+	return b.HealthCheckWithTopicVersionWithContext(ctx, utils.TopicVersionV1)
+}
+
 func (b *broker) HealthCheckWithTopicVersion(topicVersion utils.TopicVersion) error {
+	return b.HealthCheckWithTopicVersionWithContext(context.Background(), topicVersion)
+}
+
+func (b *broker) HealthCheckWithTopicVersionWithContext(ctx context.Context, topicVersion utils.TopicVersion) error {
 	endpoint := b.pulsar.endpoint(b.basePath, "/health")
 
-	buf, err := b.pulsar.Client.GetWithQueryParams(endpoint, nil, map[string]string{
+	buf, err := b.pulsar.Client.GetWithQueryParams(ctx, endpoint, nil, map[string]string{
 		"topicVersion": topicVersion.String(),
 	}, false)
 	if err != nil {
@@ -177,10 +262,15 @@ func (b *broker) HealthCheckWithTopicVersion(topicVersion utils.TopicVersion) er
 	}
 	return nil
 }
+
 func (b *broker) GetLeaderBroker() (utils.BrokerInfo, error) {
+	return b.GetLeaderBrokerWithContext(context.Background())
+}
+
+func (b *broker) GetLeaderBrokerWithContext(ctx context.Context) (utils.BrokerInfo, error) {
 	endpoint := b.pulsar.endpoint(b.basePath, "/leaderBroker")
 	var brokerInfo utils.BrokerInfo
-	err := b.pulsar.Client.Get(endpoint, &brokerInfo)
+	err := b.pulsar.Client.Get(ctx, endpoint, &brokerInfo)
 	if err != nil {
 		return brokerInfo, err
 	}

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -123,7 +124,7 @@ func TestUpdateDynamicConfigurationWithCustomURL(t *testing.T) {
 	value := `{"key/123":"https://example.com/"}`
 	encoded := url.QueryEscape(value)
 
-	resp, err := client.MakeRequestWithURL(http.MethodPost, &url.URL{
+	resp, err := client.MakeRequestWithURL(context.Background(), http.MethodPost, &url.URL{
 		Scheme: u.Scheme,
 		User:   u.User,
 		Host:   u.Host,

--- a/pulsaradmin/pkg/admin/cluster.go
+++ b/pulsaradmin/pkg/admin/cluster.go
@@ -18,6 +18,8 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 )
 
@@ -26,38 +28,74 @@ type Clusters interface {
 	// List returns the list of clusters
 	List() ([]string, error)
 
+	// ListWithContext returns the list of clusters
+	ListWithContext(context.Context) ([]string, error)
+
 	// Get the configuration data for the specified cluster
 	Get(string) (utils.ClusterData, error)
+
+	// GetWithContext returns the configuration data for the specified cluster
+	GetWithContext(context.Context, string) (utils.ClusterData, error)
 
 	// Create a new cluster
 	Create(utils.ClusterData) error
 
+	// CreateWithContext creates a new cluster
+	CreateWithContext(context.Context, utils.ClusterData) error
+
 	// Delete an existing cluster
 	Delete(string) error
+
+	// DeleteWithContext deletes an existing cluster
+	DeleteWithContext(context.Context, string) error
 
 	// Update the configuration for a cluster
 	Update(utils.ClusterData) error
 
+	// UpdateWithContext updates the configuration for a cluster
+	UpdateWithContext(context.Context, utils.ClusterData) error
+
 	// UpdatePeerClusters updates peer cluster names.
 	UpdatePeerClusters(string, []string) error
+
+	// UpdatePeerClustersWithContext updates peer cluster names.
+	UpdatePeerClustersWithContext(context.Context, string, []string) error
 
 	// GetPeerClusters returns peer-cluster names
 	GetPeerClusters(string) ([]string, error)
 
+	// GetPeerClusters returns peer-cluster names
+	GetPeerClustersWithContext(context.Context, string) ([]string, error)
+
 	// CreateFailureDomain creates a domain into cluster
 	CreateFailureDomain(utils.FailureDomainData) error
+
+	// CreateFailureDomain creates a domain into cluster
+	CreateFailureDomainWithContext(context.Context, utils.FailureDomainData) error
 
 	// GetFailureDomain returns the domain registered into a cluster
 	GetFailureDomain(clusterName, domainName string) (utils.FailureDomainData, error)
 
+	// GetFailureDomain returns the domain registered into a cluster
+	GetFailureDomainWithContext(ctx context.Context, clusterName, domainName string) (utils.FailureDomainData, error)
+
 	// ListFailureDomains returns all registered domains in cluster
 	ListFailureDomains(string) (utils.FailureDomainMap, error)
+
+	// ListFailureDomains returns all registered domains in cluster
+	ListFailureDomainsWithContext(context.Context, string) (utils.FailureDomainMap, error)
 
 	// DeleteFailureDomain deletes a domain in cluster
 	DeleteFailureDomain(utils.FailureDomainData) error
 
+	// DeleteFailureDomain deletes a domain in cluster
+	DeleteFailureDomainWithContext(context.Context, utils.FailureDomainData) error
+
 	// UpdateFailureDomain updates a domain into cluster
 	UpdateFailureDomain(utils.FailureDomainData) error
+
+	// UpdateFailureDomain updates a domain into cluster
+	UpdateFailureDomainWithContext(context.Context, utils.FailureDomainData) error
 }
 
 type clusters struct {
@@ -74,69 +112,118 @@ func (c *pulsarClient) Clusters() Clusters {
 }
 
 func (c *clusters) List() ([]string, error) {
+	return c.ListWithContext(context.Background())
+}
+
+func (c *clusters) ListWithContext(ctx context.Context) ([]string, error) {
 	var clusters []string
-	err := c.pulsar.Client.Get(c.pulsar.endpoint(c.basePath), &clusters)
+	err := c.pulsar.Client.Get(ctx, c.pulsar.endpoint(c.basePath), &clusters)
 	return clusters, err
 }
 
 func (c *clusters) Get(name string) (utils.ClusterData, error) {
+	return c.GetWithContext(context.Background(), name)
+}
+
+func (c *clusters) GetWithContext(ctx context.Context, name string) (utils.ClusterData, error) {
 	cdata := utils.ClusterData{}
 	endpoint := c.pulsar.endpoint(c.basePath, name)
-	err := c.pulsar.Client.Get(endpoint, &cdata)
+	err := c.pulsar.Client.Get(ctx, endpoint, &cdata)
 	return cdata, err
 }
 
 func (c *clusters) Create(cdata utils.ClusterData) error {
+	return c.CreateWithContext(context.Background(), cdata)
+}
+
+func (c *clusters) CreateWithContext(ctx context.Context, cdata utils.ClusterData) error {
 	endpoint := c.pulsar.endpoint(c.basePath, cdata.Name)
-	return c.pulsar.Client.Put(endpoint, &cdata)
+	return c.pulsar.Client.Put(ctx, endpoint, &cdata)
 }
 
 func (c *clusters) Delete(name string) error {
+	return c.DeleteWithContext(context.Background(), name)
+}
+
+func (c *clusters) DeleteWithContext(ctx context.Context, name string) error {
 	endpoint := c.pulsar.endpoint(c.basePath, name)
-	return c.pulsar.Client.Delete(endpoint)
+	return c.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (c *clusters) Update(cdata utils.ClusterData) error {
+	return c.UpdateWithContext(context.Background(), cdata)
+}
+
+func (c *clusters) UpdateWithContext(ctx context.Context, cdata utils.ClusterData) error {
 	endpoint := c.pulsar.endpoint(c.basePath, cdata.Name)
-	return c.pulsar.Client.Post(endpoint, &cdata)
+	return c.pulsar.Client.Post(ctx, endpoint, &cdata)
 }
 
 func (c *clusters) GetPeerClusters(name string) ([]string, error) {
+	return c.GetPeerClustersWithContext(context.Background(), name)
+}
+
+func (c *clusters) GetPeerClustersWithContext(ctx context.Context, name string) ([]string, error) {
 	var peerClusters []string
 	endpoint := c.pulsar.endpoint(c.basePath, name, "peers")
-	err := c.pulsar.Client.Get(endpoint, &peerClusters)
+	err := c.pulsar.Client.Get(ctx, endpoint, &peerClusters)
 	return peerClusters, err
 }
 
 func (c *clusters) UpdatePeerClusters(cluster string, peerClusters []string) error {
+	return c.UpdatePeerClustersWithContext(context.Background(), cluster, peerClusters)
+}
+
+func (c *clusters) UpdatePeerClustersWithContext(ctx context.Context, cluster string, peerClusters []string) error {
 	endpoint := c.pulsar.endpoint(c.basePath, cluster, "peers")
-	return c.pulsar.Client.Post(endpoint, peerClusters)
+	return c.pulsar.Client.Post(ctx, endpoint, peerClusters)
 }
 
 func (c *clusters) CreateFailureDomain(data utils.FailureDomainData) error {
+	return c.CreateFailureDomainWithContext(context.Background(), data)
+}
+
+func (c *clusters) CreateFailureDomainWithContext(ctx context.Context, data utils.FailureDomainData) error {
 	endpoint := c.pulsar.endpoint(c.basePath, data.ClusterName, "failureDomains", data.DomainName)
-	return c.pulsar.Client.Post(endpoint, &data)
+	return c.pulsar.Client.Post(ctx, endpoint, &data)
 }
 
 func (c *clusters) GetFailureDomain(clusterName string, domainName string) (utils.FailureDomainData, error) {
+	return c.GetFailureDomainWithContext(context.Background(), clusterName, domainName)
+}
+
+func (c *clusters) GetFailureDomainWithContext(ctx context.Context, clusterName string, domainName string) (utils.FailureDomainData, error) {
 	var res utils.FailureDomainData
 	endpoint := c.pulsar.endpoint(c.basePath, clusterName, "failureDomains", domainName)
-	err := c.pulsar.Client.Get(endpoint, &res)
+	err := c.pulsar.Client.Get(ctx, endpoint, &res)
 	return res, err
 }
 
 func (c *clusters) ListFailureDomains(clusterName string) (utils.FailureDomainMap, error) {
+	return c.ListFailureDomainsWithContext(context.Background(), clusterName)
+}
+
+func (c *clusters) ListFailureDomainsWithContext(ctx context.Context, clusterName string) (utils.FailureDomainMap, error) {
 	var domainData utils.FailureDomainMap
 	endpoint := c.pulsar.endpoint(c.basePath, clusterName, "failureDomains")
-	err := c.pulsar.Client.Get(endpoint, &domainData)
+	err := c.pulsar.Client.Get(ctx, endpoint, &domainData)
 	return domainData, err
 }
 
 func (c *clusters) DeleteFailureDomain(data utils.FailureDomainData) error {
-	endpoint := c.pulsar.endpoint(c.basePath, data.ClusterName, "failureDomains", data.DomainName)
-	return c.pulsar.Client.Delete(endpoint)
+	return c.DeleteFailureDomainWithContext(context.TODO(), data)
 }
-func (c *clusters) UpdateFailureDomain(data utils.FailureDomainData) error {
+
+func (c *clusters) DeleteFailureDomainWithContext(ctx context.Context, data utils.FailureDomainData) error {
 	endpoint := c.pulsar.endpoint(c.basePath, data.ClusterName, "failureDomains", data.DomainName)
-	return c.pulsar.Client.Post(endpoint, &data)
+	return c.pulsar.Client.Delete(ctx, endpoint)
+}
+
+func (c *clusters) UpdateFailureDomain(data utils.FailureDomainData) error {
+	return c.UpdateFailureDomainWithContext(context.Background(), data)
+}
+
+func (c *clusters) UpdateFailureDomainWithContext(ctx context.Context, data utils.FailureDomainData) error {
+	endpoint := c.pulsar.endpoint(c.basePath, data.ClusterName, "failureDomains", data.DomainName)
+	return c.pulsar.Client.Post(ctx, endpoint, &data)
 }

--- a/pulsaradmin/pkg/admin/functions.go
+++ b/pulsaradmin/pkg/admin/functions.go
@@ -19,6 +19,7 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,7 +37,10 @@ type Functions interface {
 	// CreateFunc create a new function.
 	CreateFunc(data *utils.FunctionConfig, fileName string) error
 
-	// CreateFuncWithURL create a new function by providing url from which fun-pkg can be downloaded.
+	// CreateFuncWithContext create a new function.
+	CreateFuncWithContext(ctx context.Context, data *utils.FunctionConfig, fileName string) error
+
+	// CreateFuncWithURL creates a new function by providing url from which fun-pkg can be downloaded.
 	// supported url: http/file
 	// eg:
 	//  File: file:/dir/fileName.jar
@@ -48,14 +52,37 @@ type Functions interface {
 	//      url from which pkg can be downloaded
 	CreateFuncWithURL(data *utils.FunctionConfig, pkgURL string) error
 
-	// StopFunction stop all function instances
+	// CreateFuncWithURLWithContext creates a new function by providing url from which fun-pkg can be downloaded.
+	// supported url: http/file
+	// eg:
+	//  File: file:/dir/fileName.jar
+	//  Http: http://www.repo.com/fileName.jar
+	//
+	// @param ctx
+	//        context used for the request
+	// @param functionConfig
+	//      the function configuration object
+	// @param pkgURL
+	//      url from which pkg can be downloaded
+	CreateFuncWithURLWithContext(ctx context.Context, data *utils.FunctionConfig, pkgURL string) error
+
+	// StopFunction stops all function instances
 	StopFunction(tenant, namespace, name string) error
 
-	// StopFunctionWithID stop function instance
+	// StopFunctionWithContext stops all function instances
+	StopFunctionWithContext(ctx context.Context, tenant, namespace, name string) error
+
+	// StopFunctionWithID stops function instance
 	StopFunctionWithID(tenant, namespace, name string, instanceID int) error
 
-	// DeleteFunction delete an existing function
+	// StopFunctionWithIDWithContext stops function instance
+	StopFunctionWithIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) error
+
+	// DeleteFunction deletes an existing function
 	DeleteFunction(tenant, namespace, name string) error
+
+	// DeleteFunctionWithContext deletes an existing function
+	DeleteFunctionWithContext(ctx context.Context, tenant, namespace, name string) error
 
 	// Download Function Code
 	// @param destinationFile
@@ -63,6 +90,15 @@ type Functions interface {
 	// @param path
 	//        Path where data is located
 	DownloadFunction(path, destinationFile string) error
+
+	// Download Function Code
+	// @param ctx
+	//        context used for the request
+	// @param destinationFile
+	//        file where data should be downloaded to
+	// @param path
+	//        Path where data is located
+	DownloadFunctionWithContext(ctx context.Context, path, destinationFile string) error
 
 	// Download Function Code
 	// @param destinationFile
@@ -75,51 +111,110 @@ type Functions interface {
 	//        Function name
 	DownloadFunctionByNs(destinationFile, tenant, namespace, function string) error
 
-	// StartFunction start all function instances
+	// Download Function Code
+	// @param ctx
+	//        context used for the request
+	// @param destinationFile
+	//        file where data should be downloaded to
+	// @param tenant
+	//        Tenant name
+	// @param namespace
+	//        Namespace name
+	// @param function
+	//        Function name
+	DownloadFunctionByNsWithContext(ctx context.Context, destinationFile, tenant, namespace, function string) error
+
+	// StartFunction starts all function instances
 	StartFunction(tenant, namespace, name string) error
 
-	// StartFunctionWithID start function instance
+	// StartFunctionWithContext starts all function instances
+	StartFunctionWithContext(ctx context.Context, tenant, namespace, name string) error
+
+	// StartFunctionWithID starts function instance
 	StartFunctionWithID(tenant, namespace, name string, instanceID int) error
+
+	// StartFunctionWithIDWithContext starts function instance
+	StartFunctionWithIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) error
 
 	// RestartFunction restart all function instances
 	RestartFunction(tenant, namespace, name string) error
 
+	// RestartFunctionWithContext restart all function instances
+	RestartFunctionWithContext(ctx context.Context, tenant, namespace, name string) error
+
 	// RestartFunctionWithID restart function instance
 	RestartFunctionWithID(tenant, namespace, name string, instanceID int) error
+
+	// RestartFunctionWithIDWithContext restart function instance
+	RestartFunctionWithIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) error
 
 	// GetFunctions returns the list of functions
 	GetFunctions(tenant, namespace string) ([]string, error)
 
+	// GetFunctionsWithContext returns the list of functions
+	GetFunctionsWithContext(ctx context.Context, tenant, namespace string) ([]string, error)
+
 	// GetFunction returns the configuration for the specified function
 	GetFunction(tenant, namespace, name string) (utils.FunctionConfig, error)
 
+	// GetFunctionWithContext returns the configuration for the specified function
+	GetFunctionWithContext(ctx context.Context, tenant, namespace, name string) (utils.FunctionConfig, error)
+
 	// GetFunctionStatus returns the current status of a function
 	GetFunctionStatus(tenant, namespace, name string) (utils.FunctionStatus, error)
+
+	// GetFunctionStatusWithContext returns the current status of a function
+	GetFunctionStatusWithContext(ctx context.Context, tenant, namespace, name string) (utils.FunctionStatus, error)
 
 	// GetFunctionStatusWithInstanceID returns the current status of a function instance
 	GetFunctionStatusWithInstanceID(tenant, namespace, name string, instanceID int) (
 		utils.FunctionInstanceStatusData, error)
 
+	// GetFunctionStatusWithInstanceIDWithContext returns the current status of a function instance
+	GetFunctionStatusWithInstanceIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) (
+		utils.FunctionInstanceStatusData, error)
+
 	// GetFunctionStats returns the current stats of a function
 	GetFunctionStats(tenant, namespace, name string) (utils.FunctionStats, error)
+
+	// GetFunctionStatsWithContext returns the current stats of a function
+	GetFunctionStatsWithContext(ctx context.Context, tenant, namespace, name string) (utils.FunctionStats, error)
 
 	// GetFunctionStatsWithInstanceID gets the current stats of a function instance
 	GetFunctionStatsWithInstanceID(tenant, namespace, name string, instanceID int) (utils.FunctionInstanceStatsData, error)
 
-	// GetFunctionState fetch the current state associated with a Pulsar Function
+	// GetFunctionStatsWithInstanceIDWithContext gets the current stats of a function instance
+	GetFunctionStatsWithInstanceIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) (utils.FunctionInstanceStatsData, error)
+
+	// GetFunctionState fetches the current state associated with a Pulsar Function
 	//
 	// Response Example:
 	// 		{ "value : 12, version : 2"}
 	GetFunctionState(tenant, namespace, name, key string) (utils.FunctionState, error)
 
+	// GetFunctionStateWithContext fetches the current state associated with a Pulsar Function
+	//
+	// Response Example:
+	// 		{ "value : 12, version : 2"}
+	GetFunctionStateWithContext(ctx context.Context, tenant, namespace, name, key string) (utils.FunctionState, error)
+
 	// PutFunctionState puts the given state associated with a Pulsar Function
 	PutFunctionState(tenant, namespace, name string, state utils.FunctionState) error
+
+	// PutFunctionStateWithContext puts the given state associated with a Pulsar Function
+	PutFunctionStateWithContext(ctx context.Context, tenant, namespace, name string, state utils.FunctionState) error
 
 	// TriggerFunction triggers the function by writing to the input topic
 	TriggerFunction(tenant, namespace, name, topic, triggerValue, triggerFile string) (string, error)
 
+	// TriggerFunctionWithContext triggers the function by writing to the input topic
+	TriggerFunctionWithContext(ctx context.Context, tenant, namespace, name, topic, triggerValue, triggerFile string) (string, error)
+
 	// UpdateFunction updates the configuration for a function.
 	UpdateFunction(functionConfig *utils.FunctionConfig, fileName string, updateOptions *utils.UpdateOptions) error
+
+	// UpdateFunctionWithContext updates the configuration for a function.
+	UpdateFunctionWithContext(ctx context.Context, functionConfig *utils.FunctionConfig, fileName string, updateOptions *utils.UpdateOptions) error
 
 	// UpdateFunctionWithURL updates the configuration for a function.
 	//
@@ -129,8 +224,19 @@ type Functions interface {
 	// Http: http://www.repo.com/fileName.jar
 	UpdateFunctionWithURL(functionConfig *utils.FunctionConfig, pkgURL string, updateOptions *utils.UpdateOptions) error
 
+	// UpdateFunctionWithURLWithContext updates the configuration for a function.
+	//
+	// Update a function by providing url from which fun-pkg can be downloaded. supported url: http/file
+	// eg:
+	// File: file:/dir/fileName.jar
+	// Http: http://www.repo.com/fileName.jar
+	UpdateFunctionWithURLWithContext(ctx context.Context, functionConfig *utils.FunctionConfig, pkgURL string, updateOptions *utils.UpdateOptions) error
+
 	// Upload function to Pulsar
 	Upload(sourceFile, path string) error
+
+	// UploadWithContext function to Pulsar
+	UploadWithContext(ctx context.Context, sourceFile, path string) error
 }
 
 type functions struct {
@@ -161,6 +267,10 @@ func (f *functions) createTextFromFiled(w *multipart.Writer, value string) (io.W
 }
 
 func (f *functions) CreateFunc(funcConf *utils.FunctionConfig, fileName string) error {
+	return f.CreateFuncWithContext(context.Background(), funcConf, fileName)
+}
+
+func (f *functions) CreateFuncWithContext(ctx context.Context, funcConf *utils.FunctionConfig, fileName string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, funcConf.Tenant, funcConf.Namespace, funcConf.Name)
 
 	// buffer to store our request as bytes
@@ -211,7 +321,7 @@ func (f *functions) CreateFunc(funcConf *utils.FunctionConfig, fileName string) 
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = f.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = f.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -220,6 +330,10 @@ func (f *functions) CreateFunc(funcConf *utils.FunctionConfig, fileName string) 
 }
 
 func (f *functions) CreateFuncWithURL(funcConf *utils.FunctionConfig, pkgURL string) error {
+	return f.CreateFuncWithURLWithContext(context.Background(), funcConf, pkgURL)
+}
+
+func (f *functions) CreateFuncWithURLWithContext(ctx context.Context, funcConf *utils.FunctionConfig, pkgURL string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, funcConf.Tenant, funcConf.Namespace, funcConf.Name)
 	// buffer to store our request as bytes
 	bodyBuf := bytes.NewBufferString("")
@@ -256,7 +370,7 @@ func (f *functions) CreateFuncWithURL(funcConf *utils.FunctionConfig, pkgURL str
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = f.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = f.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -265,23 +379,39 @@ func (f *functions) CreateFuncWithURL(funcConf *utils.FunctionConfig, pkgURL str
 }
 
 func (f *functions) StopFunction(tenant, namespace, name string) error {
+	return f.StopFunctionWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) StopFunctionWithContext(ctx context.Context, tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Post(endpoint+"/stop", nil)
+	return f.pulsar.Client.Post(ctx, endpoint+"/stop", nil)
 }
 
 func (f *functions) StopFunctionWithID(tenant, namespace, name string, instanceID int) error {
+	return f.StopFunctionWithIDWithContext(context.Background(), tenant, namespace, name, instanceID)
+}
+
+func (f *functions) StopFunctionWithIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
 
-	return f.pulsar.Client.Post(endpoint+"/stop", nil)
+	return f.pulsar.Client.Post(ctx, endpoint+"/stop", nil)
 }
 
 func (f *functions) DeleteFunction(tenant, namespace, name string) error {
+	return f.DeleteFunctionWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) DeleteFunctionWithContext(ctx context.Context, tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Delete(endpoint)
+	return f.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (f *functions) DownloadFunction(path, destinationFile string) error {
+	return f.DownloadFunctionWithContext(context.Background(), path, destinationFile)
+}
+
+func (f *functions) DownloadFunctionWithContext(ctx context.Context, path, destinationFile string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, "download")
 	_, err := os.Open(destinationFile)
 	if err != nil {
@@ -298,7 +428,7 @@ func (f *functions) DownloadFunction(path, destinationFile string) error {
 	tmpMap := make(map[string]string)
 	tmpMap["path"] = path
 
-	_, err = f.pulsar.Client.GetWithOptions(endpoint, nil, tmpMap, false, file)
+	_, err = f.pulsar.Client.GetWithOptions(ctx, endpoint, nil, tmpMap, false, file)
 	if err != nil {
 		return err
 	}
@@ -306,6 +436,10 @@ func (f *functions) DownloadFunction(path, destinationFile string) error {
 }
 
 func (f *functions) DownloadFunctionByNs(destinationFile, tenant, namespace, function string) error {
+	return f.DownloadFunctionByNsWithContext(context.Background(), destinationFile, tenant, namespace, function)
+}
+
+func (f *functions) DownloadFunctionByNsWithContext(ctx context.Context, destinationFile, tenant, namespace, function string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, function, "download")
 	_, err := os.Open(destinationFile)
 	if err != nil {
@@ -319,7 +453,7 @@ func (f *functions) DownloadFunctionByNs(destinationFile, tenant, namespace, fun
 		return err
 	}
 
-	_, err = f.pulsar.Client.GetWithOptions(endpoint, nil, nil, false, file)
+	_, err = f.pulsar.Client.GetWithOptions(ctx, endpoint, nil, nil, false, file)
 	if err != nil {
 		return err
 	}
@@ -328,44 +462,73 @@ func (f *functions) DownloadFunctionByNs(destinationFile, tenant, namespace, fun
 }
 
 func (f *functions) StartFunction(tenant, namespace, name string) error {
+	return f.StartFunctionWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) StartFunctionWithContext(ctx context.Context, tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Post(endpoint+"/start", nil)
+	return f.pulsar.Client.Post(ctx, endpoint+"/start", nil)
 }
 
 func (f *functions) StartFunctionWithID(tenant, namespace, name string, instanceID int) error {
+	return f.StartFunctionWithIDWithContext(context.Background(), tenant, namespace, name, instanceID)
+}
+
+func (f *functions) StartFunctionWithIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
 
-	return f.pulsar.Client.Post(endpoint+"/start", nil)
+	return f.pulsar.Client.Post(ctx, endpoint+"/start", nil)
 }
 
 func (f *functions) RestartFunction(tenant, namespace, name string) error {
+	return f.RestartFunctionWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) RestartFunctionWithContext(ctx context.Context, tenant, namespace, name string) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	return f.pulsar.Client.Post(endpoint+"/restart", nil)
+	return f.pulsar.Client.Post(ctx, endpoint+"/restart", nil)
 }
 
 func (f *functions) RestartFunctionWithID(tenant, namespace, name string, instanceID int) error {
+	return f.RestartFunctionWithIDWithContext(context.Background(), tenant, namespace, name, instanceID)
+}
+
+func (f *functions) RestartFunctionWithIDWithContext(ctx context.Context, tenant, namespace, name string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
 
-	return f.pulsar.Client.Post(endpoint+"/restart", nil)
+	return f.pulsar.Client.Post(ctx, endpoint+"/restart", nil)
 }
 
 func (f *functions) GetFunctions(tenant, namespace string) ([]string, error) {
+	return f.GetFunctionsWithContext(context.Background(), tenant, namespace)
+}
+
+func (f *functions) GetFunctionsWithContext(ctx context.Context, tenant, namespace string) ([]string, error) {
 	var functions []string
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace)
-	err := f.pulsar.Client.Get(endpoint, &functions)
+	err := f.pulsar.Client.Get(ctx, endpoint, &functions)
 	return functions, err
 }
 
 func (f *functions) GetFunction(tenant, namespace, name string) (utils.FunctionConfig, error) {
+	return f.GetFunctionWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) GetFunctionWithContext(ctx context.Context, tenant, namespace, name string) (utils.FunctionConfig, error) {
 	var functionConfig utils.FunctionConfig
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	err := f.pulsar.Client.Get(endpoint, &functionConfig)
+	err := f.pulsar.Client.Get(ctx, endpoint, &functionConfig)
 	return functionConfig, err
 }
 
 func (f *functions) UpdateFunction(functionConfig *utils.FunctionConfig, fileName string,
+	updateOptions *utils.UpdateOptions) error {
+	return f.UpdateFunctionWithContext(context.Background(), functionConfig, fileName, updateOptions)
+}
+
+func (f *functions) UpdateFunctionWithContext(ctx context.Context, functionConfig *utils.FunctionConfig, fileName string,
 	updateOptions *utils.UpdateOptions) error {
 	endpoint := f.pulsar.endpoint(f.basePath, functionConfig.Tenant, functionConfig.Namespace, functionConfig.Name)
 	// buffer to store our request as bytes
@@ -433,7 +596,7 @@ func (f *functions) UpdateFunction(functionConfig *utils.FunctionConfig, fileNam
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = f.pulsar.Client.PutWithMultiPart(endpoint, bodyBuf, contentType)
+	err = f.pulsar.Client.PutWithMultiPart(ctx, endpoint, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -442,6 +605,11 @@ func (f *functions) UpdateFunction(functionConfig *utils.FunctionConfig, fileNam
 }
 
 func (f *functions) UpdateFunctionWithURL(functionConfig *utils.FunctionConfig, pkgURL string,
+	updateOptions *utils.UpdateOptions) error {
+	return f.UpdateFunctionWithURLWithContext(context.Background(), functionConfig, pkgURL, updateOptions)
+}
+
+func (f *functions) UpdateFunctionWithURLWithContext(ctx context.Context, functionConfig *utils.FunctionConfig, pkgURL string,
 	updateOptions *utils.UpdateOptions) error {
 	endpoint := f.pulsar.endpoint(f.basePath, functionConfig.Tenant, functionConfig.Namespace, functionConfig.Name)
 	// buffer to store our request as bytes
@@ -498,7 +666,7 @@ func (f *functions) UpdateFunctionWithURL(functionConfig *utils.FunctionConfig, 
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = f.pulsar.Client.PutWithMultiPart(endpoint, bodyBuf, contentType)
+	err = f.pulsar.Client.PutWithMultiPart(ctx, endpoint, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -507,45 +675,71 @@ func (f *functions) UpdateFunctionWithURL(functionConfig *utils.FunctionConfig, 
 }
 
 func (f *functions) GetFunctionStatus(tenant, namespace, name string) (utils.FunctionStatus, error) {
+	return f.GetFunctionStatusWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) GetFunctionStatusWithContext(ctx context.Context, tenant, namespace, name string) (utils.FunctionStatus, error) {
 	var functionStatus utils.FunctionStatus
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	err := f.pulsar.Client.Get(endpoint+"/status", &functionStatus)
+	err := f.pulsar.Client.Get(ctx, endpoint+"/status", &functionStatus)
 	return functionStatus, err
 }
 
 func (f *functions) GetFunctionStatusWithInstanceID(tenant, namespace, name string,
 	instanceID int) (utils.FunctionInstanceStatusData, error) {
+	return f.GetFunctionStatusWithInstanceIDWithContext(context.Background(), tenant, namespace, name, instanceID)
+}
+
+func (f *functions) GetFunctionStatusWithInstanceIDWithContext(ctx context.Context, tenant, namespace, name string,
+	instanceID int) (utils.FunctionInstanceStatusData, error) {
 	var functionInstanceStatusData utils.FunctionInstanceStatusData
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
-	err := f.pulsar.Client.Get(endpoint+"/status", &functionInstanceStatusData)
+	err := f.pulsar.Client.Get(ctx, endpoint+"/status", &functionInstanceStatusData)
 	return functionInstanceStatusData, err
 }
 
 func (f *functions) GetFunctionStats(tenant, namespace, name string) (utils.FunctionStats, error) {
+	return f.GetFunctionStatsWithContext(context.Background(), tenant, namespace, name)
+}
+
+func (f *functions) GetFunctionStatsWithContext(ctx context.Context, tenant, namespace, name string) (utils.FunctionStats, error) {
 	var functionStats utils.FunctionStats
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name)
-	err := f.pulsar.Client.Get(endpoint+"/stats", &functionStats)
+	err := f.pulsar.Client.Get(ctx, endpoint+"/stats", &functionStats)
 	return functionStats, err
 }
 
 func (f *functions) GetFunctionStatsWithInstanceID(tenant, namespace, name string,
 	instanceID int) (utils.FunctionInstanceStatsData, error) {
+	return f.GetFunctionStatsWithInstanceIDWithContext(context.Background(), tenant, namespace, name, instanceID)
+}
+
+func (f *functions) GetFunctionStatsWithInstanceIDWithContext(ctx context.Context, tenant, namespace, name string,
+	instanceID int) (utils.FunctionInstanceStatsData, error) {
 	var functionInstanceStatsData utils.FunctionInstanceStatsData
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, id)
-	err := f.pulsar.Client.Get(endpoint+"/stats", &functionInstanceStatsData)
+	err := f.pulsar.Client.Get(ctx, endpoint+"/stats", &functionInstanceStatsData)
 	return functionInstanceStatsData, err
 }
 
 func (f *functions) GetFunctionState(tenant, namespace, name, key string) (utils.FunctionState, error) {
+	return f.GetFunctionStateWithContext(context.Background(), tenant, namespace, name, key)
+}
+
+func (f *functions) GetFunctionStateWithContext(ctx context.Context, tenant, namespace, name, key string) (utils.FunctionState, error) {
 	var functionState utils.FunctionState
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, "state", key)
-	err := f.pulsar.Client.Get(endpoint, &functionState)
+	err := f.pulsar.Client.Get(ctx, endpoint, &functionState)
 	return functionState, err
 }
 
 func (f *functions) PutFunctionState(tenant, namespace, name string, state utils.FunctionState) error {
+	return f.PutFunctionStateWithContext(context.Background(), tenant, namespace, name, state)
+}
+
+func (f *functions) PutFunctionStateWithContext(ctx context.Context, tenant, namespace, name string, state utils.FunctionState) error {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, "state", state.Key)
 
 	// buffer to store our request as bytes
@@ -578,7 +772,7 @@ func (f *functions) PutFunctionState(tenant, namespace, name string, state utils
 
 	contentType := multiPartWriter.FormDataContentType()
 
-	err = f.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = f.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 
 	if err != nil {
 		return err
@@ -588,6 +782,10 @@ func (f *functions) PutFunctionState(tenant, namespace, name string, state utils
 }
 
 func (f *functions) TriggerFunction(tenant, namespace, name, topic, triggerValue, triggerFile string) (string, error) {
+	return f.TriggerFunctionWithContext(context.Background(), tenant, namespace, name, topic, triggerValue, triggerFile)
+}
+
+func (f *functions) TriggerFunctionWithContext(ctx context.Context, tenant, namespace, name, topic, triggerValue, triggerFile string) (string, error) {
 	endpoint := f.pulsar.endpoint(f.basePath, tenant, namespace, name, "trigger")
 
 	// buffer to store our request as bytes
@@ -647,7 +845,7 @@ func (f *functions) TriggerFunction(tenant, namespace, name, topic, triggerValue
 
 	contentType := multiPartWriter.FormDataContentType()
 	var str string
-	err := f.pulsar.Client.PostWithMultiPart(endpoint, &str, bodyBuf, contentType)
+	err := f.pulsar.Client.PostWithMultiPart(ctx, endpoint, &str, bodyBuf, contentType)
 	if err != nil {
 		return "", err
 	}
@@ -656,6 +854,10 @@ func (f *functions) TriggerFunction(tenant, namespace, name, topic, triggerValue
 }
 
 func (f *functions) Upload(sourceFile, path string) error {
+	return f.UploadWithContext(context.Background(), sourceFile, path)
+}
+
+func (f *functions) UploadWithContext(ctx context.Context, sourceFile, path string) error {
 	if strings.TrimSpace(sourceFile) == "" && strings.TrimSpace(path) == "" {
 		return fmt.Errorf("source file or path is empty")
 	}
@@ -682,5 +884,5 @@ func (f *functions) Upload(sourceFile, path string) error {
 	if err != nil {
 		return err
 	}
-	return f.pulsar.Client.PostWithMultiPart(endpoint, nil, &b, w.FormDataContentType())
+	return f.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, &b, w.FormDataContentType())
 }

--- a/pulsaradmin/pkg/admin/functions_worker.go
+++ b/pulsaradmin/pkg/admin/functions_worker.go
@@ -18,24 +18,41 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 )
 
 type FunctionsWorker interface {
-	// Get all functions stats on a worker
+	// GetFunctionsStats returns all functions stats on a worker
 	GetFunctionsStats() ([]*utils.WorkerFunctionInstanceStats, error)
 
-	// Get worker metrics
+	// GetFunctionsStatsWithContext returns all functions stats on a worker
+	GetFunctionsStatsWithContext(context.Context) ([]*utils.WorkerFunctionInstanceStats, error)
+
+	// GetMetrics returns worker metrics
 	GetMetrics() ([]*utils.Metrics, error)
 
-	// Get List of all workers belonging to this cluster
+	// GetMetricsWithContext returns worker metrics
+	GetMetricsWithContext(context.Context) ([]*utils.Metrics, error)
+
+	// GetCluster returns all workers belonging to this cluster
 	GetCluster() ([]*utils.WorkerInfo, error)
 
-	// Get the worker who is the leader of the clusterv
+	// GetClusterWithContext returns all workers belonging to this cluster
+	GetClusterWithContext(context.Context) ([]*utils.WorkerInfo, error)
+
+	// GetClusterLeader returns the leader worker of the cluster
 	GetClusterLeader() (*utils.WorkerInfo, error)
 
-	// Get the function assignment among the cluster
+	// GetClusterLeaderWithContext returns the leader worker of the cluster
+	GetClusterLeaderWithContext(context.Context) (*utils.WorkerInfo, error)
+
+	// GetAssignments returns the cluster assignments
 	GetAssignments() (map[string][]string, error)
+
+	// GetAssignmentsWithContext returns the cluster assignments
+	GetAssignmentsWithContext(context.Context) (map[string][]string, error)
 }
 
 type worker struct {
@@ -53,9 +70,13 @@ func (c *pulsarClient) FunctionsWorker() FunctionsWorker {
 }
 
 func (w *worker) GetFunctionsStats() ([]*utils.WorkerFunctionInstanceStats, error) {
+	return w.GetFunctionsStatsWithContext(context.Background())
+}
+
+func (w *worker) GetFunctionsStatsWithContext(ctx context.Context) ([]*utils.WorkerFunctionInstanceStats, error) {
 	endpoint := w.pulsar.endpoint(w.workerStatsPath, "functionsmetrics")
 	var workerStats []*utils.WorkerFunctionInstanceStats
-	err := w.pulsar.Client.Get(endpoint, &workerStats)
+	err := w.pulsar.Client.Get(ctx, endpoint, &workerStats)
 	if err != nil {
 		return nil, err
 	}
@@ -63,9 +84,13 @@ func (w *worker) GetFunctionsStats() ([]*utils.WorkerFunctionInstanceStats, erro
 }
 
 func (w *worker) GetMetrics() ([]*utils.Metrics, error) {
+	return w.GetMetricsWithContext(context.Background())
+}
+
+func (w *worker) GetMetricsWithContext(ctx context.Context) ([]*utils.Metrics, error) {
 	endpoint := w.pulsar.endpoint(w.workerStatsPath, "metrics")
 	var metrics []*utils.Metrics
-	err := w.pulsar.Client.Get(endpoint, &metrics)
+	err := w.pulsar.Client.Get(ctx, endpoint, &metrics)
 	if err != nil {
 		return nil, err
 	}
@@ -73,9 +98,13 @@ func (w *worker) GetMetrics() ([]*utils.Metrics, error) {
 }
 
 func (w *worker) GetCluster() ([]*utils.WorkerInfo, error) {
+	return w.GetClusterWithContext(context.Background())
+}
+
+func (w *worker) GetClusterWithContext(ctx context.Context) ([]*utils.WorkerInfo, error) {
 	endpoint := w.pulsar.endpoint(w.workerPath, "cluster")
 	var workersInfo []*utils.WorkerInfo
-	err := w.pulsar.Client.Get(endpoint, &workersInfo)
+	err := w.pulsar.Client.Get(ctx, endpoint, &workersInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -83,9 +112,13 @@ func (w *worker) GetCluster() ([]*utils.WorkerInfo, error) {
 }
 
 func (w *worker) GetClusterLeader() (*utils.WorkerInfo, error) {
+	return w.GetClusterLeaderWithContext(context.Background())
+}
+
+func (w *worker) GetClusterLeaderWithContext(ctx context.Context) (*utils.WorkerInfo, error) {
 	endpoint := w.pulsar.endpoint(w.workerPath, "cluster", "leader")
 	var workerInfo utils.WorkerInfo
-	err := w.pulsar.Client.Get(endpoint, &workerInfo)
+	err := w.pulsar.Client.Get(ctx, endpoint, &workerInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +126,13 @@ func (w *worker) GetClusterLeader() (*utils.WorkerInfo, error) {
 }
 
 func (w *worker) GetAssignments() (map[string][]string, error) {
+	return w.GetAssignmentsWithContext(context.Background())
+}
+
+func (w *worker) GetAssignmentsWithContext(ctx context.Context) (map[string][]string, error) {
 	endpoint := w.pulsar.endpoint(w.workerPath, "assignments")
 	var assignments map[string][]string
-	err := w.pulsar.Client.Get(endpoint, &assignments)
+	err := w.pulsar.Client.Get(ctx, endpoint, &assignments)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsaradmin/pkg/admin/namespace.go
+++ b/pulsaradmin/pkg/admin/namespace.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 	"strings"
@@ -30,69 +31,137 @@ type Namespaces interface {
 	// GetNamespaces returns the list of all the namespaces for a certain tenant
 	GetNamespaces(tenant string) ([]string, error)
 
+	// GetNamespacesWithContext returns the list of all the namespaces for a certain tenant
+	GetNamespacesWithContext(ctx context.Context, tenant string) ([]string, error)
+
 	// GetTopics returns the list of all the topics under a certain namespace
 	GetTopics(namespace string) ([]string, error)
+
+	// GetTopicsWithContext returns the list of all the topics under a certain namespace
+	GetTopicsWithContext(ctx context.Context, namespace string) ([]string, error)
 
 	// GetPolicies returns the dump all the policies specified for a namespace
 	GetPolicies(namespace string) (*utils.Policies, error)
 
+	// GetPoliciesWithContext returns the dump all the policies specified for a namespace
+	GetPoliciesWithContext(ctx context.Context, namespace string) (*utils.Policies, error)
+
 	// CreateNamespace creates a new empty namespace with no policies attached
 	CreateNamespace(namespace string) error
+
+	// CreateNamespaceWithContext creates a new empty namespace with no policies attached
+	CreateNamespaceWithContext(ctx context.Context, namespace string) error
 
 	// CreateNsWithNumBundles creates a new empty namespace with no policies attached
 	CreateNsWithNumBundles(namespace string, numBundles int) error
 
+	// CreateNsWithNumBundlesWithContext creates a new empty namespace with no policies attached
+	CreateNsWithNumBundlesWithContext(ctx context.Context, namespace string, numBundles int) error
+
 	// CreateNsWithPolices creates a new namespace with the specified policies
 	CreateNsWithPolices(namespace string, polices utils.Policies) error
+
+	// CreateNsWithPolicesWithContext creates a new namespace with the specified policies
+	CreateNsWithPolicesWithContext(ctx context.Context, namespace string, polices utils.Policies) error
 
 	// CreateNsWithBundlesData creates a new empty namespace with no policies attached
 	CreateNsWithBundlesData(namespace string, bundleData *utils.BundlesData) error
 
+	// CreateNsWithBundlesDataWithContext creates a new empty namespace with no policies attached
+	CreateNsWithBundlesDataWithContext(ctx context.Context, namespace string, bundleData *utils.BundlesData) error
+
 	// DeleteNamespace deletes an existing namespace
 	DeleteNamespace(namespace string) error
+
+	// DeleteNamespaceWithContext deletes an existing namespace
+	DeleteNamespaceWithContext(ctx context.Context, namespace string) error
 
 	// DeleteNamespaceBundle deletes an existing bundle in a namespace
 	DeleteNamespaceBundle(namespace string, bundleRange string) error
 
+	// DeleteNamespaceBundleWithContext deletes an existing bundle in a namespace
+	DeleteNamespaceBundleWithContext(ctx context.Context, namespace string, bundleRange string) error
+
 	// SetNamespaceMessageTTL sets the messages Time to Live for all the topics within a namespace
 	SetNamespaceMessageTTL(namespace string, ttlInSeconds int) error
+
+	// SetNamespaceMessageTTLWithContext sets the messages Time to Live for all the topics within a namespace
+	SetNamespaceMessageTTLWithContext(ctx context.Context, namespace string, ttlInSeconds int) error
 
 	// GetNamespaceMessageTTL returns the message TTL for a namespace
 	GetNamespaceMessageTTL(namespace string) (int, error)
 
+	// GetNamespaceMessageTTLWithContext returns the message TTL for a namespace
+	GetNamespaceMessageTTLWithContext(ctx context.Context, namespace string) (int, error)
+
 	// GetRetention returns the retention configuration for a namespace
 	GetRetention(namespace string) (*utils.RetentionPolicies, error)
+
+	// GetRetentionWithContext returns the retention configuration for a namespace
+	GetRetentionWithContext(ctx context.Context, namespace string) (*utils.RetentionPolicies, error)
 
 	// SetRetention sets the retention configuration for all the topics on a namespace
 	SetRetention(namespace string, policy utils.RetentionPolicies) error
 
+	// SetRetentionWithContext sets the retention configuration for all the topics on a namespace
+	SetRetentionWithContext(ctx context.Context, namespace string, policy utils.RetentionPolicies) error
+
 	// GetBacklogQuotaMap returns backlog quota map on a namespace
 	GetBacklogQuotaMap(namespace string) (map[utils.BacklogQuotaType]utils.BacklogQuota, error)
+
+	// GetBacklogQuotaMapWithContext returns backlog quota map on a namespace
+	GetBacklogQuotaMapWithContext(ctx context.Context, namespace string) (map[utils.BacklogQuotaType]utils.BacklogQuota, error)
 
 	// SetBacklogQuota sets a backlog quota for all the topics on a namespace
 	SetBacklogQuota(namespace string, backlogQuota utils.BacklogQuota, backlogQuotaType utils.BacklogQuotaType) error
 
+	// SetBacklogQuotaWithContext sets a backlog quota for all the topics on a namespace
+	SetBacklogQuotaWithContext(ctx context.Context, namespace string, backlogQuota utils.BacklogQuota, backlogQuotaType utils.BacklogQuotaType) error
+
 	// RemoveBacklogQuota removes a backlog quota policy from a namespace
 	RemoveBacklogQuota(namespace string) error
+
+	// RemoveBacklogQuotaWithContext removes a backlog quota policy from a namespace
+	RemoveBacklogQuotaWithContext(ctx context.Context, namespace string) error
 
 	// GetTopicAutoCreation returns the topic auto-creation config for a namespace
 	GetTopicAutoCreation(namespace utils.NameSpaceName) (*utils.TopicAutoCreationConfig, error)
 
+	// GetTopicAutoCreationWithContext returns the topic auto-creation config for a namespace
+	GetTopicAutoCreationWithContext(ctx context.Context, namespace utils.NameSpaceName) (*utils.TopicAutoCreationConfig, error)
+
 	// SetTopicAutoCreation sets topic auto-creation config for a namespace, overriding broker settings
 	SetTopicAutoCreation(namespace utils.NameSpaceName, config utils.TopicAutoCreationConfig) error
+
+	// SetTopicAutoCreationWithContext sets topic auto-creation config for a namespace, overriding broker settings
+	SetTopicAutoCreationWithContext(ctx context.Context, namespace utils.NameSpaceName, config utils.TopicAutoCreationConfig) error
 
 	// RemoveTopicAutoCreation removes topic auto-creation config for a namespace, defaulting to broker settings
 	RemoveTopicAutoCreation(namespace utils.NameSpaceName) error
 
+	// RemoveTopicAutoCreationWithContext removes topic auto-creation config for a namespace, defaulting to broker settings
+	RemoveTopicAutoCreationWithContext(ctx context.Context, namespace utils.NameSpaceName) error
+
 	// SetSchemaValidationEnforced sets schema validation enforced for namespace
 	SetSchemaValidationEnforced(namespace utils.NameSpaceName, schemaValidationEnforced bool) error
+
+	// SetSchemaValidationEnforcedWithContext sets schema validation enforced for namespace
+	SetSchemaValidationEnforcedWithContext(ctx context.Context, namespace utils.NameSpaceName, schemaValidationEnforced bool) error
 
 	// GetSchemaValidationEnforced returns schema validation enforced for namespace
 	GetSchemaValidationEnforced(namespace utils.NameSpaceName) (bool, error)
 
+	// GetSchemaValidationEnforcedWithContext returns schema validation enforced for namespace
+	GetSchemaValidationEnforcedWithContext(ctx context.Context, namespace utils.NameSpaceName) (bool, error)
+
 	// SetSchemaAutoUpdateCompatibilityStrategy sets the strategy used to check the new schema provided
 	// by a producer is compatible with the current schema before it is installed
 	SetSchemaAutoUpdateCompatibilityStrategy(namespace utils.NameSpaceName,
+		strategy utils.SchemaAutoUpdateCompatibilityStrategy) error
+
+	// SetSchemaAutoUpdateCompatibilityStrategyWithContext sets the strategy used to check the new schema provided
+	// by a producer is compatible with the current schema before it is installed
+	SetSchemaAutoUpdateCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName,
 		strategy utils.SchemaAutoUpdateCompatibilityStrategy) error
 
 	// GetSchemaAutoUpdateCompatibilityStrategy returns the strategy used to check the new schema provided
@@ -100,230 +169,460 @@ type Namespaces interface {
 	GetSchemaAutoUpdateCompatibilityStrategy(namespace utils.NameSpaceName) (
 		utils.SchemaAutoUpdateCompatibilityStrategy, error)
 
+	// GetSchemaAutoUpdateCompatibilityStrategyWithContext returns the strategy used to check the new schema provided
+	// by a producer is compatible with the current schema before it is installed
+	GetSchemaAutoUpdateCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName) (
+		utils.SchemaAutoUpdateCompatibilityStrategy, error)
+
 	// SetSchemaCompatibilityStrategy sets the strategy used to check the new schema provided
 	// by a producer is compatible with the current schema before it is installed
 	SetSchemaCompatibilityStrategy(namespace utils.NameSpaceName,
+		strategy utils.SchemaCompatibilityStrategy) error
+
+	// SetSchemaCompatibilityStrategyWithContext sets the strategy used to check the new schema provided
+	// by a producer is compatible with the current schema before it is installed
+	SetSchemaCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName,
 		strategy utils.SchemaCompatibilityStrategy) error
 
 	// GetSchemaCompatibilityStrategy returns the strategy used to check the new schema provided
 	// by a producer is compatible with the current schema before it is installed
 	GetSchemaCompatibilityStrategy(namespace utils.NameSpaceName) (utils.SchemaCompatibilityStrategy, error)
 
+	// GetSchemaCompatibilityStrategyWithContext returns the strategy used to check the new schema provided
+	// by a producer is compatible with the current schema before it is installed
+	GetSchemaCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.SchemaCompatibilityStrategy, error)
+
 	// ClearOffloadDeleteLag clears the offload deletion lag for a namespace.
 	ClearOffloadDeleteLag(namespace utils.NameSpaceName) error
+
+	// ClearOffloadDeleteLagWithContext clears the offload deletion lag for a namespace.
+	ClearOffloadDeleteLagWithContext(ctx context.Context, namespace utils.NameSpaceName) error
 
 	// SetOffloadDeleteLag sets the offload deletion lag for a namespace
 	SetOffloadDeleteLag(namespace utils.NameSpaceName, timeMs int64) error
 
+	// SetOffloadDeleteLagWithContext sets the offload deletion lag for a namespace
+	SetOffloadDeleteLagWithContext(ctx context.Context, namespace utils.NameSpaceName, timeMs int64) error
+
 	// GetOffloadDeleteLag returns the offload deletion lag for a namespace, in milliseconds
 	GetOffloadDeleteLag(namespace utils.NameSpaceName) (int64, error)
+
+	// GetOffloadDeleteLagWithContext returns the offload deletion lag for a namespace, in milliseconds
+	GetOffloadDeleteLagWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error)
 
 	// SetOffloadThreshold sets the offloadThreshold for a namespace
 	SetOffloadThreshold(namespace utils.NameSpaceName, threshold int64) error
 
+	// SetOffloadThresholdWithContext sets the offloadThreshold for a namespace
+	SetOffloadThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName, threshold int64) error
+
 	// GetOffloadThreshold returns the offloadThreshold for a namespace
 	GetOffloadThreshold(namespace utils.NameSpaceName) (int64, error)
+
+	// GetOffloadThresholdWithContext returns the offloadThreshold for a namespace
+	GetOffloadThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error)
 
 	// SetOffloadThresholdInSeconds sets the offloadThresholdInSeconds for a namespace
 	SetOffloadThresholdInSeconds(namespace utils.NameSpaceName, threshold int64) error
 
+	// SetOffloadThresholdInSecondsWithContext sets the offloadThresholdInSeconds for a namespace
+	SetOffloadThresholdInSecondsWithContext(ctx context.Context, namespace utils.NameSpaceName, threshold int64) error
+
 	// GetOffloadThresholdInSeconds returns the offloadThresholdInSeconds for a namespace
 	GetOffloadThresholdInSeconds(namespace utils.NameSpaceName) (int64, error)
+
+	// GetOffloadThresholdInSecondsWithContext returns the offloadThresholdInSeconds for a namespace
+	GetOffloadThresholdInSecondsWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error)
 
 	// SetCompactionThreshold sets the compactionThreshold for a namespace
 	SetCompactionThreshold(namespace utils.NameSpaceName, threshold int64) error
 
+	// SetCompactionThresholdWithContext sets the compactionThreshold for a namespace
+	SetCompactionThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName, threshold int64) error
+
 	// GetCompactionThreshold returns the compactionThreshold for a namespace
 	GetCompactionThreshold(namespace utils.NameSpaceName) (int64, error)
+
+	// GetCompactionThresholdWithContext returns the compactionThreshold for a namespace
+	GetCompactionThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error)
 
 	// SetMaxConsumersPerSubscription sets maxConsumersPerSubscription for a namespace.
 	SetMaxConsumersPerSubscription(namespace utils.NameSpaceName, max int) error
 
+	// SetMaxConsumersPerSubscriptionWithContext sets maxConsumersPerSubscription for a namespace.
+	SetMaxConsumersPerSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error
+
 	// GetMaxConsumersPerSubscription returns the maxConsumersPerSubscription for a namespace.
 	GetMaxConsumersPerSubscription(namespace utils.NameSpaceName) (int, error)
+
+	// GetMaxConsumersPerSubscriptionWithContext returns the maxConsumersPerSubscription for a namespace.
+	GetMaxConsumersPerSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error)
 
 	// SetMaxConsumersPerTopic sets maxConsumersPerTopic for a namespace.
 	SetMaxConsumersPerTopic(namespace utils.NameSpaceName, max int) error
 
+	// SetMaxConsumersPerTopicWithContext sets maxConsumersPerTopic for a namespace.
+	SetMaxConsumersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error
+
 	// GetMaxConsumersPerTopic returns the maxProducersPerTopic for a namespace.
 	GetMaxConsumersPerTopic(namespace utils.NameSpaceName) (int, error)
+
+	// GetMaxConsumersPerTopicWithContext returns the maxProducersPerTopic for a namespace.
+	GetMaxConsumersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error)
 
 	// SetMaxProducersPerTopic sets maxProducersPerTopic for a namespace.
 	SetMaxProducersPerTopic(namespace utils.NameSpaceName, max int) error
 
+	// SetMaxProducersPerTopicWithContext sets maxProducersPerTopic for a namespace.
+	SetMaxProducersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error
+
 	// GetMaxProducersPerTopic returns the maxProducersPerTopic for a namespace.
 	GetMaxProducersPerTopic(namespace utils.NameSpaceName) (int, error)
+
+	// GetMaxProducersPerTopicWithContext returns the maxProducersPerTopic for a namespace.
+	GetMaxProducersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error)
 
 	// SetMaxTopicsPerNamespace sets maxTopicsPerNamespace for a namespace.
 	SetMaxTopicsPerNamespace(namespace utils.NameSpaceName, max int) error
 
+	// SetMaxTopicsPerNamespaceWithContext sets maxTopicsPerNamespace for a namespace.
+	SetMaxTopicsPerNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error
+
 	// GetMaxTopicsPerNamespace returns the maxTopicsPerNamespace for a namespace.
 	GetMaxTopicsPerNamespace(namespace utils.NameSpaceName) (int, error)
+
+	// GetMaxTopicsPerNamespaceWithContext returns the maxTopicsPerNamespace for a namespace.
+	GetMaxTopicsPerNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error)
 
 	// RemoveMaxTopicsPerNamespace removes maxTopicsPerNamespace configuration for a namespace,
 	// defaulting to broker settings
 	RemoveMaxTopicsPerNamespace(namespace utils.NameSpaceName) error
 
+	// RemoveMaxTopicsPerNamespaceWithContext removes maxTopicsPerNamespace configuration for a namespace,
+	// defaulting to broker settings
+	RemoveMaxTopicsPerNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName) error
+
 	// GetNamespaceReplicationClusters returns the replication clusters for a namespace
 	GetNamespaceReplicationClusters(namespace string) ([]string, error)
+
+	// GetNamespaceReplicationClustersWithContext returns the replication clusters for a namespace
+	GetNamespaceReplicationClustersWithContext(ctx context.Context, namespace string) ([]string, error)
 
 	// SetNamespaceReplicationClusters returns the replication clusters for a namespace
 	SetNamespaceReplicationClusters(namespace string, clusterIDs []string) error
 
+	// SetNamespaceReplicationClustersWithContext returns the replication clusters for a namespace
+	SetNamespaceReplicationClustersWithContext(ctx context.Context, namespace string, clusterIDs []string) error
+
 	// SetNamespaceAntiAffinityGroup sets anti-affinity group name for a namespace
 	SetNamespaceAntiAffinityGroup(namespace string, namespaceAntiAffinityGroup string) error
+
+	// SetNamespaceAntiAffinityGroupWithContext sets anti-affinity group name for a namespace
+	SetNamespaceAntiAffinityGroupWithContext(ctx context.Context, namespace string, namespaceAntiAffinityGroup string) error
 
 	// GetAntiAffinityNamespaces returns all namespaces that grouped with given anti-affinity group
 	GetAntiAffinityNamespaces(tenant, cluster, namespaceAntiAffinityGroup string) ([]string, error)
 
+	// GetAntiAffinityNamespacesWithContext returns all namespaces that grouped with given anti-affinity group
+	GetAntiAffinityNamespacesWithContext(ctx context.Context, tenant, cluster, namespaceAntiAffinityGroup string) ([]string, error)
+
 	// GetNamespaceAntiAffinityGroup returns anti-affinity group name for a namespace
 	GetNamespaceAntiAffinityGroup(namespace string) (string, error)
 
+	// GetNamespaceAntiAffinityGroupWithContext returns anti-affinity group name for a namespace
+	GetNamespaceAntiAffinityGroupWithContext(ctx context.Context, namespace string) (string, error)
+
 	// DeleteNamespaceAntiAffinityGroup deletes anti-affinity group name for a namespace
 	DeleteNamespaceAntiAffinityGroup(namespace string) error
+
+	// DeleteNamespaceAntiAffinityGroupWithContext deletes anti-affinity group name for a namespace
+	DeleteNamespaceAntiAffinityGroupWithContext(ctx context.Context, namespace string) error
 
 	// SetDeduplicationStatus sets the deduplication status for all topics within a namespace
 	// When deduplication is enabled, the broker will prevent to store the same Message multiple times
 	SetDeduplicationStatus(namespace string, enableDeduplication bool) error
 
+	// SetDeduplicationStatusWithContext sets the deduplication status for all topics within a namespace
+	// When deduplication is enabled, the broker will prevent to store the same Message multiple times
+	SetDeduplicationStatusWithContext(ctx context.Context, namespace string, enableDeduplication bool) error
+
 	// SetPersistence sets the persistence configuration for all the topics on a namespace
 	SetPersistence(namespace string, persistence utils.PersistencePolicies) error
 
+	// SetPersistenceWithContext sets the persistence configuration for all the topics on a namespace
+	SetPersistenceWithContext(ctx context.Context, namespace string, persistence utils.PersistencePolicies) error
+
 	// GetPersistence returns the persistence configuration for a namespace
 	GetPersistence(namespace string) (*utils.PersistencePolicies, error)
+
+	// GetPersistenceWithContext returns the persistence configuration for a namespace
+	GetPersistenceWithContext(ctx context.Context, namespace string) (*utils.PersistencePolicies, error)
 
 	// SetBookieAffinityGroup sets bookie affinity group for a namespace to isolate namespace write to bookies that are
 	// part of given affinity group
 	SetBookieAffinityGroup(namespace string, bookieAffinityGroup utils.BookieAffinityGroupData) error
 
+	// SetBookieAffinityGroupWithContext sets bookie affinity group for a namespace to isolate namespace write to bookies that are
+	// part of given affinity group
+	SetBookieAffinityGroupWithContext(ctx context.Context, namespace string, bookieAffinityGroup utils.BookieAffinityGroupData) error
+
 	// DeleteBookieAffinityGroup deletes bookie affinity group configured for a namespace
 	DeleteBookieAffinityGroup(namespace string) error
+
+	// DeleteBookieAffinityGroupWithContext deletes bookie affinity group configured for a namespace
+	DeleteBookieAffinityGroupWithContext(ctx context.Context, namespace string) error
 
 	// GetBookieAffinityGroup returns bookie affinity group configured for a namespace
 	GetBookieAffinityGroup(namespace string) (*utils.BookieAffinityGroupData, error)
 
+	// GetBookieAffinityGroupWithContext returns bookie affinity group configured for a namespace
+	GetBookieAffinityGroupWithContext(ctx context.Context, namespace string) (*utils.BookieAffinityGroupData, error)
+
 	// Unload a namespace from the current serving broker
 	Unload(namespace string) error
+
+	// UnloadWithContext a namespace from the current serving broker
+	UnloadWithContext(ctx context.Context, namespace string) error
 
 	// UnloadNamespaceBundle unloads namespace bundle
 	UnloadNamespaceBundle(namespace, bundle string) error
 
+	// UnloadNamespaceBundleWithContext unloads namespace bundle
+	UnloadNamespaceBundleWithContext(ctx context.Context, namespace, bundle string) error
+
 	// SplitNamespaceBundle splits namespace bundle
 	SplitNamespaceBundle(namespace, bundle string, unloadSplitBundles bool) error
+
+	// SplitNamespaceBundleWithContext splits namespace bundle
+	SplitNamespaceBundleWithContext(ctx context.Context, namespace, bundle string, unloadSplitBundles bool) error
 
 	// GetNamespacePermissions returns permissions on a namespace
 	GetNamespacePermissions(namespace utils.NameSpaceName) (map[string][]utils.AuthAction, error)
 
+	// GetNamespacePermissionsWithContext returns permissions on a namespace
+	GetNamespacePermissionsWithContext(ctx context.Context, namespace utils.NameSpaceName) (map[string][]utils.AuthAction, error)
+
 	// GrantNamespacePermission grants permission on a namespace.
 	GrantNamespacePermission(namespace utils.NameSpaceName, role string, action []utils.AuthAction) error
+
+	// GrantNamespacePermissionWithContext grants permission on a namespace.
+	GrantNamespacePermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, role string, action []utils.AuthAction) error
 
 	// RevokeNamespacePermission revokes permissions on a namespace.
 	RevokeNamespacePermission(namespace utils.NameSpaceName, role string) error
 
+	// RevokeNamespacePermissionWithContext revokes permissions on a namespace.
+	RevokeNamespacePermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, role string) error
+
 	// GrantSubPermission grants permission to role to access subscription's admin-api
 	GrantSubPermission(namespace utils.NameSpaceName, sName string, roles []string) error
+
+	// GrantSubPermissionWithContext grants permission to role to access subscription's admin-api
+	GrantSubPermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, sName string, roles []string) error
 
 	// RevokeSubPermission revoke permissions on a subscription's admin-api access
 	RevokeSubPermission(namespace utils.NameSpaceName, sName, role string) error
 
+	// RevokeSubPermissionWithContext revoke permissions on a subscription's admin-api access
+	RevokeSubPermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, sName, role string) error
+
 	// GetSubPermissions returns subscription permissions on a namespace
 	GetSubPermissions(namespace utils.NameSpaceName) (map[string][]string, error)
+
+	// GetSubPermissionsWithContext returns subscription permissions on a namespace
+	GetSubPermissionsWithContext(ctx context.Context, namespace utils.NameSpaceName) (map[string][]string, error)
 
 	// SetSubscriptionAuthMode sets the given subscription auth mode on all topics on a namespace
 	SetSubscriptionAuthMode(namespace utils.NameSpaceName, mode utils.SubscriptionAuthMode) error
 
+	// SetSubscriptionAuthModeWithContext sets the given subscription auth mode on all topics on a namespace
+	SetSubscriptionAuthModeWithContext(ctx context.Context, namespace utils.NameSpaceName, mode utils.SubscriptionAuthMode) error
+
 	// SetEncryptionRequiredStatus sets the encryption required status for all topics within a namespace
 	SetEncryptionRequiredStatus(namespace utils.NameSpaceName, encrypt bool) error
+
+	// SetEncryptionRequiredStatusWithContext sets the encryption required status for all topics within a namespace
+	SetEncryptionRequiredStatusWithContext(ctx context.Context, namespace utils.NameSpaceName, encrypt bool) error
 
 	// UnsubscribeNamespace unsubscribe the given subscription on all topics on a namespace
 	UnsubscribeNamespace(namespace utils.NameSpaceName, sName string) error
 
+	// UnsubscribeNamespaceWithContext unsubscribe the given subscription on all topics on a namespace
+	UnsubscribeNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName, sName string) error
+
 	// UnsubscribeNamespaceBundle unsubscribe the given subscription on all topics on a namespace bundle
 	UnsubscribeNamespaceBundle(namespace utils.NameSpaceName, bundle, sName string) error
+
+	// UnsubscribeNamespaceBundleWithContext unsubscribe the given subscription on all topics on a namespace bundle
+	UnsubscribeNamespaceBundleWithContext(ctx context.Context, namespace utils.NameSpaceName, bundle, sName string) error
 
 	// ClearNamespaceBundleBacklogForSubscription clears backlog for a given subscription on all
 	// topics on a namespace bundle
 	ClearNamespaceBundleBacklogForSubscription(namespace utils.NameSpaceName, bundle, sName string) error
 
+	// ClearNamespaceBundleBacklogForSubscriptionWithContext clears backlog for a given subscription on all
+	// topics on a namespace bundle
+	ClearNamespaceBundleBacklogForSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName, bundle, sName string) error
+
 	// ClearNamespaceBundleBacklog clears backlog for all topics on a namespace bundle
 	ClearNamespaceBundleBacklog(namespace utils.NameSpaceName, bundle string) error
+
+	// ClearNamespaceBundleBacklogWithContext clears backlog for all topics on a namespace bundle
+	ClearNamespaceBundleBacklogWithContext(ctx context.Context, namespace utils.NameSpaceName, bundle string) error
 
 	// ClearNamespaceBacklogForSubscription clears backlog for a given subscription on all topics on a namespace
 	ClearNamespaceBacklogForSubscription(namespace utils.NameSpaceName, sName string) error
 
+	// ClearNamespaceBacklogForSubscriptionWithContext clears backlog for a given subscription on all topics on a namespace
+	ClearNamespaceBacklogForSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName, sName string) error
+
 	// ClearNamespaceBacklog clears backlog for all topics on a namespace
 	ClearNamespaceBacklog(namespace utils.NameSpaceName) error
+
+	// ClearNamespaceBacklogWithContext clears backlog for all topics on a namespace
+	ClearNamespaceBacklogWithContext(ctx context.Context, namespace utils.NameSpaceName) error
 
 	// SetReplicatorDispatchRate sets replicator-Message-dispatch-rate (Replicators under this namespace
 	// can dispatch this many messages per second)
 	SetReplicatorDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error
 
-	// Get replicator-Message-dispatch-rate (Replicators under this namespace
+	// SetReplicatorDispatchRateWithContext sets replicator-Message-dispatch-rate (Replicators under this namespace
+	// can dispatch this many messages per second)
+	SetReplicatorDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.DispatchRate) error
+
+	// GetReplicatorDispatchRate returns replicator-Message-dispatch-rate (Replicators under this namespace
 	// can dispatch this many messages per second)
 	GetReplicatorDispatchRate(namespace utils.NameSpaceName) (utils.DispatchRate, error)
+
+	// GetReplicatorDispatchRateWithContext returns replicator-Message-dispatch-rate (Replicators under this namespace
+	// can dispatch this many messages per second)
+	GetReplicatorDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.DispatchRate, error)
 
 	// SetSubscriptionDispatchRate sets subscription-Message-dispatch-rate (subscriptions under this namespace
 	// can dispatch this many messages per second)
 	SetSubscriptionDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error
 
+	// SetSubscriptionDispatchRateWithContext sets subscription-Message-dispatch-rate (subscriptions under this namespace
+	// can dispatch this many messages per second)
+	SetSubscriptionDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.DispatchRate) error
+
 	// GetSubscriptionDispatchRate returns subscription-Message-dispatch-rate (subscriptions under this namespace
 	// can dispatch this many messages per second)
 	GetSubscriptionDispatchRate(namespace utils.NameSpaceName) (utils.DispatchRate, error)
 
+	// GetSubscriptionDispatchRateWithContext returns subscription-Message-dispatch-rate (subscriptions under this namespace
+	// can dispatch this many messages per second)
+	GetSubscriptionDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.DispatchRate, error)
+
 	// SetSubscribeRate sets namespace-subscribe-rate (topics under this namespace will limit by subscribeRate)
 	SetSubscribeRate(namespace utils.NameSpaceName, rate utils.SubscribeRate) error
+
+	// SetSubscribeRateWithContext sets namespace-subscribe-rate (topics under this namespace will limit by subscribeRate)
+	SetSubscribeRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.SubscribeRate) error
 
 	// GetSubscribeRate returns namespace-subscribe-rate (topics under this namespace allow subscribe
 	// times per consumer in a period)
 	GetSubscribeRate(namespace utils.NameSpaceName) (utils.SubscribeRate, error)
 
+	// GetSubscribeRateWithContext returns namespace-subscribe-rate (topics under this namespace allow subscribe
+	// times per consumer in a period)
+	GetSubscribeRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.SubscribeRate, error)
+
 	// SetDispatchRate sets Message-dispatch-rate (topics under this namespace can dispatch
 	// this many messages per second)
 	SetDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error
+
+	// SetDispatchRateWithContext sets Message-dispatch-rate (topics under this namespace can dispatch
+	// this many messages per second)
+	SetDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.DispatchRate) error
 
 	// GetDispatchRate returns Message-dispatch-rate (topics under this namespace can dispatch
 	// this many messages per second)
 	GetDispatchRate(namespace utils.NameSpaceName) (utils.DispatchRate, error)
 
+	// GetDispatchRateWithContext returns Message-dispatch-rate (topics under this namespace can dispatch
+	// this many messages per second)
+	GetDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.DispatchRate, error)
+
 	// SetPublishRate sets the maximum rate or number of messages that producers can publish to topics in this namespace
 	SetPublishRate(namespace utils.NameSpaceName, pubRate utils.PublishRate) error
+
+	// SetPublishRateWithContext sets the maximum rate or number of messages that producers can publish to topics in this namespace
+	SetPublishRateWithContext(ctx context.Context, namespace utils.NameSpaceName, pubRate utils.PublishRate) error
 
 	// GetPublishRate gets the maximum rate or number of messages that producer can publish to topics in the namespace
 	GetPublishRate(namespace utils.NameSpaceName) (utils.PublishRate, error)
 
+	// GetPublishRateWithContext gets the maximum rate or number of messages that producer can publish to topics in the namespace
+	GetPublishRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.PublishRate, error)
+
 	// SetIsAllowAutoUpdateSchema sets whether to allow auto update schema on a namespace
 	SetIsAllowAutoUpdateSchema(namespace utils.NameSpaceName, isAllowAutoUpdateSchema bool) error
+
+	// SetIsAllowAutoUpdateSchemaWithContext sets whether to allow auto update schema on a namespace
+	SetIsAllowAutoUpdateSchemaWithContext(ctx context.Context, namespace utils.NameSpaceName, isAllowAutoUpdateSchema bool) error
 
 	// GetIsAllowAutoUpdateSchema gets whether to allow auto update schema on a namespace
 	GetIsAllowAutoUpdateSchema(namespace utils.NameSpaceName) (bool, error)
 
+	// GetIsAllowAutoUpdateSchemaWithContext gets whether to allow auto update schema on a namespace
+	GetIsAllowAutoUpdateSchemaWithContext(ctx context.Context, namespace utils.NameSpaceName) (bool, error)
+
 	// GetInactiveTopicPolicies gets the inactive topic policies on a namespace
 	GetInactiveTopicPolicies(namespace utils.NameSpaceName) (utils.InactiveTopicPolicies, error)
+
+	// GetInactiveTopicPoliciesWithContext gets the inactive topic policies on a namespace
+	GetInactiveTopicPoliciesWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.InactiveTopicPolicies, error)
 
 	// RemoveInactiveTopicPolicies removes inactive topic policies from a namespace
 	RemoveInactiveTopicPolicies(namespace utils.NameSpaceName) error
 
+	// RemoveInactiveTopicPoliciesWithContext removes inactive topic policies from a namespace
+	RemoveInactiveTopicPoliciesWithContext(ctx context.Context, namespace utils.NameSpaceName) error
+
 	// SetInactiveTopicPolicies sets the inactive topic policies on a namespace
 	SetInactiveTopicPolicies(namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error
+
+	// SetInactiveTopicPoliciesWithContext sets the inactive topic policies on a namespace
+	SetInactiveTopicPoliciesWithContext(ctx context.Context, namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error
 
 	// GetSubscriptionExpirationTime gets the subscription expiration time on a namespace. Returns -1 if not set
 	GetSubscriptionExpirationTime(namespace utils.NameSpaceName) (int, error)
 
+	// GetSubscriptionExpirationTimeWithContext gets the subscription expiration time on a namespace. Returns -1 if not set
+	GetSubscriptionExpirationTimeWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error)
+
 	// SetSubscriptionExpirationTime sets the subscription expiration time on a namespace
 	SetSubscriptionExpirationTime(namespace utils.NameSpaceName, expirationTimeInMinutes int) error
+
+	// SetSubscriptionExpirationTimeWithContext sets the subscription expiration time on a namespace
+	SetSubscriptionExpirationTimeWithContext(ctx context.Context, namespace utils.NameSpaceName, expirationTimeInMinutes int) error
 
 	// RemoveSubscriptionExpirationTime removes subscription expiration time from a namespace,
 	// defaulting to broker settings
 	RemoveSubscriptionExpirationTime(namespace utils.NameSpaceName) error
 
+	// RemoveSubscriptionExpirationTimeWithContext removes subscription expiration time from a namespace,
+	// defaulting to broker settings
+	RemoveSubscriptionExpirationTimeWithContext(ctx context.Context, namespace utils.NameSpaceName) error
+
 	// UpdateProperties updates the properties of a namespace
 	UpdateProperties(namespace utils.NameSpaceName, properties map[string]string) error
+
+	// UpdatePropertiesWithContext updates the properties of a namespace
+	UpdatePropertiesWithContext(ctx context.Context, namespace utils.NameSpaceName, properties map[string]string) error
 
 	// GetProperties returns the properties of a namespace
 	GetProperties(namespace utils.NameSpaceName) (map[string]string, error)
 
+	// GetPropertiesWithContext returns the properties of a namespace
+	GetPropertiesWithContext(ctx context.Context, namespace utils.NameSpaceName) (map[string]string, error)
+
 	// RemoveProperties clears the properties of a namespace
 	RemoveProperties(namespace utils.NameSpaceName) error
+
+	// RemovePropertiesWithContext clears the properties of a namespace
+	RemovePropertiesWithContext(ctx context.Context, namespace utils.NameSpaceName) error
 }
 
 type namespaces struct {
@@ -340,48 +639,72 @@ func (c *pulsarClient) Namespaces() Namespaces {
 }
 
 func (n *namespaces) GetNamespaces(tenant string) ([]string, error) {
+	return n.GetNamespacesWithContext(context.Background(), tenant)
+}
+
+func (n *namespaces) GetNamespacesWithContext(ctx context.Context, tenant string) ([]string, error) {
 	var namespaces []string
 	endpoint := n.pulsar.endpoint(n.basePath, tenant)
-	err := n.pulsar.Client.Get(endpoint, &namespaces)
+	err := n.pulsar.Client.Get(ctx, endpoint, &namespaces)
 	return namespaces, err
 }
 
 func (n *namespaces) GetTopics(namespace string) ([]string, error) {
+	return n.GetTopicsWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetTopicsWithContext(ctx context.Context, namespace string) ([]string, error) {
 	var topics []string
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, ns.String(), "topics")
-	err = n.pulsar.Client.Get(endpoint, &topics)
+	err = n.pulsar.Client.Get(ctx, endpoint, &topics)
 	return topics, err
 }
 
 func (n *namespaces) GetPolicies(namespace string) (*utils.Policies, error) {
+	return n.GetPoliciesWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetPoliciesWithContext(ctx context.Context, namespace string) (*utils.Policies, error) {
 	var police utils.Policies
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, ns.String())
-	err = n.pulsar.Client.Get(endpoint, &police)
+	err = n.pulsar.Client.Get(ctx, endpoint, &police)
 	return &police, err
 }
 
 func (n *namespaces) CreateNsWithNumBundles(namespace string, numBundles int) error {
-	return n.CreateNsWithBundlesData(namespace, utils.NewBundlesDataWithNumBundles(numBundles))
+	return n.CreateNsWithNumBundlesWithContext(context.Background(), namespace, numBundles)
+}
+
+func (n *namespaces) CreateNsWithNumBundlesWithContext(ctx context.Context, namespace string, numBundles int) error {
+	return n.CreateNsWithBundlesDataWithContext(ctx, namespace, utils.NewBundlesDataWithNumBundles(numBundles))
 }
 
 func (n *namespaces) CreateNsWithPolices(namespace string, policies utils.Policies) error {
+	return n.CreateNsWithPolicesWithContext(context.Background(), namespace, policies)
+}
+
+func (n *namespaces) CreateNsWithPolicesWithContext(ctx context.Context, namespace string, policies utils.Policies) error {
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, ns.String())
-	return n.pulsar.Client.Put(endpoint, &policies)
+	return n.pulsar.Client.Put(ctx, endpoint, &policies)
 }
 
 func (n *namespaces) CreateNsWithBundlesData(namespace string, bundleData *utils.BundlesData) error {
+	return n.CreateNsWithBundlesDataWithContext(context.Background(), namespace, bundleData)
+}
+
+func (n *namespaces) CreateNsWithBundlesDataWithContext(ctx context.Context, namespace string, bundleData *utils.BundlesData) error {
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
@@ -390,89 +713,126 @@ func (n *namespaces) CreateNsWithBundlesData(namespace string, bundleData *utils
 	polices := new(utils.Policies)
 	polices.Bundles = bundleData
 
-	return n.pulsar.Client.Put(endpoint, &polices)
+	return n.pulsar.Client.Put(ctx, endpoint, &polices)
 }
 
 func (n *namespaces) CreateNamespace(namespace string) error {
+	return n.CreateNamespaceWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) CreateNamespaceWithContext(ctx context.Context, namespace string) error {
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, ns.String())
-	return n.pulsar.Client.Put(endpoint, nil)
+	return n.pulsar.Client.Put(ctx, endpoint, nil)
 }
 
 func (n *namespaces) DeleteNamespace(namespace string) error {
+	return n.DeleteNamespaceWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) DeleteNamespaceWithContext(ctx context.Context, namespace string) error {
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, ns.String())
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) DeleteNamespaceBundle(namespace string, bundleRange string) error {
+	return n.DeleteNamespaceBundleWithContext(context.Background(), namespace, bundleRange)
+}
+
+func (n *namespaces) DeleteNamespaceBundleWithContext(ctx context.Context, namespace string, bundleRange string) error {
 	ns, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, ns.String(), bundleRange)
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) GetNamespaceMessageTTL(namespace string) (int, error) {
+	return n.GetNamespaceMessageTTLWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetNamespaceMessageTTLWithContext(ctx context.Context, namespace string) (int, error) {
 	var ttl int
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return 0, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "messageTTL")
-	err = n.pulsar.Client.Get(endpoint, &ttl)
+	err = n.pulsar.Client.Get(ctx, endpoint, &ttl)
 	return ttl, err
 }
 
 func (n *namespaces) SetNamespaceMessageTTL(namespace string, ttlInSeconds int) error {
+	return n.SetNamespaceMessageTTLWithContext(context.Background(), namespace, ttlInSeconds)
+}
+
+func (n *namespaces) SetNamespaceMessageTTLWithContext(ctx context.Context, namespace string, ttlInSeconds int) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "messageTTL")
-	return n.pulsar.Client.Post(endpoint, &ttlInSeconds)
+	return n.pulsar.Client.Post(ctx, endpoint, &ttlInSeconds)
 }
 
 func (n *namespaces) SetRetention(namespace string, policy utils.RetentionPolicies) error {
+	return n.SetRetentionWithContext(context.Background(), namespace, policy)
+}
+
+func (n *namespaces) SetRetentionWithContext(ctx context.Context, namespace string, policy utils.RetentionPolicies) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "retention")
-	return n.pulsar.Client.Post(endpoint, &policy)
+	return n.pulsar.Client.Post(ctx, endpoint, &policy)
 }
 
 func (n *namespaces) GetRetention(namespace string) (*utils.RetentionPolicies, error) {
+	return n.GetRetentionWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetRetentionWithContext(ctx context.Context, namespace string) (*utils.RetentionPolicies, error) {
 	var policy utils.RetentionPolicies
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "retention")
-	err = n.pulsar.Client.Get(endpoint, &policy)
+	err = n.pulsar.Client.Get(ctx, endpoint, &policy)
 	return &policy, err
 }
 
 func (n *namespaces) GetBacklogQuotaMap(namespace string) (map[utils.BacklogQuotaType]utils.BacklogQuota, error) {
+	return n.GetBacklogQuotaMapWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetBacklogQuotaMapWithContext(ctx context.Context, namespace string) (map[utils.BacklogQuotaType]utils.BacklogQuota, error) {
 	var backlogQuotaMap map[utils.BacklogQuotaType]utils.BacklogQuota
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "backlogQuotaMap")
-	err = n.pulsar.Client.Get(endpoint, &backlogQuotaMap)
+	err = n.pulsar.Client.Get(ctx, endpoint, &backlogQuotaMap)
 	return backlogQuotaMap, err
 }
 
 func (n *namespaces) SetBacklogQuota(namespace string, backlogQuota utils.BacklogQuota,
+	backlogQuotaType utils.BacklogQuotaType) error {
+	return n.SetBacklogQuotaWithContext(context.Background(), namespace, backlogQuota, backlogQuotaType)
+}
+
+func (n *namespaces) SetBacklogQuotaWithContext(ctx context.Context, namespace string, backlogQuota utils.BacklogQuota,
 	backlogQuotaType utils.BacklogQuotaType) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
@@ -481,10 +841,14 @@ func (n *namespaces) SetBacklogQuota(namespace string, backlogQuota utils.Backlo
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "backlogQuota")
 	params := make(map[string]string)
 	params["backlogQuotaType"] = string(backlogQuotaType)
-	return n.pulsar.Client.PostWithQueryParams(endpoint, &backlogQuota, params)
+	return n.pulsar.Client.PostWithQueryParams(ctx, endpoint, &backlogQuota, params)
 }
 
 func (n *namespaces) RemoveBacklogQuota(namespace string) error {
+	return n.RemoveBacklogQuotaWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) RemoveBacklogQuotaWithContext(ctx context.Context, namespace string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
@@ -493,48 +857,78 @@ func (n *namespaces) RemoveBacklogQuota(namespace string) error {
 	params := map[string]string{
 		"backlogQuotaType": string(utils.DestinationStorage),
 	}
-	return n.pulsar.Client.DeleteWithQueryParams(endpoint, params)
+	return n.pulsar.Client.DeleteWithQueryParams(ctx, endpoint, params)
 }
 
 func (n *namespaces) GetTopicAutoCreation(namespace utils.NameSpaceName) (*utils.TopicAutoCreationConfig, error) {
+	return n.GetTopicAutoCreationWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetTopicAutoCreationWithContext(ctx context.Context, namespace utils.NameSpaceName) (*utils.TopicAutoCreationConfig, error) {
 	var topicAutoCreation utils.TopicAutoCreationConfig
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "autoTopicCreation")
-	err := n.pulsar.Client.Get(endpoint, &topicAutoCreation)
+	err := n.pulsar.Client.Get(ctx, endpoint, &topicAutoCreation)
 	return &topicAutoCreation, err
 }
 
 func (n *namespaces) SetTopicAutoCreation(namespace utils.NameSpaceName, config utils.TopicAutoCreationConfig) error {
+	return n.SetTopicAutoCreationWithContext(context.Background(), namespace, config)
+}
+
+func (n *namespaces) SetTopicAutoCreationWithContext(ctx context.Context, namespace utils.NameSpaceName, config utils.TopicAutoCreationConfig) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "autoTopicCreation")
-	return n.pulsar.Client.Post(endpoint, &config)
+	return n.pulsar.Client.Post(ctx, endpoint, &config)
 }
 
 func (n *namespaces) RemoveTopicAutoCreation(namespace utils.NameSpaceName) error {
+	return n.RemoveTopicAutoCreationWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) RemoveTopicAutoCreationWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "autoTopicCreation")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) SetSchemaValidationEnforced(namespace utils.NameSpaceName, schemaValidationEnforced bool) error {
+	return n.SetSchemaValidationEnforcedWithContext(context.Background(), namespace, schemaValidationEnforced)
+}
+
+func (n *namespaces) SetSchemaValidationEnforcedWithContext(ctx context.Context, namespace utils.NameSpaceName, schemaValidationEnforced bool) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaValidationEnforced")
-	return n.pulsar.Client.Post(endpoint, schemaValidationEnforced)
+	return n.pulsar.Client.Post(ctx, endpoint, schemaValidationEnforced)
 }
 
 func (n *namespaces) GetSchemaValidationEnforced(namespace utils.NameSpaceName) (bool, error) {
+	return n.GetSchemaValidationEnforcedWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSchemaValidationEnforcedWithContext(ctx context.Context, namespace utils.NameSpaceName) (bool, error) {
 	var result bool
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaValidationEnforced")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetSchemaAutoUpdateCompatibilityStrategy(namespace utils.NameSpaceName,
 	strategy utils.SchemaAutoUpdateCompatibilityStrategy) error {
+	return n.SetSchemaAutoUpdateCompatibilityStrategyWithContext(context.Background(), namespace, strategy)
+}
+
+func (n *namespaces) SetSchemaAutoUpdateCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName,
+	strategy utils.SchemaAutoUpdateCompatibilityStrategy) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaAutoUpdateCompatibilityStrategy")
-	return n.pulsar.Client.Put(endpoint, strategy.String())
+	return n.pulsar.Client.Put(ctx, endpoint, strategy.String())
 }
 
 func (n *namespaces) GetSchemaAutoUpdateCompatibilityStrategy(namespace utils.NameSpaceName) (
 	utils.SchemaAutoUpdateCompatibilityStrategy, error) {
+	return n.GetSchemaAutoUpdateCompatibilityStrategyWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSchemaAutoUpdateCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName) (
+	utils.SchemaAutoUpdateCompatibilityStrategy, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaAutoUpdateCompatibilityStrategy")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
+	b, err := n.pulsar.Client.GetWithQueryParams(ctx, endpoint, nil, nil, false)
 	if err != nil {
 		return "", err
 	}
@@ -547,14 +941,24 @@ func (n *namespaces) GetSchemaAutoUpdateCompatibilityStrategy(namespace utils.Na
 
 func (n *namespaces) SetSchemaCompatibilityStrategy(namespace utils.NameSpaceName,
 	strategy utils.SchemaCompatibilityStrategy) error {
+	return n.SetSchemaCompatibilityStrategyWithContext(context.Background(), namespace, strategy)
+}
+
+func (n *namespaces) SetSchemaCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName,
+	strategy utils.SchemaCompatibilityStrategy) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaCompatibilityStrategy")
-	return n.pulsar.Client.Put(endpoint, strategy.String())
+	return n.pulsar.Client.Put(ctx, endpoint, strategy.String())
 }
 
 func (n *namespaces) GetSchemaCompatibilityStrategy(namespace utils.NameSpaceName) (
 	utils.SchemaCompatibilityStrategy, error) {
+	return n.GetSchemaCompatibilityStrategyWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSchemaCompatibilityStrategyWithContext(ctx context.Context, namespace utils.NameSpaceName) (
+	utils.SchemaCompatibilityStrategy, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "schemaCompatibilityStrategy")
-	b, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
+	b, err := n.pulsar.Client.GetWithQueryParams(ctx, endpoint, nil, nil, false)
 	if err != nil {
 		return "", err
 	}
@@ -566,229 +970,349 @@ func (n *namespaces) GetSchemaCompatibilityStrategy(namespace utils.NameSpaceNam
 }
 
 func (n *namespaces) ClearOffloadDeleteLag(namespace utils.NameSpaceName) error {
+	return n.ClearOffloadDeleteLagWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) ClearOffloadDeleteLagWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadDeletionLagMs")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) SetOffloadDeleteLag(namespace utils.NameSpaceName, timeMs int64) error {
+	return n.SetOffloadDeleteLagWithContext(context.Background(), namespace, timeMs)
+}
+
+func (n *namespaces) SetOffloadDeleteLagWithContext(ctx context.Context, namespace utils.NameSpaceName, timeMs int64) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadDeletionLagMs")
-	return n.pulsar.Client.Put(endpoint, timeMs)
+	return n.pulsar.Client.Put(ctx, endpoint, timeMs)
 }
 
 func (n *namespaces) GetOffloadDeleteLag(namespace utils.NameSpaceName) (int64, error) {
+	return n.GetOffloadDeleteLagWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetOffloadDeleteLagWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error) {
 	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadDeletionLagMs")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetMaxConsumersPerSubscription(namespace utils.NameSpaceName, max int) error {
+	return n.SetMaxConsumersPerSubscriptionWithContext(context.Background(), namespace, max)
+}
+
+func (n *namespaces) SetMaxConsumersPerSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxConsumersPerSubscription")
-	return n.pulsar.Client.Post(endpoint, max)
+	return n.pulsar.Client.Post(ctx, endpoint, max)
 }
 
 func (n *namespaces) GetMaxConsumersPerSubscription(namespace utils.NameSpaceName) (int, error) {
+	return n.GetMaxConsumersPerSubscriptionWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetMaxConsumersPerSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error) {
 	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxConsumersPerSubscription")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetOffloadThreshold(namespace utils.NameSpaceName, threshold int64) error {
+	return n.SetOffloadThresholdWithContext(context.Background(), namespace, threshold)
+}
+
+func (n *namespaces) SetOffloadThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName, threshold int64) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadThreshold")
-	return n.pulsar.Client.Put(endpoint, threshold)
+	return n.pulsar.Client.Put(ctx, endpoint, threshold)
 }
 
 func (n *namespaces) GetOffloadThreshold(namespace utils.NameSpaceName) (int64, error) {
+	return n.GetOffloadThresholdWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetOffloadThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error) {
 	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadThreshold")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetOffloadThresholdInSeconds(namespace utils.NameSpaceName, threshold int64) error {
+	return n.SetOffloadThresholdInSecondsWithContext(context.Background(), namespace, threshold)
+}
+
+func (n *namespaces) SetOffloadThresholdInSecondsWithContext(ctx context.Context, namespace utils.NameSpaceName, threshold int64) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadThresholdInSeconds")
-	return n.pulsar.Client.Put(endpoint, threshold)
+	return n.pulsar.Client.Put(ctx, endpoint, threshold)
 }
 
 func (n *namespaces) GetOffloadThresholdInSeconds(namespace utils.NameSpaceName) (int64, error) {
+	return n.GetOffloadThresholdInSecondsWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetOffloadThresholdInSecondsWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error) {
 	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "offloadThresholdInSeconds")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetMaxConsumersPerTopic(namespace utils.NameSpaceName, max int) error {
+	return n.SetMaxConsumersPerTopicWithContext(context.Background(), namespace, max)
+}
+
+func (n *namespaces) SetMaxConsumersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxConsumersPerTopic")
-	return n.pulsar.Client.Post(endpoint, max)
+	return n.pulsar.Client.Post(ctx, endpoint, max)
 }
 
 func (n *namespaces) GetMaxConsumersPerTopic(namespace utils.NameSpaceName) (int, error) {
+	return n.GetMaxConsumersPerTopicWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetMaxConsumersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error) {
 	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxConsumersPerTopic")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetCompactionThreshold(namespace utils.NameSpaceName, threshold int64) error {
+	return n.SetCompactionThresholdWithContext(context.Background(), namespace, threshold)
+}
+
+func (n *namespaces) SetCompactionThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName, threshold int64) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "compactionThreshold")
-	return n.pulsar.Client.Put(endpoint, threshold)
+	return n.pulsar.Client.Put(ctx, endpoint, threshold)
 }
 
 func (n *namespaces) GetCompactionThreshold(namespace utils.NameSpaceName) (int64, error) {
+	return n.GetCompactionThresholdWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetCompactionThresholdWithContext(ctx context.Context, namespace utils.NameSpaceName) (int64, error) {
 	var result int64
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "compactionThreshold")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetMaxProducersPerTopic(namespace utils.NameSpaceName, max int) error {
+	return n.SetMaxProducersPerTopicWithContext(context.Background(), namespace, max)
+}
+
+func (n *namespaces) SetMaxProducersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxProducersPerTopic")
-	return n.pulsar.Client.Post(endpoint, max)
+	return n.pulsar.Client.Post(ctx, endpoint, max)
 }
 
 func (n *namespaces) GetMaxProducersPerTopic(namespace utils.NameSpaceName) (int, error) {
+	return n.GetMaxProducersPerTopicWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetMaxProducersPerTopicWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error) {
 	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxProducersPerTopic")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) GetNamespaceReplicationClusters(namespace string) ([]string, error) {
+	return n.GetNamespaceReplicationClustersWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetNamespaceReplicationClustersWithContext(ctx context.Context, namespace string) ([]string, error) {
 	var data []string
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "replication")
-	err = n.pulsar.Client.Get(endpoint, &data)
+	err = n.pulsar.Client.Get(ctx, endpoint, &data)
 	return data, err
 }
 
 func (n *namespaces) SetNamespaceReplicationClusters(namespace string, clusterIDs []string) error {
+	return n.SetNamespaceReplicationClustersWithContext(context.Background(), namespace, clusterIDs)
+}
+
+func (n *namespaces) SetNamespaceReplicationClustersWithContext(ctx context.Context, namespace string, clusterIDs []string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "replication")
-	return n.pulsar.Client.Post(endpoint, &clusterIDs)
+	return n.pulsar.Client.Post(ctx, endpoint, &clusterIDs)
 }
 
 func (n *namespaces) SetNamespaceAntiAffinityGroup(namespace string, namespaceAntiAffinityGroup string) error {
+	return n.SetNamespaceAntiAffinityGroupWithContext(context.Background(), namespace, namespaceAntiAffinityGroup)
+}
+
+func (n *namespaces) SetNamespaceAntiAffinityGroupWithContext(ctx context.Context, namespace string, namespaceAntiAffinityGroup string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "antiAffinity")
-	return n.pulsar.Client.Post(endpoint, namespaceAntiAffinityGroup)
+	return n.pulsar.Client.Post(ctx, endpoint, namespaceAntiAffinityGroup)
 }
 
 func (n *namespaces) GetAntiAffinityNamespaces(tenant, cluster, namespaceAntiAffinityGroup string) ([]string, error) {
+	return n.GetAntiAffinityNamespacesWithContext(context.Background(), tenant, cluster, namespaceAntiAffinityGroup)
+}
+
+func (n *namespaces) GetAntiAffinityNamespacesWithContext(ctx context.Context, tenant, cluster, namespaceAntiAffinityGroup string) ([]string, error) {
 	var data []string
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "antiAffinity", namespaceAntiAffinityGroup)
 	params := map[string]string{
 		"property": tenant,
 	}
-	_, err := n.pulsar.Client.GetWithQueryParams(endpoint, &data, params, false)
+	_, err := n.pulsar.Client.GetWithQueryParams(ctx, endpoint, &data, params, false)
 	return data, err
 }
 
 func (n *namespaces) GetNamespaceAntiAffinityGroup(namespace string) (string, error) {
+	return n.GetNamespaceAntiAffinityGroupWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetNamespaceAntiAffinityGroupWithContext(ctx context.Context, namespace string) (string, error) {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return "", err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "antiAffinity")
-	data, err := n.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
+	data, err := n.pulsar.Client.GetWithQueryParams(ctx, endpoint, nil, nil, false)
 	return string(data), err
 }
 
 func (n *namespaces) DeleteNamespaceAntiAffinityGroup(namespace string) error {
+	return n.DeleteNamespaceAntiAffinityGroupWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) DeleteNamespaceAntiAffinityGroupWithContext(ctx context.Context, namespace string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "antiAffinity")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) SetDeduplicationStatus(namespace string, enableDeduplication bool) error {
+	return n.SetDeduplicationStatusWithContext(context.Background(), namespace, enableDeduplication)
+}
+
+func (n *namespaces) SetDeduplicationStatusWithContext(ctx context.Context, namespace string, enableDeduplication bool) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "deduplication")
-	return n.pulsar.Client.Post(endpoint, enableDeduplication)
+	return n.pulsar.Client.Post(ctx, endpoint, enableDeduplication)
 }
 
 func (n *namespaces) SetPersistence(namespace string, persistence utils.PersistencePolicies) error {
+	return n.SetPersistenceWithContext(context.Background(), namespace, persistence)
+}
+
+func (n *namespaces) SetPersistenceWithContext(ctx context.Context, namespace string, persistence utils.PersistencePolicies) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "persistence")
-	return n.pulsar.Client.Post(endpoint, &persistence)
+	return n.pulsar.Client.Post(ctx, endpoint, &persistence)
 }
 
 func (n *namespaces) SetBookieAffinityGroup(namespace string, bookieAffinityGroup utils.BookieAffinityGroupData) error {
+	return n.SetBookieAffinityGroupWithContext(context.Background(), namespace, bookieAffinityGroup)
+}
+
+func (n *namespaces) SetBookieAffinityGroupWithContext(ctx context.Context, namespace string, bookieAffinityGroup utils.BookieAffinityGroupData) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "persistence", "bookieAffinity")
-	return n.pulsar.Client.Post(endpoint, &bookieAffinityGroup)
+	return n.pulsar.Client.Post(ctx, endpoint, &bookieAffinityGroup)
 }
 
 func (n *namespaces) DeleteBookieAffinityGroup(namespace string) error {
+	return n.DeleteBookieAffinityGroupWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) DeleteBookieAffinityGroupWithContext(ctx context.Context, namespace string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "persistence", "bookieAffinity")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) GetBookieAffinityGroup(namespace string) (*utils.BookieAffinityGroupData, error) {
+	return n.GetBookieAffinityGroupWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetBookieAffinityGroupWithContext(ctx context.Context, namespace string) (*utils.BookieAffinityGroupData, error) {
 	var data utils.BookieAffinityGroupData
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "persistence", "bookieAffinity")
-	err = n.pulsar.Client.Get(endpoint, &data)
+	err = n.pulsar.Client.Get(ctx, endpoint, &data)
 	return &data, err
 }
 
 func (n *namespaces) GetPersistence(namespace string) (*utils.PersistencePolicies, error) {
+	return n.GetPersistenceWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetPersistenceWithContext(ctx context.Context, namespace string) (*utils.PersistencePolicies, error) {
 	var persistence utils.PersistencePolicies
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return nil, err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "persistence")
-	err = n.pulsar.Client.Get(endpoint, &persistence)
+	err = n.pulsar.Client.Get(ctx, endpoint, &persistence)
 	return &persistence, err
 }
 
 func (n *namespaces) Unload(namespace string) error {
+	return n.UnloadWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) UnloadWithContext(ctx context.Context, namespace string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), "unload")
-	return n.pulsar.Client.Put(endpoint, nil)
+	return n.pulsar.Client.Put(ctx, endpoint, nil)
 }
 
 func (n *namespaces) UnloadNamespaceBundle(namespace, bundle string) error {
+	return n.UnloadNamespaceBundleWithContext(context.Background(), namespace, bundle)
+}
+
+func (n *namespaces) UnloadNamespaceBundleWithContext(ctx context.Context, namespace, bundle string) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
 	}
 	endpoint := n.pulsar.endpoint(n.basePath, nsName.String(), bundle, "unload")
-	return n.pulsar.Client.Put(endpoint, nil)
+	return n.pulsar.Client.Put(ctx, endpoint, nil)
 }
 
 func (n *namespaces) SplitNamespaceBundle(namespace, bundle string, unloadSplitBundles bool) error {
+	return n.SplitNamespaceBundleWithContext(context.Background(), namespace, bundle, unloadSplitBundles)
+}
+
+func (n *namespaces) SplitNamespaceBundleWithContext(ctx context.Context, namespace, bundle string, unloadSplitBundles bool) error {
 	nsName, err := utils.GetNamespaceName(namespace)
 	if err != nil {
 		return err
@@ -797,229 +1321,384 @@ func (n *namespaces) SplitNamespaceBundle(namespace, bundle string, unloadSplitB
 	params := map[string]string{
 		"unload": strconv.FormatBool(unloadSplitBundles),
 	}
-	return n.pulsar.Client.PutWithQueryParams(endpoint, nil, nil, params)
+	return n.pulsar.Client.PutWithQueryParams(ctx, endpoint, nil, nil, params)
 }
 
 func (n *namespaces) GetNamespacePermissions(namespace utils.NameSpaceName) (map[string][]utils.AuthAction, error) {
+	return n.GetNamespacePermissionsWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetNamespacePermissionsWithContext(ctx context.Context, namespace utils.NameSpaceName) (map[string][]utils.AuthAction, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions")
 	var permissions map[string][]utils.AuthAction
-	err := n.pulsar.Client.Get(endpoint, &permissions)
+	err := n.pulsar.Client.Get(ctx, endpoint, &permissions)
 	return permissions, err
 }
 
 func (n *namespaces) GrantNamespacePermission(namespace utils.NameSpaceName, role string,
+	action []utils.AuthAction) error {
+	return n.GrantNamespacePermissionWithContext(context.Background(), namespace, role, action)
+}
+
+func (n *namespaces) GrantNamespacePermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, role string,
 	action []utils.AuthAction) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions", role)
 	s := make([]string, 0)
 	for _, v := range action {
 		s = append(s, v.String())
 	}
-	return n.pulsar.Client.Post(endpoint, s)
+	return n.pulsar.Client.Post(ctx, endpoint, s)
 }
 
 func (n *namespaces) RevokeNamespacePermission(namespace utils.NameSpaceName, role string) error {
+	return n.RevokeNamespacePermissionWithContext(context.Background(), namespace, role)
+}
+
+func (n *namespaces) RevokeNamespacePermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, role string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions", role)
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) GrantSubPermission(namespace utils.NameSpaceName, sName string, roles []string) error {
+	return n.GrantSubPermissionWithContext(context.Background(), namespace, sName, roles)
+}
+
+func (n *namespaces) GrantSubPermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, sName string, roles []string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions",
 		"subscription", sName)
-	return n.pulsar.Client.Post(endpoint, roles)
+	return n.pulsar.Client.Post(ctx, endpoint, roles)
 }
 
 func (n *namespaces) RevokeSubPermission(namespace utils.NameSpaceName, sName, role string) error {
+	return n.RevokeSubPermissionWithContext(context.Background(), namespace, sName, role)
+}
+
+func (n *namespaces) RevokeSubPermissionWithContext(ctx context.Context, namespace utils.NameSpaceName, sName, role string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions",
 		sName, role)
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) GetSubPermissions(namespace utils.NameSpaceName) (map[string][]string, error) {
+	return n.GetSubPermissionsWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSubPermissionsWithContext(ctx context.Context, namespace utils.NameSpaceName) (map[string][]string, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions", "subscription")
 	var permissions map[string][]string
-	err := n.pulsar.Client.Get(endpoint, &permissions)
+	err := n.pulsar.Client.Get(ctx, endpoint, &permissions)
 	return permissions, err
 }
 
 func (n *namespaces) SetSubscriptionAuthMode(namespace utils.NameSpaceName, mode utils.SubscriptionAuthMode) error {
+	return n.SetSubscriptionAuthModeWithContext(context.Background(), namespace, mode)
+}
+
+func (n *namespaces) SetSubscriptionAuthModeWithContext(ctx context.Context, namespace utils.NameSpaceName, mode utils.SubscriptionAuthMode) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionAuthMode")
-	return n.pulsar.Client.Post(endpoint, mode.String())
+	return n.pulsar.Client.Post(ctx, endpoint, mode.String())
 }
 
 func (n *namespaces) SetEncryptionRequiredStatus(namespace utils.NameSpaceName, encrypt bool) error {
+	return n.SetEncryptionRequiredStatusWithContext(context.Background(), namespace, encrypt)
+}
+
+func (n *namespaces) SetEncryptionRequiredStatusWithContext(ctx context.Context, namespace utils.NameSpaceName, encrypt bool) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "encryptionRequired")
-	return n.pulsar.Client.Post(endpoint, strconv.FormatBool(encrypt))
+	return n.pulsar.Client.Post(ctx, endpoint, strconv.FormatBool(encrypt))
 }
 
 func (n *namespaces) UnsubscribeNamespace(namespace utils.NameSpaceName, sName string) error {
+	return n.UnsubscribeNamespaceWithContext(context.Background(), namespace, sName)
+}
+
+func (n *namespaces) UnsubscribeNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "unsubscribe", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, nil)
+	return n.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (n *namespaces) UnsubscribeNamespaceBundle(namespace utils.NameSpaceName, bundle, sName string) error {
+	return n.UnsubscribeNamespaceBundleWithContext(context.Background(), namespace, bundle, sName)
+}
+
+func (n *namespaces) UnsubscribeNamespaceBundleWithContext(ctx context.Context, namespace utils.NameSpaceName, bundle, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), bundle, "unsubscribe", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, nil)
+	return n.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBundleBacklogForSubscription(namespace utils.NameSpaceName,
 	bundle, sName string) error {
+	return n.ClearNamespaceBundleBacklogForSubscriptionWithContext(context.Background(), namespace, bundle, sName)
+}
+
+func (n *namespaces) ClearNamespaceBundleBacklogForSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName,
+	bundle, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), bundle, "clearBacklog", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, nil)
+	return n.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBundleBacklog(namespace utils.NameSpaceName, bundle string) error {
+	return n.ClearNamespaceBundleBacklogWithContext(context.Background(), namespace, bundle)
+}
+
+func (n *namespaces) ClearNamespaceBundleBacklogWithContext(ctx context.Context, namespace utils.NameSpaceName, bundle string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), bundle, "clearBacklog")
-	return n.pulsar.Client.Post(endpoint, nil)
+	return n.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBacklogForSubscription(namespace utils.NameSpaceName, sName string) error {
+	return n.ClearNamespaceBacklogForSubscriptionWithContext(context.Background(), namespace, sName)
+}
+
+func (n *namespaces) ClearNamespaceBacklogForSubscriptionWithContext(ctx context.Context, namespace utils.NameSpaceName, sName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "clearBacklog", url.QueryEscape(sName))
-	return n.pulsar.Client.Post(endpoint, nil)
+	return n.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (n *namespaces) ClearNamespaceBacklog(namespace utils.NameSpaceName) error {
+	return n.ClearNamespaceBacklogWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) ClearNamespaceBacklogWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "clearBacklog")
-	return n.pulsar.Client.Post(endpoint, nil)
+	return n.pulsar.Client.Post(ctx, endpoint, nil)
 }
 
 func (n *namespaces) SetReplicatorDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error {
+	return n.SetReplicatorDispatchRateWithContext(context.Background(), namespace, rate)
+}
+
+func (n *namespaces) SetReplicatorDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.DispatchRate) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "replicatorDispatchRate")
-	return n.pulsar.Client.Post(endpoint, rate)
+	return n.pulsar.Client.Post(ctx, endpoint, rate)
 }
 
 func (n *namespaces) GetReplicatorDispatchRate(namespace utils.NameSpaceName) (utils.DispatchRate, error) {
+	return n.GetReplicatorDispatchRateWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetReplicatorDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.DispatchRate, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "replicatorDispatchRate")
 	var rate utils.DispatchRate
-	err := n.pulsar.Client.Get(endpoint, &rate)
+	err := n.pulsar.Client.Get(ctx, endpoint, &rate)
 	return rate, err
 }
 
 func (n *namespaces) SetSubscriptionDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error {
+	return n.SetSubscriptionDispatchRateWithContext(context.Background(), namespace, rate)
+}
+
+func (n *namespaces) SetSubscriptionDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.DispatchRate) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionDispatchRate")
-	return n.pulsar.Client.Post(endpoint, rate)
+	return n.pulsar.Client.Post(ctx, endpoint, rate)
 }
 
 func (n *namespaces) GetSubscriptionDispatchRate(namespace utils.NameSpaceName) (utils.DispatchRate, error) {
+	return n.GetSubscriptionDispatchRateWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSubscriptionDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.DispatchRate, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionDispatchRate")
 	var rate utils.DispatchRate
-	err := n.pulsar.Client.Get(endpoint, &rate)
+	err := n.pulsar.Client.Get(ctx, endpoint, &rate)
 	return rate, err
 }
 
 func (n *namespaces) SetSubscribeRate(namespace utils.NameSpaceName, rate utils.SubscribeRate) error {
+	return n.SetSubscribeRateWithContext(context.Background(), namespace, rate)
+}
+
+func (n *namespaces) SetSubscribeRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.SubscribeRate) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscribeRate")
-	return n.pulsar.Client.Post(endpoint, rate)
+	return n.pulsar.Client.Post(ctx, endpoint, rate)
 }
 
 func (n *namespaces) GetSubscribeRate(namespace utils.NameSpaceName) (utils.SubscribeRate, error) {
+	return n.GetSubscribeRateWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSubscribeRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.SubscribeRate, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscribeRate")
 	var rate utils.SubscribeRate
-	err := n.pulsar.Client.Get(endpoint, &rate)
+	err := n.pulsar.Client.Get(ctx, endpoint, &rate)
 	return rate, err
 }
 
 func (n *namespaces) SetDispatchRate(namespace utils.NameSpaceName, rate utils.DispatchRate) error {
+	return n.SetDispatchRateWithContext(context.Background(), namespace, rate)
+}
+
+func (n *namespaces) SetDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName, rate utils.DispatchRate) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "dispatchRate")
-	return n.pulsar.Client.Post(endpoint, rate)
+	return n.pulsar.Client.Post(ctx, endpoint, rate)
 }
 
 func (n *namespaces) GetDispatchRate(namespace utils.NameSpaceName) (utils.DispatchRate, error) {
+	return n.GetDispatchRateWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetDispatchRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.DispatchRate, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "dispatchRate")
 	var rate utils.DispatchRate
-	err := n.pulsar.Client.Get(endpoint, &rate)
+	err := n.pulsar.Client.Get(ctx, endpoint, &rate)
 	return rate, err
 }
 
 func (n *namespaces) SetPublishRate(namespace utils.NameSpaceName, pubRate utils.PublishRate) error {
+	return n.SetPublishRateWithContext(context.Background(), namespace, pubRate)
+}
+
+func (n *namespaces) SetPublishRateWithContext(ctx context.Context, namespace utils.NameSpaceName, pubRate utils.PublishRate) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "publishRate")
-	return n.pulsar.Client.Post(endpoint, pubRate)
+	return n.pulsar.Client.Post(ctx, endpoint, pubRate)
 }
 
 func (n *namespaces) GetPublishRate(namespace utils.NameSpaceName) (utils.PublishRate, error) {
+	return n.GetPublishRateWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetPublishRateWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.PublishRate, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "publishRate")
 	var pubRate utils.PublishRate
-	err := n.pulsar.Client.Get(endpoint, &pubRate)
+	err := n.pulsar.Client.Get(ctx, endpoint, &pubRate)
 	return pubRate, err
 }
 
 func (n *namespaces) SetIsAllowAutoUpdateSchema(namespace utils.NameSpaceName, isAllowAutoUpdateSchema bool) error {
+	return n.SetIsAllowAutoUpdateSchemaWithContext(context.Background(), namespace, isAllowAutoUpdateSchema)
+}
+
+func (n *namespaces) SetIsAllowAutoUpdateSchemaWithContext(ctx context.Context, namespace utils.NameSpaceName, isAllowAutoUpdateSchema bool) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "isAllowAutoUpdateSchema")
-	return n.pulsar.Client.Post(endpoint, &isAllowAutoUpdateSchema)
+	return n.pulsar.Client.Post(ctx, endpoint, &isAllowAutoUpdateSchema)
 }
 
 func (n *namespaces) GetIsAllowAutoUpdateSchema(namespace utils.NameSpaceName) (bool, error) {
+	return n.GetIsAllowAutoUpdateSchemaWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetIsAllowAutoUpdateSchemaWithContext(ctx context.Context, namespace utils.NameSpaceName) (bool, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "isAllowAutoUpdateSchema")
 	var result bool
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) GetInactiveTopicPolicies(namespace utils.NameSpaceName) (utils.InactiveTopicPolicies, error) {
+	return n.GetInactiveTopicPoliciesWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetInactiveTopicPoliciesWithContext(ctx context.Context, namespace utils.NameSpaceName) (utils.InactiveTopicPolicies, error) {
 	var out utils.InactiveTopicPolicies
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
-	err := n.pulsar.Client.Get(endpoint, &out)
+	err := n.pulsar.Client.Get(ctx, endpoint, &out)
 	return out, err
 }
 
 func (n *namespaces) RemoveInactiveTopicPolicies(namespace utils.NameSpaceName) error {
+	return n.RemoveInactiveTopicPoliciesWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) RemoveInactiveTopicPoliciesWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) SetInactiveTopicPolicies(namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error {
+	return n.SetInactiveTopicPoliciesWithContext(context.Background(), namespace, data)
+}
+
+func (n *namespaces) SetInactiveTopicPoliciesWithContext(ctx context.Context, namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
-	return n.pulsar.Client.Post(endpoint, data)
+	return n.pulsar.Client.Post(ctx, endpoint, data)
 }
 
 func (n *namespaces) GetSubscriptionExpirationTime(namespace utils.NameSpaceName) (int, error) {
+	return n.GetSubscriptionExpirationTimeWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetSubscriptionExpirationTimeWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error) {
 	var result = -1
 
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) SetSubscriptionExpirationTime(namespace utils.NameSpaceName,
 	subscriptionExpirationTimeInMinutes int) error {
+	return n.SetSubscriptionExpirationTimeWithContext(context.Background(), namespace, subscriptionExpirationTimeInMinutes)
+}
+
+func (n *namespaces) SetSubscriptionExpirationTimeWithContext(ctx context.Context, namespace utils.NameSpaceName,
+	subscriptionExpirationTimeInMinutes int) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
-	return n.pulsar.Client.Post(endpoint, &subscriptionExpirationTimeInMinutes)
+	return n.pulsar.Client.Post(ctx, endpoint, &subscriptionExpirationTimeInMinutes)
 }
 
 func (n *namespaces) RemoveSubscriptionExpirationTime(namespace utils.NameSpaceName) error {
+	return n.RemoveSubscriptionExpirationTimeWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) RemoveSubscriptionExpirationTimeWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "subscriptionExpirationTime")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) UpdateProperties(namespace utils.NameSpaceName, properties map[string]string) error {
+	return n.UpdatePropertiesWithContext(context.Background(), namespace, properties)
+}
+
+func (n *namespaces) UpdatePropertiesWithContext(ctx context.Context, namespace utils.NameSpaceName, properties map[string]string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "properties")
-	return n.pulsar.Client.Put(endpoint, properties)
+	return n.pulsar.Client.Put(ctx, endpoint, properties)
 }
 
 func (n *namespaces) GetProperties(namespace utils.NameSpaceName) (map[string]string, error) {
+	return n.GetPropertiesWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetPropertiesWithContext(ctx context.Context, namespace utils.NameSpaceName) (map[string]string, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "properties")
 	properties := make(map[string]string)
-	err := n.pulsar.Client.Get(endpoint, &properties)
+	err := n.pulsar.Client.Get(ctx, endpoint, &properties)
 	return properties, err
 }
 
 func (n *namespaces) RemoveProperties(namespace utils.NameSpaceName) error {
+	return n.RemovePropertiesWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) RemovePropertiesWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "properties")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *namespaces) SetMaxTopicsPerNamespace(namespace utils.NameSpaceName, max int) error {
+	return n.SetMaxTopicsPerNamespaceWithContext(context.Background(), namespace, max)
+}
+
+func (n *namespaces) SetMaxTopicsPerNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName, max int) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxTopicsPerNamespace")
-	return n.pulsar.Client.Post(endpoint, max)
+	return n.pulsar.Client.Post(ctx, endpoint, max)
 }
 
 func (n *namespaces) GetMaxTopicsPerNamespace(namespace utils.NameSpaceName) (int, error) {
+	return n.GetMaxTopicsPerNamespaceWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) GetMaxTopicsPerNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName) (int, error) {
 	var result int
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxTopicsPerNamespace")
-	err := n.pulsar.Client.Get(endpoint, &result)
+	err := n.pulsar.Client.Get(ctx, endpoint, &result)
 	return result, err
 }
 
 func (n *namespaces) RemoveMaxTopicsPerNamespace(namespace utils.NameSpaceName) error {
+	return n.RemoveMaxTopicsPerNamespaceWithContext(context.Background(), namespace)
+}
+
+func (n *namespaces) RemoveMaxTopicsPerNamespaceWithContext(ctx context.Context, namespace utils.NameSpaceName) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "maxTopicsPerNamespace")
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }

--- a/pulsaradmin/pkg/admin/ns_isolation_policy.go
+++ b/pulsaradmin/pkg/admin/ns_isolation_policy.go
@@ -18,27 +18,47 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 )
 
 type NsIsolationPolicy interface {
-	// Create a namespace isolation policy for a cluster
+	// CreateNamespaceIsolationPolicy creates a namespace isolation policy for a cluster
 	CreateNamespaceIsolationPolicy(cluster, policyName string, namespaceIsolationData utils.NamespaceIsolationData) error
 
-	// Delete a namespace isolation policy for a cluster
+	// CreateNamespaceIsolationPolicyWithContext creates a namespace isolation policy for a cluster
+	CreateNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, policyName string, namespaceIsolationData utils.NamespaceIsolationData) error
+
+	// DeleteNamespaceIsolationPolicy deletes a namespace isolation policy for a cluster
 	DeleteNamespaceIsolationPolicy(cluster, policyName string) error
 
-	// Get a single namespace isolation policy for a cluster
+	// DeleteNamespaceIsolationPolicyWithContext deletes a namespace isolation policy for a cluster
+	DeleteNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, policyName string) error
+
+	// GetNamespaceIsolationPolicy returns a single namespace isolation policy for a cluster
 	GetNamespaceIsolationPolicy(cluster, policyName string) (*utils.NamespaceIsolationData, error)
 
-	// Get the namespace isolation policies of a cluster
+	// GetNamespaceIsolationPolicyWithContext returns a single namespace isolation policy for a cluster
+	GetNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, policyName string) (*utils.NamespaceIsolationData, error)
+
+	// GetNamespaceIsolationPolicies returns the namespace isolation policies of a cluster
 	GetNamespaceIsolationPolicies(cluster string) (map[string]utils.NamespaceIsolationData, error)
 
-	// Returns list of active brokers with namespace-isolation policies attached to it.
+	// GetNamespaceIsolationPoliciesWithContext returns the namespace isolation policies of a cluster
+	GetNamespaceIsolationPoliciesWithContext(ctx context.Context, cluster string) (map[string]utils.NamespaceIsolationData, error)
+
+	// GetBrokersWithNamespaceIsolationPolicy returns list of active brokers with namespace-isolation policies attached to it.
 	GetBrokersWithNamespaceIsolationPolicy(cluster string) ([]utils.BrokerNamespaceIsolationData, error)
 
-	// Returns active broker with namespace-isolation policies attached to it.
+	// GetBrokersWithNamespaceIsolationPolicyWithContext returns list of active brokers with namespace-isolation policies attached to it.
+	GetBrokersWithNamespaceIsolationPolicyWithContext(ctx context.Context, cluster string) ([]utils.BrokerNamespaceIsolationData, error)
+
+	// GetBrokerWithNamespaceIsolationPolicy returns active broker with namespace-isolation policies attached to it.
 	GetBrokerWithNamespaceIsolationPolicy(cluster, broker string) (*utils.BrokerNamespaceIsolationData, error)
+
+	// GetBrokerWithNamespaceIsolationPolicyWithContext returns active broker with namespace-isolation policies attached to it.
+	GetBrokerWithNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, broker string) (*utils.BrokerNamespaceIsolationData, error)
 }
 
 type nsIsolationPolicy struct {
@@ -55,25 +75,39 @@ func (c *pulsarClient) NsIsolationPolicy() NsIsolationPolicy {
 
 func (n *nsIsolationPolicy) CreateNamespaceIsolationPolicy(cluster, policyName string,
 	namespaceIsolationData utils.NamespaceIsolationData) error {
-	return n.setNamespaceIsolationPolicy(cluster, policyName, namespaceIsolationData)
+	return n.CreateNamespaceIsolationPolicyWithContext(context.Background(), cluster, policyName, namespaceIsolationData)
 }
 
-func (n *nsIsolationPolicy) setNamespaceIsolationPolicy(cluster, policyName string,
+func (n *nsIsolationPolicy) CreateNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, policyName string,
+	namespaceIsolationData utils.NamespaceIsolationData) error {
+	return n.setNamespaceIsolationPolicy(ctx, cluster, policyName, namespaceIsolationData)
+}
+
+func (n *nsIsolationPolicy) setNamespaceIsolationPolicy(ctx context.Context, cluster, policyName string,
 	namespaceIsolationData utils.NamespaceIsolationData) error {
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "namespaceIsolationPolicies", policyName)
-	return n.pulsar.Client.Post(endpoint, &namespaceIsolationData)
+	return n.pulsar.Client.Post(ctx, endpoint, &namespaceIsolationData)
 }
 
 func (n *nsIsolationPolicy) DeleteNamespaceIsolationPolicy(cluster, policyName string) error {
+	return n.DeleteNamespaceIsolationPolicyWithContext(context.Background(), cluster, policyName)
+}
+
+func (n *nsIsolationPolicy) DeleteNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, policyName string) error {
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "namespaceIsolationPolicies", policyName)
-	return n.pulsar.Client.Delete(endpoint)
+	return n.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (n *nsIsolationPolicy) GetNamespaceIsolationPolicy(cluster, policyName string) (
 	*utils.NamespaceIsolationData, error) {
+	return n.GetNamespaceIsolationPolicyWithContext(context.Background(), cluster, policyName)
+}
+
+func (n *nsIsolationPolicy) GetNamespaceIsolationPolicyWithContext(ctx context.Context, cluster, policyName string) (
+	*utils.NamespaceIsolationData, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "namespaceIsolationPolicies", policyName)
 	var nsIsolationData utils.NamespaceIsolationData
-	err := n.pulsar.Client.Get(endpoint, &nsIsolationData)
+	err := n.pulsar.Client.Get(ctx, endpoint, &nsIsolationData)
 	if err != nil {
 		return nil, err
 	}
@@ -82,9 +116,14 @@ func (n *nsIsolationPolicy) GetNamespaceIsolationPolicy(cluster, policyName stri
 
 func (n *nsIsolationPolicy) GetNamespaceIsolationPolicies(cluster string) (
 	map[string]utils.NamespaceIsolationData, error) {
+	return n.GetNamespaceIsolationPoliciesWithContext(context.Background(), cluster)
+}
+
+func (n *nsIsolationPolicy) GetNamespaceIsolationPoliciesWithContext(ctx context.Context, cluster string) (
+	map[string]utils.NamespaceIsolationData, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "namespaceIsolationPolicies")
 	var tmpMap map[string]utils.NamespaceIsolationData
-	err := n.pulsar.Client.Get(endpoint, &tmpMap)
+	err := n.pulsar.Client.Get(ctx, endpoint, &tmpMap)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +132,14 @@ func (n *nsIsolationPolicy) GetNamespaceIsolationPolicies(cluster string) (
 
 func (n *nsIsolationPolicy) GetBrokersWithNamespaceIsolationPolicy(cluster string) (
 	[]utils.BrokerNamespaceIsolationData, error) {
+	return n.GetBrokersWithNamespaceIsolationPolicyWithContext(context.Background(), cluster)
+}
+
+func (n *nsIsolationPolicy) GetBrokersWithNamespaceIsolationPolicyWithContext(ctx context.Context, cluster string) (
+	[]utils.BrokerNamespaceIsolationData, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "namespaceIsolationPolicies", "brokers")
 	var res []utils.BrokerNamespaceIsolationData
-	err := n.pulsar.Client.Get(endpoint, &res)
+	err := n.pulsar.Client.Get(ctx, endpoint, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +148,14 @@ func (n *nsIsolationPolicy) GetBrokersWithNamespaceIsolationPolicy(cluster strin
 
 func (n *nsIsolationPolicy) GetBrokerWithNamespaceIsolationPolicy(cluster,
 	broker string) (*utils.BrokerNamespaceIsolationData, error) {
+	return n.GetBrokerWithNamespaceIsolationPolicyWithContext(context.Background(), cluster, broker)
+}
+
+func (n *nsIsolationPolicy) GetBrokerWithNamespaceIsolationPolicyWithContext(ctx context.Context, cluster,
+	broker string) (*utils.BrokerNamespaceIsolationData, error) {
 	endpoint := n.pulsar.endpoint(n.basePath, cluster, "namespaceIsolationPolicies", "brokers", broker)
 	var brokerNamespaceIsolationData utils.BrokerNamespaceIsolationData
-	err := n.pulsar.Client.Get(endpoint, &brokerNamespaceIsolationData)
+	err := n.pulsar.Client.Get(ctx, endpoint, &brokerNamespaceIsolationData)
 	if err != nil {
 		return nil, err
 	}

--- a/pulsaradmin/pkg/admin/resource_quotas.go
+++ b/pulsaradmin/pkg/admin/resource_quotas.go
@@ -18,24 +18,41 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 )
 
 type ResourceQuotas interface {
-	// Get default resource quota for new resource bundles.
+	// GetDefaultResourceQuota returns default resource quota for new resource bundles.
 	GetDefaultResourceQuota() (*utils.ResourceQuota, error)
 
-	// Set default resource quota for new namespace bundles.
+	// GetDefaultResourceQuotaWithContext returns default resource quota for new resource bundles.
+	GetDefaultResourceQuotaWithContext(ctx context.Context) (*utils.ResourceQuota, error)
+
+	// SetDefaultResourceQuota sets default resource quota for new namespace bundles.
 	SetDefaultResourceQuota(quota utils.ResourceQuota) error
 
-	// Get resource quota of a namespace bundle.
+	// SetDefaultResourceQuotaWithContext sets default resource quota for new namespace bundles.
+	SetDefaultResourceQuotaWithContext(ctx context.Context, quota utils.ResourceQuota) error
+
+	// GetNamespaceBundleResourceQuota returns resource quota of a namespace bundle.
 	GetNamespaceBundleResourceQuota(namespace, bundle string) (*utils.ResourceQuota, error)
 
-	// Set resource quota for a namespace bundle.
+	// GetNamespaceBundleResourceQuotaWithContext returns resource quota of a namespace bundle.
+	GetNamespaceBundleResourceQuotaWithContext(ctx context.Context, namespace, bundle string) (*utils.ResourceQuota, error)
+
+	// SetNamespaceBundleResourceQuota sets resource quota for a namespace bundle.
 	SetNamespaceBundleResourceQuota(namespace, bundle string, quota utils.ResourceQuota) error
 
-	// Reset resource quota for a namespace bundle to default value.
+	// SetNamespaceBundleResourceQuotaWithContext sets resource quota for a namespace bundle.
+	SetNamespaceBundleResourceQuotaWithContext(ctx context.Context, namespace, bundle string, quota utils.ResourceQuota) error
+
+	// ResetNamespaceBundleResourceQuota resets resource quota for a namespace bundle to default value.
 	ResetNamespaceBundleResourceQuota(namespace, bundle string) error
+
+	// ResetNamespaceBundleResourceQuotaWithContext resets resource quota for a namespace bundle to default value.
+	ResetNamespaceBundleResourceQuotaWithContext(ctx context.Context, namespace, bundle string) error
 }
 
 type resource struct {
@@ -51,9 +68,13 @@ func (c *pulsarClient) ResourceQuotas() ResourceQuotas {
 }
 
 func (r *resource) GetDefaultResourceQuota() (*utils.ResourceQuota, error) {
+	return r.GetDefaultResourceQuotaWithContext(context.Background())
+}
+
+func (r *resource) GetDefaultResourceQuotaWithContext(ctx context.Context) (*utils.ResourceQuota, error) {
 	endpoint := r.pulsar.endpoint(r.basePath)
 	var quota utils.ResourceQuota
-	err := r.pulsar.Client.Get(endpoint, &quota)
+	err := r.pulsar.Client.Get(ctx, endpoint, &quota)
 	if err != nil {
 		return nil, err
 	}
@@ -61,14 +82,22 @@ func (r *resource) GetDefaultResourceQuota() (*utils.ResourceQuota, error) {
 }
 
 func (r *resource) SetDefaultResourceQuota(quota utils.ResourceQuota) error {
+	return r.SetDefaultResourceQuotaWithContext(context.Background(), quota)
+}
+
+func (r *resource) SetDefaultResourceQuotaWithContext(ctx context.Context, quota utils.ResourceQuota) error {
 	endpoint := r.pulsar.endpoint(r.basePath)
-	return r.pulsar.Client.Post(endpoint, &quota)
+	return r.pulsar.Client.Post(ctx, endpoint, &quota)
 }
 
 func (r *resource) GetNamespaceBundleResourceQuota(namespace, bundle string) (*utils.ResourceQuota, error) {
+	return r.GetNamespaceBundleResourceQuotaWithContext(context.Background(), namespace, bundle)
+}
+
+func (r *resource) GetNamespaceBundleResourceQuotaWithContext(ctx context.Context, namespace, bundle string) (*utils.ResourceQuota, error) {
 	endpoint := r.pulsar.endpoint(r.basePath, namespace, bundle)
 	var quota utils.ResourceQuota
-	err := r.pulsar.Client.Get(endpoint, &quota)
+	err := r.pulsar.Client.Get(ctx, endpoint, &quota)
 	if err != nil {
 		return nil, err
 	}
@@ -76,11 +105,19 @@ func (r *resource) GetNamespaceBundleResourceQuota(namespace, bundle string) (*u
 }
 
 func (r *resource) SetNamespaceBundleResourceQuota(namespace, bundle string, quota utils.ResourceQuota) error {
+	return r.SetNamespaceBundleResourceQuotaWithContext(context.Background(), namespace, bundle, quota)
+}
+
+func (r *resource) SetNamespaceBundleResourceQuotaWithContext(ctx context.Context, namespace, bundle string, quota utils.ResourceQuota) error {
 	endpoint := r.pulsar.endpoint(r.basePath, namespace, bundle)
-	return r.pulsar.Client.Post(endpoint, &quota)
+	return r.pulsar.Client.Post(ctx, endpoint, &quota)
 }
 
 func (r *resource) ResetNamespaceBundleResourceQuota(namespace, bundle string) error {
+	return r.ResetNamespaceBundleResourceQuotaWithContext(context.Background(), namespace, bundle)
+}
+
+func (r *resource) ResetNamespaceBundleResourceQuotaWithContext(ctx context.Context, namespace, bundle string) error {
 	endpoint := r.pulsar.endpoint(r.basePath, namespace, bundle)
-	return r.pulsar.Client.Delete(endpoint)
+	return r.pulsar.Client.Delete(ctx, endpoint)
 }

--- a/pulsaradmin/pkg/admin/schema.go
+++ b/pulsaradmin/pkg/admin/schema.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -78,6 +79,10 @@ func (c *pulsarClient) Schemas() Schema {
 }
 
 func (s *schemas) GetSchemaInfo(topic string) (*utils.SchemaInfo, error) {
+	return s.GetSchemaInfoWithContext(context.Background(), topic)
+}
+
+func (s *schemas) GetSchemaInfoWithContext(ctx context.Context, topic string) (*utils.SchemaInfo, error) {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return nil, err
@@ -86,7 +91,7 @@ func (s *schemas) GetSchemaInfo(topic string) (*utils.SchemaInfo, error) {
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "schema")
 
-	err = s.pulsar.Client.Get(endpoint, &response)
+	err = s.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -96,6 +101,10 @@ func (s *schemas) GetSchemaInfo(topic string) (*utils.SchemaInfo, error) {
 }
 
 func (s *schemas) GetSchemaInfoWithVersion(topic string) (*utils.SchemaInfoWithVersion, error) {
+	return s.GetSchemaInfoWithVersionWithContext(context.Background(), topic)
+}
+
+func (s *schemas) GetSchemaInfoWithVersionWithContext(ctx context.Context, topic string) (*utils.SchemaInfoWithVersion, error) {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return nil, err
@@ -104,7 +113,7 @@ func (s *schemas) GetSchemaInfoWithVersion(topic string) (*utils.SchemaInfoWithV
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "schema")
 
-	err = s.pulsar.Client.Get(endpoint, &response)
+	err = s.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		fmt.Println("err:", err.Error())
 		return nil, err
@@ -115,6 +124,10 @@ func (s *schemas) GetSchemaInfoWithVersion(topic string) (*utils.SchemaInfoWithV
 }
 
 func (s *schemas) GetSchemaInfoByVersion(topic string, version int64) (*utils.SchemaInfo, error) {
+	return s.GetSchemaInfoByVersionWithContext(context.Background(), topic, version)
+}
+
+func (s *schemas) GetSchemaInfoByVersionWithContext(ctx context.Context, topic string, version int64) (*utils.SchemaInfo, error) {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return nil, err
@@ -124,7 +137,7 @@ func (s *schemas) GetSchemaInfoByVersion(topic string, version int64) (*utils.Sc
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(), topicName.GetLocalName(),
 		"schema", strconv.FormatInt(version, 10))
 
-	err = s.pulsar.Client.Get(endpoint, &response)
+	err = s.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +147,10 @@ func (s *schemas) GetSchemaInfoByVersion(topic string, version int64) (*utils.Sc
 }
 
 func (s *schemas) GetAllSchemas(topic string) ([]*utils.SchemaInfoWithVersion, error) {
+	return s.GetAllSchemasWithContext(context.Background(), topic)
+}
+
+func (s *schemas) GetAllSchemasWithContext(ctx context.Context, topic string) ([]*utils.SchemaInfoWithVersion, error) {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return nil, err
@@ -142,7 +159,7 @@ func (s *schemas) GetAllSchemas(topic string) ([]*utils.SchemaInfoWithVersion, e
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "schemas")
 
-	err = s.pulsar.Client.Get(endpoint, &response)
+	err = s.pulsar.Client.Get(ctx, endpoint, &response)
 	if err != nil {
 		return nil, err
 	}
@@ -152,14 +169,22 @@ func (s *schemas) GetAllSchemas(topic string) ([]*utils.SchemaInfoWithVersion, e
 }
 
 func (s *schemas) DeleteSchema(topic string) error {
-	return s.delete(topic, false)
+	return s.DeleteSchemaWithContext(context.Background(), topic)
+}
+
+func (s *schemas) DeleteSchemaWithContext(ctx context.Context, topic string) error {
+	return s.delete(ctx, topic, false)
 }
 
 func (s *schemas) ForceDeleteSchema(topic string) error {
-	return s.delete(topic, true)
+	return s.ForceDeleteSchemaWithContext(context.Background(), topic)
 }
 
-func (s *schemas) delete(topic string, force bool) error {
+func (s *schemas) ForceDeleteSchemaWithContext(ctx context.Context, topic string) error {
+	return s.delete(ctx, topic, true)
+}
+
+func (s *schemas) delete(ctx context.Context, topic string, force bool) error {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return err
@@ -171,10 +196,14 @@ func (s *schemas) delete(topic string, force bool) error {
 	queryParams := make(map[string]string)
 	queryParams["force"] = strconv.FormatBool(force)
 
-	return s.pulsar.Client.DeleteWithQueryParams(endpoint, queryParams)
+	return s.pulsar.Client.DeleteWithQueryParams(ctx, endpoint, queryParams)
 }
 
 func (s *schemas) CreateSchemaByPayload(topic string, schemaPayload utils.PostSchemaPayload) error {
+	return s.CreateSchemaByPayloadWithContext(context.Background(), topic, schemaPayload)
+}
+
+func (s *schemas) CreateSchemaByPayloadWithContext(ctx context.Context, topic string, schemaPayload utils.PostSchemaPayload) error {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return err
@@ -183,20 +212,32 @@ func (s *schemas) CreateSchemaByPayload(topic string, schemaPayload utils.PostSc
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "schema")
 
-	return s.pulsar.Client.Post(endpoint, &schemaPayload)
+	return s.pulsar.Client.Post(ctx, endpoint, &schemaPayload)
 }
 
 func (s *schemas) CreateSchemaBySchemaInfo(topic string, schemaInfo utils.SchemaInfo) error {
+	return s.CreateSchemaBySchemaInfoWithContext(context.Background(), topic, schemaInfo)
+}
+
+func (s *schemas) CreateSchemaBySchemaInfoWithContext(ctx context.Context, topic string, schemaInfo utils.SchemaInfo) error {
 	schemaPayload := utils.ConvertSchemaInfoToPostSchemaPayload(schemaInfo)
 	return s.CreateSchemaByPayload(topic, schemaPayload)
 }
 
 func (s *schemas) GetVersionBySchemaInfo(topic string, schemaInfo utils.SchemaInfo) (int64, error) {
+	return s.GetVersionBySchemaInfoWithContext(context.Background(), topic, schemaInfo)
+}
+
+func (s *schemas) GetVersionBySchemaInfoWithContext(ctx context.Context, topic string, schemaInfo utils.SchemaInfo) (int64, error) {
 	schemaPayload := utils.ConvertSchemaInfoToPostSchemaPayload(schemaInfo)
 	return s.GetVersionByPayload(topic, schemaPayload)
 }
 
 func (s *schemas) GetVersionByPayload(topic string, schemaPayload utils.PostSchemaPayload) (int64, error) {
+	return s.GetVersionByPayloadWithContext(context.Background(), topic, schemaPayload)
+}
+
+func (s *schemas) GetVersionByPayloadWithContext(ctx context.Context, topic string, schemaPayload utils.PostSchemaPayload) (int64, error) {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
 		return 0, err
@@ -206,17 +247,27 @@ func (s *schemas) GetVersionByPayload(topic string, schemaPayload utils.PostSche
 	}{}
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "version")
-	err = s.pulsar.Client.PostWithObj(endpoint, &schemaPayload, &version)
+	err = s.pulsar.Client.PostWithObj(ctx, endpoint, &schemaPayload, &version)
 	return version.Version, err
 }
 
 func (s *schemas) TestCompatibilityWithSchemaInfo(topic string,
 	schemaInfo utils.SchemaInfo) (*utils.IsCompatibility, error) {
+	return s.TestCompatibilityWithSchemaInfoWithContext(context.Background(), topic, schemaInfo)
+}
+
+func (s *schemas) TestCompatibilityWithSchemaInfoWithContext(ctx context.Context, topic string,
+	schemaInfo utils.SchemaInfo) (*utils.IsCompatibility, error) {
 	schemaPayload := utils.ConvertSchemaInfoToPostSchemaPayload(schemaInfo)
-	return s.TestCompatibilityWithPostSchemaPayload(topic, schemaPayload)
+	return s.TestCompatibilityWithPostSchemaPayloadWithContext(ctx, topic, schemaPayload)
 }
 
 func (s *schemas) TestCompatibilityWithPostSchemaPayload(topic string,
+	schemaPayload utils.PostSchemaPayload) (*utils.IsCompatibility, error) {
+	return s.TestCompatibilityWithPostSchemaPayloadWithContext(context.Background(), topic, schemaPayload)
+}
+
+func (s *schemas) TestCompatibilityWithPostSchemaPayloadWithContext(ctx context.Context, topic string,
 	schemaPayload utils.PostSchemaPayload) (*utils.IsCompatibility, error) {
 	topicName, err := utils.GetTopicName(topic)
 	if err != nil {
@@ -225,6 +276,6 @@ func (s *schemas) TestCompatibilityWithPostSchemaPayload(topic string,
 	var isCompatibility utils.IsCompatibility
 	endpoint := s.pulsar.endpoint(s.basePath, topicName.GetTenant(), topicName.GetNamespace(),
 		topicName.GetLocalName(), "compatibility")
-	err = s.pulsar.Client.PostWithObj(endpoint, &schemaPayload, &isCompatibility)
+	err = s.pulsar.Client.PostWithObj(ctx, endpoint, &schemaPayload, &isCompatibility)
 	return &isCompatibility, err
 }

--- a/pulsaradmin/pkg/admin/sinks.go
+++ b/pulsaradmin/pkg/admin/sinks.go
@@ -19,6 +19,7 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,53 +37,104 @@ type Sinks interface {
 	// ListSinks returns the list of all the Pulsar Sinks.
 	ListSinks(tenant, namespace string) ([]string, error)
 
+	// ListSinksWithContext returns the list of all the Pulsar Sinks.
+	ListSinksWithContext(ctx context.Context, tenant, namespace string) ([]string, error)
+
 	// GetSink returns the configuration for the specified sink
 	GetSink(tenant, namespace, Sink string) (utils.SinkConfig, error)
+
+	// GetSinkWithContext returns the configuration for the specified sink
+	GetSinkWithContext(ctx context.Context, tenant, namespace, Sink string) (utils.SinkConfig, error)
 
 	// CreateSink creates a new sink
 	CreateSink(config *utils.SinkConfig, fileName string) error
 
+	// CreateSinkWithContext creates a new sink
+	CreateSinkWithContext(ctx context.Context, config *utils.SinkConfig, fileName string) error
+
 	// CreateSinkWithURL creates a new sink by providing url from which fun-pkg can be downloaded. supported url: http/file
 	CreateSinkWithURL(config *utils.SinkConfig, pkgURL string) error
+
+	// CreateSinkWithURLWithContext creates a new sink by providing url from which fun-pkg can be downloaded. supported url: http/file
+	CreateSinkWithURLWithContext(ctx context.Context, config *utils.SinkConfig, pkgURL string) error
 
 	// UpdateSink updates the configuration for a sink.
 	UpdateSink(config *utils.SinkConfig, fileName string, options *utils.UpdateOptions) error
 
+	// UpdateSinkWithContext updates the configuration for a sink.
+	UpdateSinkWithContext(ctx context.Context, config *utils.SinkConfig, fileName string, options *utils.UpdateOptions) error
+
 	// UpdateSinkWithURL updates a sink by providing url from which fun-pkg can be downloaded. supported url: http/file
 	UpdateSinkWithURL(config *utils.SinkConfig, pkgURL string, options *utils.UpdateOptions) error
+
+	// UpdateSinkWithURLWithContext updates a sink by providing url from which fun-pkg can be downloaded. supported url: http/file
+	UpdateSinkWithURLWithContext(ctx context.Context, config *utils.SinkConfig, pkgURL string, options *utils.UpdateOptions) error
 
 	// DeleteSink deletes an existing sink
 	DeleteSink(tenant, namespace, Sink string) error
 
+	// DeleteSinkWithContext deletes an existing sink
+	DeleteSinkWithContext(ctx context.Context, tenant, namespace, Sink string) error
+
 	// GetSinkStatus returns the current status of a sink.
 	GetSinkStatus(tenant, namespace, Sink string) (utils.SinkStatus, error)
+
+	// GetSinkStatusWithContext returns the current status of a sink.
+	GetSinkStatusWithContext(ctx context.Context, tenant, namespace, Sink string) (utils.SinkStatus, error)
 
 	// GetSinkStatusWithID returns the current status of a sink instance.
 	GetSinkStatusWithID(tenant, namespace, Sink string, id int) (utils.SinkInstanceStatusData, error)
 
+	// GetSinkStatusWithIDWithContext returns the current status of a sink instance.
+	GetSinkStatusWithIDWithContext(ctx context.Context, tenant, namespace, Sink string, id int) (utils.SinkInstanceStatusData, error)
+
 	// RestartSink restarts all sink instances
 	RestartSink(tenant, namespace, Sink string) error
+
+	// RestartSinkWithContext restarts all sink instances
+	RestartSinkWithContext(ctx context.Context, tenant, namespace, Sink string) error
 
 	// RestartSinkWithID restarts sink instance
 	RestartSinkWithID(tenant, namespace, Sink string, id int) error
 
+	// RestartSinkWithIDWithContext restarts sink instance
+	RestartSinkWithIDWithContext(ctx context.Context, tenant, namespace, Sink string, id int) error
+
 	// StopSink stops all sink instances
 	StopSink(tenant, namespace, Sink string) error
+
+	// StopSinkWithContext stops all sink instances
+	StopSinkWithContext(ctx context.Context, tenant, namespace, Sink string) error
 
 	// StopSinkWithID stops sink instance
 	StopSinkWithID(tenant, namespace, Sink string, id int) error
 
+	// StopSinkWithIDWithContext stops sink instance
+	StopSinkWithIDWithContext(ctx context.Context, tenant, namespace, Sink string, id int) error
+
 	// StartSink starts all sink instances
 	StartSink(tenant, namespace, Sink string) error
+
+	// StartSinkWithContext starts all sink instances
+	StartSinkWithContext(ctx context.Context, tenant, namespace, Sink string) error
 
 	// StartSinkWithID starts sink instance
 	StartSinkWithID(tenant, namespace, Sink string, id int) error
 
+	// StartSinkWithIDWithContext starts sink instance
+	StartSinkWithIDWithContext(ctx context.Context, tenant, namespace, Sink string, id int) error
+
 	// GetBuiltInSinks fetches a list of supported Pulsar IO sinks currently running in cluster mode
 	GetBuiltInSinks() ([]*utils.ConnectorDefinition, error)
 
-	// ReloadBuiltInSinks reload the available built-in connectors, include Source and Sink
+	// GetBuiltInSinksWithContext fetches a list of supported Pulsar IO sinks currently running in cluster mode
+	GetBuiltInSinksWithContext(ctx context.Context) ([]*utils.ConnectorDefinition, error)
+
+	// ReloadBuiltInSinks reloads the available built-in connectors, include Source and Sink
 	ReloadBuiltInSinks() error
+
+	// ReloadBuiltInSinksWithContext reloads the available built-in connectors, include Source and Sink
+	ReloadBuiltInSinksWithContext(ctx context.Context) error
 }
 
 type sinks struct {
@@ -113,20 +165,32 @@ func (s *sinks) createTextFromFiled(w *multipart.Writer, value string) (io.Write
 }
 
 func (s *sinks) ListSinks(tenant, namespace string) ([]string, error) {
+	return s.ListSinksWithContext(context.Background(), tenant, namespace)
+}
+
+func (s *sinks) ListSinksWithContext(ctx context.Context, tenant, namespace string) ([]string, error) {
 	var sinks []string
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace)
-	err := s.pulsar.Client.Get(endpoint, &sinks)
+	err := s.pulsar.Client.Get(ctx, endpoint, &sinks)
 	return sinks, err
 }
 
 func (s *sinks) GetSink(tenant, namespace, sink string) (utils.SinkConfig, error) {
+	return s.GetSinkWithContext(context.Background(), tenant, namespace, sink)
+}
+
+func (s *sinks) GetSinkWithContext(ctx context.Context, tenant, namespace, sink string) (utils.SinkConfig, error) {
 	var sinkConfig utils.SinkConfig
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	err := s.pulsar.Client.Get(endpoint, &sinkConfig)
+	err := s.pulsar.Client.Get(ctx, endpoint, &sinkConfig)
 	return sinkConfig, err
 }
 
 func (s *sinks) CreateSink(config *utils.SinkConfig, fileName string) error {
+	return s.CreateSinkWithContext(context.Background(), config, fileName)
+}
+
+func (s *sinks) CreateSinkWithContext(ctx context.Context, config *utils.SinkConfig, fileName string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 
 	// buffer to store our request as bytes
@@ -176,7 +240,7 @@ func (s *sinks) CreateSink(config *utils.SinkConfig, fileName string) error {
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = s.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -185,6 +249,10 @@ func (s *sinks) CreateSink(config *utils.SinkConfig, fileName string) error {
 }
 
 func (s *sinks) CreateSinkWithURL(config *utils.SinkConfig, pkgURL string) error {
+	return s.CreateSinkWithURLWithContext(context.Background(), config, pkgURL)
+}
+
+func (s *sinks) CreateSinkWithURLWithContext(ctx context.Context, config *utils.SinkConfig, pkgURL string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 	// buffer to store our request as bytes
 	bodyBuf := bytes.NewBufferString("")
@@ -221,7 +289,7 @@ func (s *sinks) CreateSinkWithURL(config *utils.SinkConfig, pkgURL string) error
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = s.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -230,6 +298,10 @@ func (s *sinks) CreateSinkWithURL(config *utils.SinkConfig, pkgURL string) error
 }
 
 func (s *sinks) UpdateSink(config *utils.SinkConfig, fileName string, updateOptions *utils.UpdateOptions) error {
+	return s.UpdateSinkWithContext(context.Background(), config, fileName, updateOptions)
+}
+
+func (s *sinks) UpdateSinkWithContext(ctx context.Context, config *utils.SinkConfig, fileName string, updateOptions *utils.UpdateOptions) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 	// buffer to store our request as bytes
 	bodyBuf := bytes.NewBufferString("")
@@ -296,7 +368,7 @@ func (s *sinks) UpdateSink(config *utils.SinkConfig, fileName string, updateOpti
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PutWithMultiPart(endpoint, bodyBuf, contentType)
+	err = s.pulsar.Client.PutWithMultiPart(ctx, endpoint, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -305,6 +377,10 @@ func (s *sinks) UpdateSink(config *utils.SinkConfig, fileName string, updateOpti
 }
 
 func (s *sinks) UpdateSinkWithURL(config *utils.SinkConfig, pkgURL string, updateOptions *utils.UpdateOptions) error {
+	return s.UpdateSinkWithURLWithContext(context.Background(), config, pkgURL, updateOptions)
+}
+
+func (s *sinks) UpdateSinkWithURLWithContext(ctx context.Context, config *utils.SinkConfig, pkgURL string, updateOptions *utils.UpdateOptions) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 	// buffer to store our request as bytes
 	bodyBuf := bytes.NewBufferString("")
@@ -360,7 +436,7 @@ func (s *sinks) UpdateSinkWithURL(config *utils.SinkConfig, pkgURL string, updat
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PutWithMultiPart(endpoint, bodyBuf, contentType)
+	err = s.pulsar.Client.PutWithMultiPart(ctx, endpoint, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -369,69 +445,113 @@ func (s *sinks) UpdateSinkWithURL(config *utils.SinkConfig, pkgURL string, updat
 }
 
 func (s *sinks) DeleteSink(tenant, namespace, sink string) error {
+	return s.DeleteSinkWithContext(context.Background(), tenant, namespace, sink)
+}
+
+func (s *sinks) DeleteSinkWithContext(ctx context.Context, tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Delete(endpoint)
+	return s.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (s *sinks) GetSinkStatus(tenant, namespace, sink string) (utils.SinkStatus, error) {
+	return s.GetSinkStatusWithContext(context.Background(), tenant, namespace, sink)
+}
+
+func (s *sinks) GetSinkStatusWithContext(ctx context.Context, tenant, namespace, sink string) (utils.SinkStatus, error) {
 	var sinkStatus utils.SinkStatus
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	err := s.pulsar.Client.Get(endpoint+"/status", &sinkStatus)
+	err := s.pulsar.Client.Get(ctx, endpoint+"/status", &sinkStatus)
 	return sinkStatus, err
 }
 
 func (s *sinks) GetSinkStatusWithID(tenant, namespace, sink string, id int) (utils.SinkInstanceStatusData, error) {
+	return s.GetSinkStatusWithIDWithContext(context.Background(), tenant, namespace, sink, id)
+}
+
+func (s *sinks) GetSinkStatusWithIDWithContext(ctx context.Context, tenant, namespace, sink string, id int) (utils.SinkInstanceStatusData, error) {
 	var sinkInstanceStatusData utils.SinkInstanceStatusData
 	instanceID := fmt.Sprintf("%d", id)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, instanceID)
-	err := s.pulsar.Client.Get(endpoint+"/status", &sinkInstanceStatusData)
+	err := s.pulsar.Client.Get(ctx, endpoint+"/status", &sinkInstanceStatusData)
 	return sinkInstanceStatusData, err
 }
 
 func (s *sinks) RestartSink(tenant, namespace, sink string) error {
+	return s.RestartSinkWithContext(context.Background(), tenant, namespace, sink)
+}
+
+func (s *sinks) RestartSinkWithContext(ctx context.Context, tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Post(endpoint+"/restart", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/restart", nil)
 }
 
 func (s *sinks) RestartSinkWithID(tenant, namespace, sink string, instanceID int) error {
+	return s.RestartSinkWithIDWithContext(context.Background(), tenant, namespace, sink, instanceID)
+}
+
+func (s *sinks) RestartSinkWithIDWithContext(ctx context.Context, tenant, namespace, sink string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, id)
 
-	return s.pulsar.Client.Post(endpoint+"/restart", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/restart", nil)
 }
 
 func (s *sinks) StopSink(tenant, namespace, sink string) error {
+	return s.StopSinkWithContext(context.Background(), tenant, namespace, sink)
+}
+
+func (s *sinks) StopSinkWithContext(ctx context.Context, tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Post(endpoint+"/stop", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/stop", nil)
 }
 
 func (s *sinks) StopSinkWithID(tenant, namespace, sink string, instanceID int) error {
+	return s.StopSinkWithIDWithContext(context.Background(), tenant, namespace, sink, instanceID)
+}
+
+func (s *sinks) StopSinkWithIDWithContext(ctx context.Context, tenant, namespace, sink string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, id)
 
-	return s.pulsar.Client.Post(endpoint+"/stop", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/stop", nil)
 }
 
 func (s *sinks) StartSink(tenant, namespace, sink string) error {
+	return s.StartSinkWithContext(context.Background(), tenant, namespace, sink)
+}
+
+func (s *sinks) StartSinkWithContext(ctx context.Context, tenant, namespace, sink string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink)
-	return s.pulsar.Client.Post(endpoint+"/start", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/start", nil)
 }
 
 func (s *sinks) StartSinkWithID(tenant, namespace, sink string, instanceID int) error {
+	return s.StartSinkWithIDWithContext(context.Background(), tenant, namespace, sink, instanceID)
+}
+
+func (s *sinks) StartSinkWithIDWithContext(ctx context.Context, tenant, namespace, sink string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, sink, id)
 
-	return s.pulsar.Client.Post(endpoint+"/start", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/start", nil)
 }
 
 func (s *sinks) GetBuiltInSinks() ([]*utils.ConnectorDefinition, error) {
+	return s.GetBuiltInSinksWithContext(context.Background())
+}
+
+func (s *sinks) GetBuiltInSinksWithContext(ctx context.Context) ([]*utils.ConnectorDefinition, error) {
 	var connectorDefinition []*utils.ConnectorDefinition
 	endpoint := s.pulsar.endpoint(s.basePath, "builtinsinks")
-	err := s.pulsar.Client.Get(endpoint, &connectorDefinition)
+	err := s.pulsar.Client.Get(ctx, endpoint, &connectorDefinition)
 	return connectorDefinition, err
 }
 
 func (s *sinks) ReloadBuiltInSinks() error {
+	return s.ReloadBuiltInSinksWithContext(context.Background())
+}
+
+func (s *sinks) ReloadBuiltInSinksWithContext(ctx context.Context) error {
 	endpoint := s.pulsar.endpoint(s.basePath, "reloadBuiltInSinks")
-	return s.pulsar.Client.Post(endpoint, nil)
+	return s.pulsar.Client.Post(ctx, endpoint, nil)
 }

--- a/pulsaradmin/pkg/admin/sources.go
+++ b/pulsaradmin/pkg/admin/sources.go
@@ -19,6 +19,7 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,54 +37,106 @@ type Sources interface {
 	// ListSources returns the list of all the Pulsar Sources.
 	ListSources(tenant, namespace string) ([]string, error)
 
+	// ListSources returns the list of all the Pulsar Sources.
+	ListSourcesWithContext(ctx context.Context, tenant, namespace string) ([]string, error)
+
 	// GetSource return the configuration for the specified source
 	GetSource(tenant, namespace, source string) (utils.SourceConfig, error)
 
+	// GetSource return the configuration for the specified source
+	GetSourceWithContext(ctx context.Context, tenant, namespace, source string) (utils.SourceConfig, error)
+
 	// CreateSource creates a new source
 	CreateSource(config *utils.SourceConfig, fileName string) error
+
+	// CreateSource creates a new source
+	CreateSourceWithContext(ctx context.Context, config *utils.SourceConfig, fileName string) error
 
 	// CreateSourceWithURL creates a new source by providing url from which fun-pkg can be downloaded.
 	// supported url: http/file
 	CreateSourceWithURL(config *utils.SourceConfig, pkgURL string) error
 
+	// CreateSourceWithURL creates a new source by providing url from which fun-pkg can be downloaded.
+	// supported url: http/file
+	CreateSourceWithURLWithContext(ctx context.Context, config *utils.SourceConfig, pkgURL string) error
+
 	// UpdateSource updates the configuration for a source.
 	UpdateSource(config *utils.SourceConfig, fileName string, options *utils.UpdateOptions) error
+
+	// UpdateSource updates the configuration for a source.
+	UpdateSourceWithContext(ctx context.Context, config *utils.SourceConfig, fileName string, options *utils.UpdateOptions) error
 
 	// UpdateSourceWithURL updates a source by providing url from which fun-pkg can be downloaded. supported url: http/file
 	UpdateSourceWithURL(config *utils.SourceConfig, pkgURL string, options *utils.UpdateOptions) error
 
+	// UpdateSourceWithURL updates a source by providing url from which fun-pkg can be downloaded. supported url: http/file
+	UpdateSourceWithURLWithContext(ctx context.Context, config *utils.SourceConfig, pkgURL string, options *utils.UpdateOptions) error
+
 	// DeleteSource deletes an existing source
 	DeleteSource(tenant, namespace, source string) error
+
+	// DeleteSource deletes an existing source
+	DeleteSourceWithContext(ctx context.Context, tenant, namespace, source string) error
 
 	// GetSourceStatus returns the current status of a source.
 	GetSourceStatus(tenant, namespace, source string) (utils.SourceStatus, error)
 
+	// GetSourceStatus returns the current status of a source.
+	GetSourceStatusWithContext(ctx context.Context, tenant, namespace, source string) (utils.SourceStatus, error)
+
 	// GetSourceStatusWithID returns the current status of a source instance.
 	GetSourceStatusWithID(tenant, namespace, source string, id int) (utils.SourceInstanceStatusData, error)
+
+	// GetSourceStatusWithID returns the current status of a source instance.
+	GetSourceStatusWithIDWithContext(ctx context.Context, tenant, namespace, source string, id int) (utils.SourceInstanceStatusData, error)
 
 	// RestartSource restarts all source instances
 	RestartSource(tenant, namespace, source string) error
 
+	// RestartSource restarts all source instances
+	RestartSourceWithContext(ctx context.Context, tenant, namespace, source string) error
+
 	// RestartSourceWithID restarts source instance
 	RestartSourceWithID(tenant, namespace, source string, id int) error
+
+	// RestartSourceWithID restarts source instance
+	RestartSourceWithIDWithContext(ctx context.Context, tenant, namespace, source string, id int) error
 
 	// StopSource stops all source instances
 	StopSource(tenant, namespace, source string) error
 
+	// StopSource stops all source instances
+	StopSourceWithContext(ctx context.Context, tenant, namespace, source string) error
+
 	// StopSourceWithID stops source instance
 	StopSourceWithID(tenant, namespace, source string, id int) error
+
+	// StopSourceWithID stops source instance
+	StopSourceWithIDWithContext(ctx context.Context, tenant, namespace, source string, id int) error
 
 	// StartSource starts all source instances
 	StartSource(tenant, namespace, source string) error
 
+	// StartSource starts all source instances
+	StartSourceWithContext(ctx context.Context, tenant, namespace, source string) error
+
 	// StartSourceWithID starts source instance
 	StartSourceWithID(tenant, namespace, source string, id int) error
+
+	// StartSourceWithID starts source instance
+	StartSourceWithIDWithContext(ctx context.Context, tenant, namespace, source string, id int) error
 
 	// GetBuiltInSources fetches a list of supported Pulsar IO sources currently running in cluster mode
 	GetBuiltInSources() ([]*utils.ConnectorDefinition, error)
 
+	// GetBuiltInSources fetches a list of supported Pulsar IO sources currently running in cluster mode
+	GetBuiltInSourcesWithContext(ctx context.Context) ([]*utils.ConnectorDefinition, error)
+
 	// ReloadBuiltInSources reloads the available built-in connectors, include Source and Sink
 	ReloadBuiltInSources() error
+
+	// ReloadBuiltInSources reloads the available built-in connectors, include Source and Sink
+	ReloadBuiltInSourcesWithContext(ctx context.Context) error
 }
 
 type sources struct {
@@ -114,20 +167,32 @@ func (s *sources) createTextFromFiled(w *multipart.Writer, value string) (io.Wri
 }
 
 func (s *sources) ListSources(tenant, namespace string) ([]string, error) {
+	return s.ListSourcesWithContext(context.Background(), tenant, namespace)
+}
+
+func (s *sources) ListSourcesWithContext(ctx context.Context, tenant, namespace string) ([]string, error) {
 	var sources []string
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace)
-	err := s.pulsar.Client.Get(endpoint, &sources)
+	err := s.pulsar.Client.Get(ctx, endpoint, &sources)
 	return sources, err
 }
 
 func (s *sources) GetSource(tenant, namespace, source string) (utils.SourceConfig, error) {
+	return s.GetSourceWithContext(context.Background(), tenant, namespace, source)
+}
+
+func (s *sources) GetSourceWithContext(ctx context.Context, tenant, namespace, source string) (utils.SourceConfig, error) {
 	var sourceConfig utils.SourceConfig
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	err := s.pulsar.Client.Get(endpoint, &sourceConfig)
+	err := s.pulsar.Client.Get(ctx, endpoint, &sourceConfig)
 	return sourceConfig, err
 }
 
 func (s *sources) CreateSource(config *utils.SourceConfig, fileName string) error {
+	return s.CreateSourceWithContext(context.Background(), config, fileName)
+}
+
+func (s *sources) CreateSourceWithContext(ctx context.Context, config *utils.SourceConfig, fileName string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 
 	// buffer to store our request as bytes
@@ -177,7 +242,7 @@ func (s *sources) CreateSource(config *utils.SourceConfig, fileName string) erro
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = s.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -186,6 +251,10 @@ func (s *sources) CreateSource(config *utils.SourceConfig, fileName string) erro
 }
 
 func (s *sources) CreateSourceWithURL(config *utils.SourceConfig, pkgURL string) error {
+	return s.CreateSourceWithURLWithContext(context.Background(), config, pkgURL)
+}
+
+func (s *sources) CreateSourceWithURLWithContext(ctx context.Context, config *utils.SourceConfig, pkgURL string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 	// buffer to store our request as bytes
 	bodyBuf := bytes.NewBufferString("")
@@ -222,7 +291,7 @@ func (s *sources) CreateSourceWithURL(config *utils.SourceConfig, pkgURL string)
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PostWithMultiPart(endpoint, nil, bodyBuf, contentType)
+	err = s.pulsar.Client.PostWithMultiPart(ctx, endpoint, nil, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -231,6 +300,10 @@ func (s *sources) CreateSourceWithURL(config *utils.SourceConfig, pkgURL string)
 }
 
 func (s *sources) UpdateSource(config *utils.SourceConfig, fileName string, updateOptions *utils.UpdateOptions) error {
+	return s.UpdateSourceWithContext(context.Background(), config, fileName, updateOptions)
+}
+
+func (s *sources) UpdateSourceWithContext(ctx context.Context, config *utils.SourceConfig, fileName string, updateOptions *utils.UpdateOptions) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 	// buffer to store our request as bytes
 	bodyBuf := bytes.NewBufferString("")
@@ -297,7 +370,7 @@ func (s *sources) UpdateSource(config *utils.SourceConfig, fileName string, upda
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PutWithMultiPart(endpoint, bodyBuf, contentType)
+	err = s.pulsar.Client.PutWithMultiPart(ctx, endpoint, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -306,6 +379,11 @@ func (s *sources) UpdateSource(config *utils.SourceConfig, fileName string, upda
 }
 
 func (s *sources) UpdateSourceWithURL(config *utils.SourceConfig, pkgURL string,
+	updateOptions *utils.UpdateOptions) error {
+	return s.UpdateSourceWithURLWithContext(context.Background(), config, pkgURL, updateOptions)
+}
+
+func (s *sources) UpdateSourceWithURLWithContext(ctx context.Context, config *utils.SourceConfig, pkgURL string,
 	updateOptions *utils.UpdateOptions) error {
 	endpoint := s.pulsar.endpoint(s.basePath, config.Tenant, config.Namespace, config.Name)
 	// buffer to store our request as bytes
@@ -362,7 +440,7 @@ func (s *sources) UpdateSourceWithURL(config *utils.SourceConfig, pkgURL string,
 	}
 
 	contentType := multiPartWriter.FormDataContentType()
-	err = s.pulsar.Client.PutWithMultiPart(endpoint, bodyBuf, contentType)
+	err = s.pulsar.Client.PutWithMultiPart(ctx, endpoint, bodyBuf, contentType)
 	if err != nil {
 		return err
 	}
@@ -371,70 +449,115 @@ func (s *sources) UpdateSourceWithURL(config *utils.SourceConfig, pkgURL string,
 }
 
 func (s *sources) DeleteSource(tenant, namespace, source string) error {
+	return s.DeleteSourceWithContext(context.Background(), tenant, namespace, source)
+}
+
+func (s *sources) DeleteSourceWithContext(ctx context.Context, tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Delete(endpoint)
+	return s.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (s *sources) GetSourceStatus(tenant, namespace, source string) (utils.SourceStatus, error) {
+	return s.GetSourceStatusWithContext(context.Background(), tenant, namespace, source)
+}
+
+func (s *sources) GetSourceStatusWithContext(ctx context.Context, tenant, namespace, source string) (utils.SourceStatus, error) {
 	var sourceStatus utils.SourceStatus
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	err := s.pulsar.Client.Get(endpoint+"/status", &sourceStatus)
+	err := s.pulsar.Client.Get(ctx, endpoint+"/status", &sourceStatus)
 	return sourceStatus, err
 }
 
 func (s *sources) GetSourceStatusWithID(tenant, namespace, source string, id int) (
 	utils.SourceInstanceStatusData, error) {
+	return s.GetSourceStatusWithIDWithContext(context.Background(), tenant, namespace, source, id)
+}
+
+func (s *sources) GetSourceStatusWithIDWithContext(ctx context.Context, tenant, namespace, source string, id int) (
+	utils.SourceInstanceStatusData, error) {
 	var sourceInstanceStatusData utils.SourceInstanceStatusData
 	instanceID := fmt.Sprintf("%d", id)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, instanceID)
-	err := s.pulsar.Client.Get(endpoint+"/status", &sourceInstanceStatusData)
+	err := s.pulsar.Client.Get(ctx, endpoint+"/status", &sourceInstanceStatusData)
 	return sourceInstanceStatusData, err
 }
 
 func (s *sources) RestartSource(tenant, namespace, source string) error {
+	return s.RestartSourceWithContext(context.Background(), tenant, namespace, source)
+}
+
+func (s *sources) RestartSourceWithContext(ctx context.Context, tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Post(endpoint+"/restart", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/restart", nil)
 }
 
 func (s *sources) RestartSourceWithID(tenant, namespace, source string, instanceID int) error {
+	return s.RestartSourceWithIDWithContext(context.Background(), tenant, namespace, source, instanceID)
+}
+
+func (s *sources) RestartSourceWithIDWithContext(ctx context.Context, tenant, namespace, source string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, id)
 
-	return s.pulsar.Client.Post(endpoint+"/restart", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/restart", nil)
 }
 
 func (s *sources) StopSource(tenant, namespace, source string) error {
+	return s.StopSourceWithContext(context.Background(), tenant, namespace, source)
+}
+
+func (s *sources) StopSourceWithContext(ctx context.Context, tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Post(endpoint+"/stop", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/stop", nil)
 }
 
 func (s *sources) StopSourceWithID(tenant, namespace, source string, instanceID int) error {
+	return s.StopSourceWithIDWithContext(context.Background(), tenant, namespace, source, instanceID)
+}
+
+func (s *sources) StopSourceWithIDWithContext(ctx context.Context, tenant, namespace, source string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, id)
 
-	return s.pulsar.Client.Post(endpoint+"/stop", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/stop", nil)
 }
 
 func (s *sources) StartSource(tenant, namespace, source string) error {
+	return s.StartSourceWithContext(context.Background(), tenant, namespace, source)
+}
+
+func (s *sources) StartSourceWithContext(ctx context.Context, tenant, namespace, source string) error {
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source)
-	return s.pulsar.Client.Post(endpoint+"/start", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/start", nil)
 }
 
 func (s *sources) StartSourceWithID(tenant, namespace, source string, instanceID int) error {
+	return s.StartSourceWithIDWithContext(context.Background(), tenant, namespace, source, instanceID)
+}
+
+func (s *sources) StartSourceWithIDWithContext(ctx context.Context, tenant, namespace, source string, instanceID int) error {
 	id := fmt.Sprintf("%d", instanceID)
 	endpoint := s.pulsar.endpoint(s.basePath, tenant, namespace, source, id)
 
-	return s.pulsar.Client.Post(endpoint+"/start", nil)
+	return s.pulsar.Client.Post(ctx, endpoint+"/start", nil)
 }
 
 func (s *sources) GetBuiltInSources() ([]*utils.ConnectorDefinition, error) {
+	return s.GetBuiltInSourcesWithContext(context.Background())
+}
+
+func (s *sources) GetBuiltInSourcesWithContext(ctx context.Context) ([]*utils.ConnectorDefinition, error) {
 	var connectorDefinition []*utils.ConnectorDefinition
 	endpoint := s.pulsar.endpoint(s.basePath, "builtinsources")
-	err := s.pulsar.Client.Get(endpoint, &connectorDefinition)
+	err := s.pulsar.Client.Get(ctx, endpoint, &connectorDefinition)
 	return connectorDefinition, err
 }
 
 func (s *sources) ReloadBuiltInSources() error {
+	return s.ReloadBuiltInSourcesWithContext(context.Background())
+}
+
+func (s *sources) ReloadBuiltInSourcesWithContext(ctx context.Context) error {
 	endpoint := s.pulsar.endpoint(s.basePath, "reloadBuiltInSources")
-	return s.pulsar.Client.Post(endpoint, nil)
+	return s.pulsar.Client.Post(ctx, endpoint, nil)
 }

--- a/pulsaradmin/pkg/admin/tenant.go
+++ b/pulsaradmin/pkg/admin/tenant.go
@@ -18,25 +18,42 @@
 package admin
 
 import (
+	"context"
+
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 )
 
 // Tenants is admin interface for tenants management
 type Tenants interface {
-	// Create a new tenant
+	// Create creates a new tenant
 	Create(utils.TenantData) error
 
-	// Delete an existing tenant
+	// CreateWithContext creates a new tenant
+	CreateWithContext(context.Context, utils.TenantData) error
+
+	// Delete deletes an existing tenant
 	Delete(string) error
 
-	// Update the admins for a tenant
+	// DeleteWithContext deletes an existing tenant
+	DeleteWithContext(context.Context, string) error
+
+	// Update updates the admins for a tenant
 	Update(utils.TenantData) error
+
+	// UpdateWithContext updates the admins for a tenant
+	UpdateWithContext(context.Context, utils.TenantData) error
 
 	// List returns the list of tenants
 	List() ([]string, error)
 
+	// ListWithContext returns the list of tenants
+	ListWithContext(context.Context) ([]string, error)
+
 	// Get returns the config of the tenant.
 	Get(string) (utils.TenantData, error)
+
+	// GetWithContext returns the config of the tenant.
+	GetWithContext(context.Context, string) (utils.TenantData, error)
 }
 
 type tenants struct {
@@ -53,30 +70,50 @@ func (c *pulsarClient) Tenants() Tenants {
 }
 
 func (c *tenants) Create(data utils.TenantData) error {
+	return c.CreateWithContext(context.Background(), data)
+}
+
+func (c *tenants) CreateWithContext(ctx context.Context, data utils.TenantData) error {
 	endpoint := c.pulsar.endpoint(c.basePath, data.Name)
-	return c.pulsar.Client.Put(endpoint, &data)
+	return c.pulsar.Client.Put(ctx, endpoint, &data)
 }
 
 func (c *tenants) Delete(name string) error {
+	return c.DeleteWithContext(context.Background(), name)
+}
+
+func (c *tenants) DeleteWithContext(ctx context.Context, name string) error {
 	endpoint := c.pulsar.endpoint(c.basePath, name)
-	return c.pulsar.Client.Delete(endpoint)
+	return c.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (c *tenants) Update(data utils.TenantData) error {
+	return c.UpdateWithContext(context.Background(), data)
+}
+
+func (c *tenants) UpdateWithContext(ctx context.Context, data utils.TenantData) error {
 	endpoint := c.pulsar.endpoint(c.basePath, data.Name)
-	return c.pulsar.Client.Post(endpoint, &data)
+	return c.pulsar.Client.Post(ctx, endpoint, &data)
 }
 
 func (c *tenants) List() ([]string, error) {
+	return c.ListWithContext(context.Background())
+}
+
+func (c *tenants) ListWithContext(ctx context.Context) ([]string, error) {
 	var tenantList []string
 	endpoint := c.pulsar.endpoint(c.basePath, "")
-	err := c.pulsar.Client.Get(endpoint, &tenantList)
+	err := c.pulsar.Client.Get(ctx, endpoint, &tenantList)
 	return tenantList, err
 }
 
 func (c *tenants) Get(name string) (utils.TenantData, error) {
+	return c.GetWithContext(context.Background(), name)
+}
+
+func (c *tenants) GetWithContext(ctx context.Context, name string) (utils.TenantData, error) {
 	var data utils.TenantData
 	endpoint := c.pulsar.endpoint(c.basePath, name)
-	err := c.pulsar.Client.Get(endpoint, &data)
+	err := c.pulsar.Client.Get(ctx, endpoint, &data)
 	return data, err
 }

--- a/pulsaradmin/pkg/admin/topic.go
+++ b/pulsaradmin/pkg/admin/topic.go
@@ -18,6 +18,7 @@
 package admin
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -28,7 +29,7 @@ import (
 
 // Topics is admin interface for topics management
 type Topics interface {
-	// Create a partitioned or non-partitioned topic
+	// Create creates a partitioned or non-partitioned topic
 	//
 	// @param topic
 	//        topicName struct
@@ -37,7 +38,18 @@ type Topics interface {
 	//        when setting to 0, it will create a non-partitioned topic
 	Create(topic utils.TopicName, partitions int) error
 
-	// CreateWithProperties Create a partitioned or non-partitioned topic
+	// CreateWithContext creates a partitioned or non-partitioned topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param partitions
+	//        number of topic partitions,
+	//        when setting to 0, it will create a non-partitioned topic
+	CreateWithContext(ctx context.Context, topic utils.TopicName, partitions int) error
+
+	// CreateWithProperties creates a partitioned or non-partitioned topic with specific properties
 	//
 	// @param topic
 	//        topicName struct
@@ -48,16 +60,38 @@ type Topics interface {
 	//        topic properties
 	CreateWithProperties(topic utils.TopicName, partitions int, meta map[string]string) error
 
+	// CreateWithPropertiesWithContext creates a partitioned or non-partitioned topic with specific properties
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param partitions
+	//        number of topic partitions,
+	//        when setting to 0, it will create a non-partitioned topic
+	// @param meta
+	//        topic properties
+	CreateWithPropertiesWithContext(ctx context.Context, topic utils.TopicName, partitions int, meta map[string]string) error
+
 	// GetProperties returns the properties of a topic
 	GetProperties(topic utils.TopicName) (map[string]string, error)
+
+	// GetPropertiesWithContext returns the properties of a topic
+	GetPropertiesWithContext(ctx context.Context, topic utils.TopicName) (map[string]string, error)
 
 	// UpdateProperties updates the properties of a topic
 	UpdateProperties(topic utils.TopicName, properties map[string]string) error
 
+	// UpdatePropertiesWithContext updates the properties of a topic
+	UpdatePropertiesWithContext(ctx context.Context, topic utils.TopicName, properties map[string]string) error
+
 	// RemoveProperty removes a property with the given key of a topic
 	RemoveProperty(topic utils.TopicName, key string) error
 
-	// Delete a topic, this function can delete both partitioned or non-partitioned topic
+	// RemovePropertyWithContext removes a property with the given key of a topic
+	RemovePropertyWithContext(ctx context.Context, topic utils.TopicName, key string) error
+
+	// Delete deletes a topic, this function can delete both partitioned or non-partitioned topic
 	//
 	// @param topic
 	//        topicName struct
@@ -68,7 +102,20 @@ type Topics interface {
 	//        Otherwise it will be treated as a partitioned topic
 	Delete(topic utils.TopicName, force bool, nonPartitioned bool) error
 
-	// Update number of partitions of a non-global partitioned topic
+	// DeleteWithContext deletes a topic, this function can delete both partitioned or non-partitioned topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param force
+	//        delete topic forcefully
+	// @param nonPartitioned
+	//        when set to true, topic will be treated as a non-partitioned topic
+	//        Otherwise it will be treated as a partitioned topic
+	DeleteWithContext(ctx context.Context, topic utils.TopicName, force bool, nonPartitioned bool) error
+
+	// Update updates number of partitions of a non-global partitioned topic
 	// It requires partitioned-topic to be already exist and number of new partitions must be greater than existing
 	// number of partitions. Decrementing number of partitions requires deletion of topic which is not supported.
 	//
@@ -78,19 +125,45 @@ type Topics interface {
 	//        number of new partitions of already exist partitioned-topic
 	Update(topic utils.TopicName, partitions int) error
 
+	// UpdateWithContext updates number of partitions of a non-global partitioned topic
+	// It requires partitioned-topic to be already exist and number of new partitions must be greater than existing
+	// number of partitions. Decrementing number of partitions requires deletion of topic which is not supported.
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param partitions
+	//        number of new partitions of already exist partitioned-topic
+	UpdateWithContext(ctx context.Context, topic utils.TopicName, partitions int) error
+
 	// GetMetadata returns metadata of a partitioned topic
 	GetMetadata(utils.TopicName) (utils.PartitionedTopicMetadata, error)
+
+	// GetMetadataWithContext returns metadata of a partitioned topic
+	GetMetadataWithContext(context.Context, utils.TopicName) (utils.PartitionedTopicMetadata, error)
 
 	// List returns the list of topics under a namespace
 	List(utils.NameSpaceName) ([]string, []string, error)
 
+	// ListWithContext returns the list of topics under a namespace
+	ListWithContext(context.Context, utils.NameSpaceName) ([]string, []string, error)
+
 	// GetInternalInfo returns the internal metadata info for the topic
 	GetInternalInfo(utils.TopicName) (utils.ManagedLedgerInfo, error)
+
+	// GetInternalInfoWithContext returns the internal metadata info for the topic
+	GetInternalInfoWithContext(context.Context, utils.TopicName) (utils.ManagedLedgerInfo, error)
 
 	// GetPermissions returns permissions on a topic
 	// Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at the
 	// namespace level combined (union) with any eventual specific permission set on the topic.
 	GetPermissions(utils.TopicName) (map[string][]utils.AuthAction, error)
+
+	// GetPermissionsWithContext returns permissions on a topic
+	// Retrieve the effective permissions for a topic. These permissions are defined by the permissions set at the
+	// namespace level combined (union) with any eventual specific permission set on the topic.
+	GetPermissionsWithContext(context.Context, utils.TopicName) (map[string][]utils.AuthAction, error)
 
 	// GrantPermission grants a new permission to a client role on a single topic
 	//
@@ -102,6 +175,18 @@ type Topics interface {
 	//        auth actions (e.g. produce and consume)
 	GrantPermission(topic utils.TopicName, role string, action []utils.AuthAction) error
 
+	// GrantPermissionWithContext grants a new permission to a client role on a single topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param role
+	//        client role to which grant permission
+	// @param action
+	//        auth actions (e.g. produce and consume)
+	GrantPermissionWithContext(ctx context.Context, topic utils.TopicName, role string, action []utils.AuthAction) error
+
 	// RevokePermission revokes permissions to a client role on a single topic. If the permission
 	// was not set at the topic level, but rather at the namespace level, this operation will
 	// return an error (HTTP status code 412).
@@ -112,14 +197,35 @@ type Topics interface {
 	//        client role to which remove permissions
 	RevokePermission(topic utils.TopicName, role string) error
 
-	// Lookup a topic returns the broker URL that serves the topic
+	// RevokePermissionWithContext revokes permissions to a client role on a single topic. If the permission
+	// was not set at the topic level, but rather at the namespace level, this operation will
+	// return an error (HTTP status code 412).
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param role
+	//        client role to which remove permissions
+	RevokePermissionWithContext(ctx context.Context, topic utils.TopicName, role string) error
+
+	// Lookup returns the broker URL that serves the topic
 	Lookup(utils.TopicName) (utils.LookupData, error)
+
+	// LookupWithContext returns the broker URL that serves the topic
+	LookupWithContext(context.Context, utils.TopicName) (utils.LookupData, error)
 
 	// GetBundleRange returns a bundle range of a topic
 	GetBundleRange(utils.TopicName) (string, error)
 
+	// GetBundleRangeWithContext returns a bundle range of a topic
+	GetBundleRangeWithContext(context.Context, utils.TopicName) (string, error)
+
 	// GetLastMessageID returns the last commit message Id of a topic
 	GetLastMessageID(utils.TopicName) (utils.MessageID, error)
+
+	// GetLastMessageIDWithContext returns the last commit message Id of a topic
+	GetLastMessageIDWithContext(context.Context, utils.TopicName) (utils.MessageID, error)
 
 	// GetMessageID returns the message Id by timestamp(ms) of a topic
 	//
@@ -129,10 +235,25 @@ type Topics interface {
 	//        absolute timestamp (in ms)
 	GetMessageID(topic utils.TopicName, timestamp int64) (utils.MessageID, error)
 
+	// GetMessageIDWithContext returns the message Id by timestamp(ms) of a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param timestamp
+	//        absolute timestamp (in ms)
+	GetMessageIDWithContext(ctx context.Context, topic utils.TopicName, timestamp int64) (utils.MessageID, error)
+
 	// GetStats returns the stats for the topic.
 	//
 	// All the rates are computed over a 1-minute window and are relative the last completed 1-minute period
 	GetStats(utils.TopicName) (utils.TopicStats, error)
+
+	// GetStatsWithContext returns the stats for the topic.
+	//
+	// All the rates are computed over a 1-minute window and are relative the last completed 1-minute period
+	GetStatsWithContext(context.Context, utils.TopicName) (utils.TopicStats, error)
 
 	// GetStatsWithOption returns the stats for the topic
 	//
@@ -144,8 +265,23 @@ type Topics interface {
 	//        request option, e.g. get_precise_backlog or subscription_backlog_size
 	GetStatsWithOption(topic utils.TopicName, option utils.GetStatsOptions) (utils.TopicStats, error)
 
+	// GetStatsWithOptionWithContext returns the stats for the topic
+	//
+	// All the rates are computed over a 1-minute window and are relative the last completed 1-minute period
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param option
+	//        request option, e.g. get_precise_backlog or subscription_backlog_size
+	GetStatsWithOptionWithContext(ctx context.Context, topic utils.TopicName, option utils.GetStatsOptions) (utils.TopicStats, error)
+
 	// GetInternalStats returns the internal stats for the topic.
 	GetInternalStats(utils.TopicName) (utils.PersistentTopicInternalStats, error)
+
+	// GetInternalStatsWithContext returns the internal stats for the topic.
+	GetInternalStatsWithContext(context.Context, utils.TopicName) (utils.PersistentTopicInternalStats, error)
 
 	// GetPartitionedStats returns the stats for the partitioned topic
 	//
@@ -156,6 +292,18 @@ type Topics interface {
 	// @param perPartition
 	//        flag to get stats per partition
 	GetPartitionedStats(topic utils.TopicName, perPartition bool) (utils.PartitionedTopicStats, error)
+
+	// GetPartitionedStatsWithContext returns the stats for the partitioned topic
+	//
+	// All the rates are computed over a 1-minute window and are relative the last completed 1-minute period
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param perPartition
+	//        flag to get stats per partition
+	GetPartitionedStatsWithContext(ctx context.Context, topic utils.TopicName, perPartition bool) (utils.PartitionedTopicStats, error)
 
 	// GetPartitionedStatsWithOption returns the stats for the partitioned topic
 	//
@@ -173,29 +321,69 @@ type Topics interface {
 		option utils.GetStatsOptions,
 	) (utils.PartitionedTopicStats, error)
 
-	// Terminate the topic and prevent any more messages being published on it
+	// GetPartitionedStatsWithOptionWithContext returns the stats for the partitioned topic
+	//
+	// All the rates are computed over a 1-minute window and are relative the last completed 1-minute period
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param perPartition
+	//        flag to get stats per partition
+	// @param option
+	//        request option, e.g. get_precise_backlog or subscription_backlog_size
+	GetPartitionedStatsWithOptionWithContext(ctx context.Context,
+		topic utils.TopicName,
+		perPartition bool,
+		option utils.GetStatsOptions,
+	) (utils.PartitionedTopicStats, error)
+
+	// Terminate terminates the topic and prevent any more messages being published on it
 	Terminate(utils.TopicName) (utils.MessageID, error)
+
+	// TerminateWithContext terminates the topic and prevent any more messages being published on it
+	TerminateWithContext(context.Context, utils.TopicName) (utils.MessageID, error)
 
 	// Offload triggers offloading messages in topic to longterm storage
 	Offload(utils.TopicName, utils.MessageID) error
 
+	// OffloadWithContext triggers offloading messages in topic to longterm storage
+	OffloadWithContext(context.Context, utils.TopicName, utils.MessageID) error
+
 	// OffloadStatus checks the status of an ongoing offloading operation for a topic
 	OffloadStatus(utils.TopicName) (utils.OffloadProcessStatus, error)
 
+	// OffloadStatusWithContext checks the status of an ongoing offloading operation for a topic
+	OffloadStatusWithContext(context.Context, utils.TopicName) (utils.OffloadProcessStatus, error)
+
 	// Unload a topic
 	Unload(utils.TopicName) error
+
+	// UnloadWithContext a topic
+	UnloadWithContext(context.Context, utils.TopicName) error
 
 	// Compact triggers compaction to run for a topic. A single topic can only have one instance of compaction
 	// running at any time. Any attempt to trigger another will be met with a ConflictException.
 	Compact(utils.TopicName) error
 
+	// CompactWithContext triggers compaction to run for a topic. A single topic can only have one instance of compaction
+	// running at any time. Any attempt to trigger another will be met with a ConflictException.
+	CompactWithContext(context.Context, utils.TopicName) error
+
 	// CompactStatus checks the status of an ongoing compaction for a topic
 	CompactStatus(utils.TopicName) (utils.LongRunningProcessStatus, error)
 
-	// GetMessageTTL Get the message TTL for a topic
+	// CompactStatusWithContext checks the status of an ongoing compaction for a topic
+	CompactStatusWithContext(context.Context, utils.TopicName) (utils.LongRunningProcessStatus, error)
+
+	// GetMessageTTL returns the message TTL for a topic
 	GetMessageTTL(utils.TopicName) (int, error)
 
-	// SetMessageTTL Set the message TTL for a topic
+	// GetMessageTTLWithContext returns the message TTL for a topic
+	GetMessageTTLWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMessageTTL sets the message TTL for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -203,13 +391,29 @@ type Topics interface {
 	//        Message TTL in second
 	SetMessageTTL(topic utils.TopicName, messageTTL int) error
 
-	// RemoveMessageTTL Remove the message TTL for a topic
+	// SetMessageTTLWithContext sets the message TTL for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param messageTTL
+	//        Message TTL in second
+	SetMessageTTLWithContext(ctx context.Context, topic utils.TopicName, messageTTL int) error
+
+	// RemoveMessageTTL removes the message TTL for a topic
 	RemoveMessageTTL(utils.TopicName) error
+
+	// RemoveMessageTTLWithContext removes the message TTL for a topic
+	RemoveMessageTTLWithContext(context.Context, utils.TopicName) error
 
 	// GetMaxProducers Get max number of producers for a topic
 	GetMaxProducers(utils.TopicName) (int, error)
 
-	// SetMaxProducers Set max number of producers for a topic
+	// GetMaxProducersWithContext Get max number of producers for a topic
+	GetMaxProducersWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxProducers sets max number of producers for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -217,13 +421,29 @@ type Topics interface {
 	//        max number of producer
 	SetMaxProducers(topic utils.TopicName, maxProducers int) error
 
-	// RemoveMaxProducers Remove max number of producers for a topic
+	// SetMaxProducersWithContext sets max number of producers for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param maxProducers
+	//        max number of producer
+	SetMaxProducersWithContext(ctx context.Context, topic utils.TopicName, maxProducers int) error
+
+	// RemoveMaxProducers removes max number of producers for a topic
 	RemoveMaxProducers(utils.TopicName) error
 
-	// GetMaxConsumers Get max number of consumers for a topic
+	// RemoveMaxProducersWithContext removes max number of producers for a topic
+	RemoveMaxProducersWithContext(context.Context, utils.TopicName) error
+
+	// GetMaxConsumers returns max number of consumers for a topic
 	GetMaxConsumers(utils.TopicName) (int, error)
 
-	// SetMaxConsumers Set max number of consumers for a topic
+	// GetMaxConsumersWithContext returns max number of consumers for a topic
+	GetMaxConsumersWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxConsumers sets max number of consumers for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -231,13 +451,29 @@ type Topics interface {
 	//        max number of consumer
 	SetMaxConsumers(topic utils.TopicName, maxConsumers int) error
 
-	// RemoveMaxConsumers Remove max number of consumers for a topic
+	// SetMaxConsumersWithContext sets max number of consumers for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param maxConsumers
+	//        max number of consumer
+	SetMaxConsumersWithContext(ctx context.Context, topic utils.TopicName, maxConsumers int) error
+
+	// RemoveMaxConsumers removes max number of consumers for a topic
 	RemoveMaxConsumers(utils.TopicName) error
 
-	// GetMaxUnackMessagesPerConsumer Get max unacked messages policy on consumer for a topic
+	// RemoveMaxConsumersWithContext removes max number of consumers for a topic
+	RemoveMaxConsumersWithContext(context.Context, utils.TopicName) error
+
+	// GetMaxUnackMessagesPerConsumer returns max unacked messages policy on consumer for a topic
 	GetMaxUnackMessagesPerConsumer(utils.TopicName) (int, error)
 
-	// SetMaxUnackMessagesPerConsumer Set max unacked messages policy on consumer for a topic
+	// GetMaxUnackMessagesPerConsumerWithContext returns max unacked messages policy on consumer for a topic
+	GetMaxUnackMessagesPerConsumerWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxUnackMessagesPerConsumer sets max unacked messages policy on consumer for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -245,13 +481,29 @@ type Topics interface {
 	//        max unAcked messages on each consumer
 	SetMaxUnackMessagesPerConsumer(topic utils.TopicName, maxUnackedNum int) error
 
-	// RemoveMaxUnackMessagesPerConsumer Remove max unacked messages policy on consumer for a topic
+	// SetMaxUnackMessagesPerConsumerWithContext sets max unacked messages policy on consumer for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param maxUnackedNum
+	//        max unAcked messages on each consumer
+	SetMaxUnackMessagesPerConsumerWithContext(ctx context.Context, topic utils.TopicName, maxUnackedNum int) error
+
+	// RemoveMaxUnackMessagesPerConsumer removes max unacked messages policy on consumer for a topic
 	RemoveMaxUnackMessagesPerConsumer(utils.TopicName) error
 
-	// GetMaxUnackMessagesPerSubscription Get max unacked messages policy on subscription for a topic
+	// RemoveMaxUnackMessagesPerConsumerWithContext removes max unacked messages policy on consumer for a topic
+	RemoveMaxUnackMessagesPerConsumerWithContext(context.Context, utils.TopicName) error
+
+	// GetMaxUnackMessagesPerSubscription returns max unacked messages policy on subscription for a topic
 	GetMaxUnackMessagesPerSubscription(utils.TopicName) (int, error)
 
-	// SetMaxUnackMessagesPerSubscription Set max unacked messages policy on subscription for a topic
+	// GetMaxUnackMessagesPerSubscriptionWithContext returns max unacked messages policy on subscription for a topic
+	GetMaxUnackMessagesPerSubscriptionWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxUnackMessagesPerSubscription sets max unacked messages policy on subscription for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -259,49 +511,101 @@ type Topics interface {
 	//        max unAcked messages on subscription of a topic
 	SetMaxUnackMessagesPerSubscription(topic utils.TopicName, maxUnackedNum int) error
 
-	// RemoveMaxUnackMessagesPerSubscription Remove max unacked messages policy on subscription for a topic
+	// SetMaxUnackMessagesPerSubscriptionWithContext sets max unacked messages policy on subscription for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param maxUnackedNum
+	//        max unAcked messages on subscription of a topic
+	SetMaxUnackMessagesPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName, maxUnackedNum int) error
+
+	// RemoveMaxUnackMessagesPerSubscription removes max unacked messages policy on subscription for a topic
 	RemoveMaxUnackMessagesPerSubscription(utils.TopicName) error
 
-	// GetPersistence Get the persistence policies for a topic
+	// RemoveMaxUnackMessagesPerSubscriptionWithContext removes max unacked messages policy on subscription for a topic
+	RemoveMaxUnackMessagesPerSubscriptionWithContext(context.Context, utils.TopicName) error
+
+	// GetPersistence returns the persistence policies for a topic
 	GetPersistence(utils.TopicName) (*utils.PersistenceData, error)
 
-	// SetPersistence Set the persistence policies for a topic
+	// GetPersistenceWithContext returns the persistence policies for a topic
+	GetPersistenceWithContext(context.Context, utils.TopicName) (*utils.PersistenceData, error)
+
+	// SetPersistence sets the persistence policies for a topic
 	SetPersistence(utils.TopicName, utils.PersistenceData) error
 
-	// RemovePersistence Remove the persistence policies for a topic
+	// SetPersistenceWithContext sets the persistence policies for a topic
+	SetPersistenceWithContext(context.Context, utils.TopicName, utils.PersistenceData) error
+
+	// RemovePersistence removes the persistence policies for a topic
 	RemovePersistence(utils.TopicName) error
 
-	// GetDelayedDelivery Get the delayed delivery policy for a topic
+	// RemovePersistenceWithContext removes the persistence policies for a topic
+	RemovePersistenceWithContext(context.Context, utils.TopicName) error
+
+	// GetDelayedDelivery returns the delayed delivery policy for a topic
 	GetDelayedDelivery(utils.TopicName) (*utils.DelayedDeliveryData, error)
 
-	// SetDelayedDelivery Set the delayed delivery policy on a topic
+	// GetDelayedDeliveryWithContext returns the delayed delivery policy for a topic
+	GetDelayedDeliveryWithContext(context.Context, utils.TopicName) (*utils.DelayedDeliveryData, error)
+
+	// SetDelayedDelivery sets the delayed delivery policy on a topic
 	SetDelayedDelivery(utils.TopicName, utils.DelayedDeliveryData) error
 
-	// RemoveDelayedDelivery Remove the delayed delivery policy on a topic
+	// SetDelayedDeliveryWithContext sets the delayed delivery policy on a topic
+	SetDelayedDeliveryWithContext(context.Context, utils.TopicName, utils.DelayedDeliveryData) error
+
+	// RemoveDelayedDelivery removes the delayed delivery policy on a topic
 	RemoveDelayedDelivery(utils.TopicName) error
 
-	// GetDispatchRate Get message dispatch rate for a topic
+	// RemoveDelayedDeliveryWithContext removes the delayed delivery policy on a topic
+	RemoveDelayedDeliveryWithContext(context.Context, utils.TopicName) error
+
+	// GetDispatchRate returns message dispatch rate for a topic
 	GetDispatchRate(utils.TopicName) (*utils.DispatchRateData, error)
 
-	// SetDispatchRate Set message dispatch rate for a topic
+	// GetDispatchRateWithContext returns message dispatch rate for a topic
+	GetDispatchRateWithContext(context.Context, utils.TopicName) (*utils.DispatchRateData, error)
+
+	// SetDispatchRate sets message dispatch rate for a topic
 	SetDispatchRate(utils.TopicName, utils.DispatchRateData) error
 
-	// RemoveDispatchRate Remove message dispatch rate for a topic
+	// SetDispatchRateWithContext sets message dispatch rate for a topic
+	SetDispatchRateWithContext(context.Context, utils.TopicName, utils.DispatchRateData) error
+
+	// RemoveDispatchRate removes message dispatch rate for a topic
 	RemoveDispatchRate(utils.TopicName) error
 
-	// GetPublishRate Get message publish rate for a topic
+	// RemoveDispatchRateWithContext removes message dispatch rate for a topic
+	RemoveDispatchRateWithContext(context.Context, utils.TopicName) error
+
+	// GetPublishRate returns message publish rate for a topic
 	GetPublishRate(utils.TopicName) (*utils.PublishRateData, error)
 
-	// SetPublishRate Set message publish rate for a topic
+	// GetPublishRateWithContext returns message publish rate for a topic
+	GetPublishRateWithContext(context.Context, utils.TopicName) (*utils.PublishRateData, error)
+
+	// SetPublishRate sets message publish rate for a topic
 	SetPublishRate(utils.TopicName, utils.PublishRateData) error
 
-	// RemovePublishRate Remove message publish rate for a topic
+	// SetPublishRateWithContext sets message publish rate for a topic
+	SetPublishRateWithContext(context.Context, utils.TopicName, utils.PublishRateData) error
+
+	// RemovePublishRate removes message publish rate for a topic
 	RemovePublishRate(utils.TopicName) error
 
-	// GetDeduplicationStatus Get the deduplication policy for a topic
+	// RemovePublishRateWithContext removes message publish rate for a topic
+	RemovePublishRateWithContext(context.Context, utils.TopicName) error
+
+	// GetDeduplicationStatus returns the deduplication policy for a topic
 	GetDeduplicationStatus(utils.TopicName) (bool, error)
 
-	// SetDeduplicationStatus Set the deduplication policy for a topic
+	// GetDeduplicationStatusWithContext returns the deduplication policy for a topic
+	GetDeduplicationStatusWithContext(context.Context, utils.TopicName) (bool, error)
+
+	// SetDeduplicationStatus sets the deduplication policy for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -309,8 +613,21 @@ type Topics interface {
 	//        set enable or disable deduplication of the topic
 	SetDeduplicationStatus(topic utils.TopicName, enabled bool) error
 
-	// RemoveDeduplicationStatus Remove the deduplication policy for a topic
+	// SetDeduplicationStatusWithContext sets the deduplication policy for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param enabled
+	//        set enable or disable deduplication of the topic
+	SetDeduplicationStatusWithContext(ctx context.Context, topic utils.TopicName, enabled bool) error
+
+	// RemoveDeduplicationStatus removes the deduplication policy for a topic
 	RemoveDeduplicationStatus(utils.TopicName) error
+
+	// RemoveDeduplicationStatusWithContext removes the deduplication policy for a topic
+	RemoveDeduplicationStatusWithContext(context.Context, utils.TopicName) error
 
 	// GetRetention returns the retention configuration for a topic
 	//
@@ -321,13 +638,30 @@ type Topics interface {
 	//        in namespace or broker level, if no policy set in topic level
 	GetRetention(topic utils.TopicName, applied bool) (*utils.RetentionPolicies, error)
 
+	// GetRetentionWithContext returns the retention configuration for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param applied
+	//        when set to true, function will try to find policy applied to this topic
+	//        in namespace or broker level, if no policy set in topic level
+	GetRetentionWithContext(ctx context.Context, topic utils.TopicName, applied bool) (*utils.RetentionPolicies, error)
+
 	// RemoveRetention removes the retention configuration on a topic
 	RemoveRetention(utils.TopicName) error
+
+	// RemoveRetentionWithContext removes the retention configuration on a topic
+	RemoveRetentionWithContext(context.Context, utils.TopicName) error
 
 	// SetRetention sets the retention policy for a topic
 	SetRetention(utils.TopicName, utils.RetentionPolicies) error
 
-	// GetCompactionThreshold Get the compaction threshold for a topic.
+	// SetRetentionWithContext sets the retention policy for a topic
+	SetRetentionWithContext(context.Context, utils.TopicName, utils.RetentionPolicies) error
+
+	// GetCompactionThreshold returns the compaction threshold for a topic.
 	//
 	// i.e. The maximum number of bytes can have before compaction is triggered.
 	//
@@ -338,7 +672,20 @@ type Topics interface {
 	//        in namespace or broker level, if no policy set in topic level
 	GetCompactionThreshold(topic utils.TopicName, applied bool) (int64, error)
 
-	// SetCompactionThreshold Set the compaction threshold for a topic
+	// GetCompactionThresholdWithContext returns the compaction threshold for a topic.
+	//
+	// i.e. The maximum number of bytes can have before compaction is triggered.
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param applied
+	//        when set to true, function will try to find policy applied to this topic
+	//        in namespace or broker level, if no policy set in topic level
+	GetCompactionThresholdWithContext(ctx context.Context, topic utils.TopicName, applied bool) (int64, error)
+
+	// SetCompactionThreshold sets the compaction threshold for a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -346,8 +693,21 @@ type Topics interface {
 	//        maximum number of backlog bytes before compaction is triggered
 	SetCompactionThreshold(topic utils.TopicName, threshold int64) error
 
-	// Remove compaction threshold for a topic
+	// SetCompactionThresholdWithContext sets the compaction threshold for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param threshold
+	//        maximum number of backlog bytes before compaction is triggered
+	SetCompactionThresholdWithContext(ctx context.Context, topic utils.TopicName, threshold int64) error
+
+	// RemoveCompactionThreshold removes compaction threshold for a topic
 	RemoveCompactionThreshold(utils.TopicName) error
+
+	// RemoveCompactionThresholdWithContext removes compaction threshold for a topic
+	RemoveCompactionThresholdWithContext(context.Context, utils.TopicName) error
 
 	// GetBacklogQuotaMap returns backlog quota map for a topic
 	//
@@ -358,13 +718,30 @@ type Topics interface {
 	//        in namespace or broker level, if no policy set in topic level
 	GetBacklogQuotaMap(topic utils.TopicName, applied bool) (map[utils.BacklogQuotaType]utils.BacklogQuota, error)
 
+	// GetBacklogQuotaMapWithContext returns backlog quota map for a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param applied
+	//        when set to true, function will try to find policy applied to this topic
+	//        in namespace or broker level, if no policy set in topic level
+	GetBacklogQuotaMapWithContext(ctx context.Context, topic utils.TopicName, applied bool) (map[utils.BacklogQuotaType]utils.BacklogQuota, error)
+
 	// SetBacklogQuota sets a backlog quota for a topic
 	SetBacklogQuota(utils.TopicName, utils.BacklogQuota, utils.BacklogQuotaType) error
+
+	// SetBacklogQuotaWithContext sets a backlog quota for a topic
+	SetBacklogQuotaWithContext(context.Context, utils.TopicName, utils.BacklogQuota, utils.BacklogQuotaType) error
 
 	// RemoveBacklogQuota removes a backlog quota policy from a topic
 	RemoveBacklogQuota(utils.TopicName, utils.BacklogQuotaType) error
 
-	// GetInactiveTopicPolicies gets the inactive topic policies on a topic
+	// RemoveBacklogQuotaWithContext removes a backlog quota policy from a topic
+	RemoveBacklogQuotaWithContext(context.Context, utils.TopicName, utils.BacklogQuotaType) error
+
+	// GetInactiveTopicPolicies returns the inactive topic policies on a topic
 	//
 	// @param topic
 	//        topicName struct
@@ -373,14 +750,34 @@ type Topics interface {
 	//        in namespace or broker level, if no policy set in topic level
 	GetInactiveTopicPolicies(topic utils.TopicName, applied bool) (utils.InactiveTopicPolicies, error)
 
+	// GetInactiveTopicPoliciesWithContext returns the inactive topic policies on a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param applied
+	//        when set to true, function will try to find policy applied to this topic
+	//        in namespace or broker level, if no policy set in topic level
+	GetInactiveTopicPoliciesWithContext(ctx context.Context, topic utils.TopicName, applied bool) (utils.InactiveTopicPolicies, error)
+
 	// RemoveInactiveTopicPolicies removes inactive topic policies from a topic
 	RemoveInactiveTopicPolicies(utils.TopicName) error
+
+	// RemoveInactiveTopicPoliciesWithContext removes inactive topic policies from a topic
+	RemoveInactiveTopicPoliciesWithContext(context.Context, utils.TopicName) error
 
 	// SetInactiveTopicPolicies sets the inactive topic policies on a topic
 	SetInactiveTopicPolicies(topic utils.TopicName, data utils.InactiveTopicPolicies) error
 
-	// GetReplicationClusters get the replication clusters of a topic
+	// SetInactiveTopicPoliciesWithContext sets the inactive topic policies on a topic
+	SetInactiveTopicPoliciesWithContext(ctx context.Context, topic utils.TopicName, data utils.InactiveTopicPolicies) error
+
+	// GetReplicationClusters returns the replication clusters of a topic
 	GetReplicationClusters(topic utils.TopicName) ([]string, error)
+
+	// GetReplicationClustersWithContext returns the replication clusters of a topic
+	GetReplicationClustersWithContext(ctx context.Context, topic utils.TopicName) ([]string, error)
 
 	// SetReplicationClusters sets the replication clusters on a topic
 	//
@@ -390,106 +787,217 @@ type Topics interface {
 	//        list of replication cluster id
 	SetReplicationClusters(topic utils.TopicName, data []string) error
 
-	// GetSubscribeRate Get subscribe rate configuration for a topic
+	// SetReplicationClustersWithContext sets the replication clusters on a topic
+	//
+	// @param ctx
+	//        context used for the request
+	// @param topic
+	//        topicName struct
+	// @param data
+	//        list of replication cluster id
+	SetReplicationClustersWithContext(ctx context.Context, topic utils.TopicName, data []string) error
+
+	// GetSubscribeRate returns subscribe rate configuration for a topic
 	GetSubscribeRate(utils.TopicName) (*utils.SubscribeRate, error)
 
-	// SetSubscribeRate Set subscribe rate configuration for a topic
+	// GetSubscribeRateWithContext returns subscribe rate configuration for a topic
+	GetSubscribeRateWithContext(context.Context, utils.TopicName) (*utils.SubscribeRate, error)
+
+	// SetSubscribeRate sets subscribe rate configuration for a topic
 	SetSubscribeRate(utils.TopicName, utils.SubscribeRate) error
 
-	// RemoveSubscribeRate Remove subscribe rate configuration for a topic
+	// SetSubscribeRateWithContext sets subscribe rate configuration for a topic
+	SetSubscribeRateWithContext(context.Context, utils.TopicName, utils.SubscribeRate) error
+
+	// RemoveSubscribeRate removes subscribe rate configuration for a topic
 	RemoveSubscribeRate(utils.TopicName) error
 
-	// GetSubscriptionDispatchRate Get subscription dispatch rate for a topic
+	// RemoveSubscribeRateWithContext removes subscribe rate configuration for a topic
+	RemoveSubscribeRateWithContext(context.Context, utils.TopicName) error
+
+	// GetSubscriptionDispatchRate returns subscription dispatch rate for a topic
 	GetSubscriptionDispatchRate(utils.TopicName) (*utils.DispatchRateData, error)
 
-	// SetSubscriptionDispatchRate Set subscription dispatch rate for a topic
+	// GetSubscriptionDispatchRateWithContext returns subscription dispatch rate for a topic
+	GetSubscriptionDispatchRateWithContext(context.Context, utils.TopicName) (*utils.DispatchRateData, error)
+
+	// SetSubscriptionDispatchRate sets subscription dispatch rate for a topic
 	SetSubscriptionDispatchRate(utils.TopicName, utils.DispatchRateData) error
 
-	// RemoveSubscriptionDispatchRate Remove subscription dispatch rate for a topic
+	// SetSubscriptionDispatchRateWithContext sets subscription dispatch rate for a topic
+	SetSubscriptionDispatchRateWithContext(context.Context, utils.TopicName, utils.DispatchRateData) error
+
+	// RemoveSubscriptionDispatchRate removes subscription dispatch rate for a topic
 	RemoveSubscriptionDispatchRate(utils.TopicName) error
 
-	// GetMaxConsumersPerSubscription Get max consumers per subscription for a topic
+	// RemoveSubscriptionDispatchRateWithContext removes subscription dispatch rate for a topic
+	RemoveSubscriptionDispatchRateWithContext(context.Context, utils.TopicName) error
+
+	// GetMaxConsumersPerSubscription returns max consumers per subscription for a topic
 	GetMaxConsumersPerSubscription(utils.TopicName) (int, error)
 
-	// SetMaxConsumersPerSubscription Set max consumers per subscription for a topic
+	// GetMaxConsumersPerSubscriptionWithContext returns max consumers per subscription for a topic
+	GetMaxConsumersPerSubscriptionWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxConsumersPerSubscription sets max consumers per subscription for a topic
 	SetMaxConsumersPerSubscription(utils.TopicName, int) error
 
-	// RemoveMaxConsumersPerSubscription Remove max consumers per subscription for a topic
+	// SetMaxConsumersPerSubscriptionWithContext sets max consumers per subscription for a topic
+	SetMaxConsumersPerSubscriptionWithContext(context.Context, utils.TopicName, int) error
+
+	// RemoveMaxConsumersPerSubscription removes max consumers per subscription for a topic
 	RemoveMaxConsumersPerSubscription(utils.TopicName) error
 
-	// GetMaxMessageSize Get max message size for a topic
+	// RemoveMaxConsumersPerSubscriptionWithContext removes max consumers per subscription for a topic
+	RemoveMaxConsumersPerSubscriptionWithContext(context.Context, utils.TopicName) error
+
+	// GetMaxMessageSize returns max message size for a topic
 	GetMaxMessageSize(utils.TopicName) (int, error)
 
-	// SetMaxMessageSize Set max message size for a topic
+	// GetMaxMessageSizeWithContext returns max message size for a topic
+	GetMaxMessageSizeWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxMessageSize sets max message size for a topic
 	SetMaxMessageSize(utils.TopicName, int) error
 
-	// RemoveMaxMessageSize Remove max message size for a topic
+	// SetMaxMessageSizeWithContext sets max message size for a topic
+	SetMaxMessageSizeWithContext(context.Context, utils.TopicName, int) error
+
+	// RemoveMaxMessageSize removes max message size for a topic
 	RemoveMaxMessageSize(utils.TopicName) error
 
-	// GetMaxSubscriptionsPerTopic Get max subscriptions per topic
+	// RemoveMaxMessageSizeWithContext removes max message size for a topic
+	RemoveMaxMessageSizeWithContext(context.Context, utils.TopicName) error
+
+	// GetMaxSubscriptionsPerTopic returns max subscriptions per topic
 	GetMaxSubscriptionsPerTopic(utils.TopicName) (int, error)
 
-	// SetMaxSubscriptionsPerTopic Set max subscriptions per topic
+	// GetMaxSubscriptionsPerTopicWithContext returns max subscriptions per topic
+	GetMaxSubscriptionsPerTopicWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetMaxSubscriptionsPerTopic sets max subscriptions per topic
 	SetMaxSubscriptionsPerTopic(utils.TopicName, int) error
 
-	// RemoveMaxSubscriptionsPerTopic Remove max subscriptions per topic
+	// SetMaxSubscriptionsPerTopicWithContext sets max subscriptions per topic
+	SetMaxSubscriptionsPerTopicWithContext(context.Context, utils.TopicName, int) error
+
+	// RemoveMaxSubscriptionsPerTopic removes max subscriptions per topic
 	RemoveMaxSubscriptionsPerTopic(utils.TopicName) error
 
-	// GetSchemaValidationEnforced Get schema validation enforced flag for a topic
+	// RemoveMaxSubscriptionsPerTopicWithContext removes max subscriptions per topic
+	RemoveMaxSubscriptionsPerTopicWithContext(context.Context, utils.TopicName) error
+
+	// GetSchemaValidationEnforced returns schema validation enforced flag for a topic
 	GetSchemaValidationEnforced(utils.TopicName) (bool, error)
 
-	// SetSchemaValidationEnforced Set schema validation enforced flag for a topic
+	// GetSchemaValidationEnforcedWithContext returns schema validation enforced flag for a topic
+	GetSchemaValidationEnforcedWithContext(context.Context, utils.TopicName) (bool, error)
+
+	// SetSchemaValidationEnforced sets schema validation enforced flag for a topic
 	SetSchemaValidationEnforced(utils.TopicName, bool) error
 
-	// RemoveSchemaValidationEnforced Remove schema validation enforced flag for a topic
+	// SetSchemaValidationEnforcedWithContext sets schema validation enforced flag for a topic
+	SetSchemaValidationEnforcedWithContext(context.Context, utils.TopicName, bool) error
+
+	// RemoveSchemaValidationEnforced removes schema validation enforced flag for a topic
 	RemoveSchemaValidationEnforced(utils.TopicName) error
 
-	// GetDeduplicationSnapshotInterval Get deduplication snapshot interval for a topic
+	// RemoveSchemaValidationEnforcedWithContext removes schema validation enforced flag for a topic
+	RemoveSchemaValidationEnforcedWithContext(context.Context, utils.TopicName) error
+
+	// GetDeduplicationSnapshotInterval returns deduplication snapshot interval for a topic
 	GetDeduplicationSnapshotInterval(utils.TopicName) (int, error)
 
-	// SetDeduplicationSnapshotInterval Set deduplication snapshot interval for a topic
+	// GetDeduplicationSnapshotIntervalWithContext returns deduplication snapshot interval for a topic
+	GetDeduplicationSnapshotIntervalWithContext(context.Context, utils.TopicName) (int, error)
+
+	// SetDeduplicationSnapshotInterval sets deduplication snapshot interval for a topic
 	SetDeduplicationSnapshotInterval(utils.TopicName, int) error
 
-	// RemoveDeduplicationSnapshotInterval Remove deduplication snapshot interval for a topic
+	// SetDeduplicationSnapshotIntervalWithContext sets deduplication snapshot interval for a topic
+	SetDeduplicationSnapshotIntervalWithContext(context.Context, utils.TopicName, int) error
+
+	// RemoveDeduplicationSnapshotInterval removes deduplication snapshot interval for a topic
 	RemoveDeduplicationSnapshotInterval(utils.TopicName) error
 
-	// GetReplicatorDispatchRate Get replicator dispatch rate for a topic
+	// RemoveDeduplicationSnapshotIntervalWithContext removes deduplication snapshot interval for a topic
+	RemoveDeduplicationSnapshotIntervalWithContext(context.Context, utils.TopicName) error
+
+	// GetReplicatorDispatchRate returns replicator dispatch rate for a topic
 	GetReplicatorDispatchRate(utils.TopicName) (*utils.DispatchRateData, error)
 
-	// SetReplicatorDispatchRate Set replicator dispatch rate for a topic
+	// GetReplicatorDispatchRateWithContext returns replicator dispatch rate for a topic
+	GetReplicatorDispatchRateWithContext(context.Context, utils.TopicName) (*utils.DispatchRateData, error)
+
+	// SetReplicatorDispatchRate sets replicator dispatch rate for a topic
 	SetReplicatorDispatchRate(utils.TopicName, utils.DispatchRateData) error
 
-	// RemoveReplicatorDispatchRate Remove replicator dispatch rate for a topic
+	// SetReplicatorDispatchRateWithContext sets replicator dispatch rate for a topic
+	SetReplicatorDispatchRateWithContext(context.Context, utils.TopicName, utils.DispatchRateData) error
+
+	// RemoveReplicatorDispatchRate removes replicator dispatch rate for a topic
 	RemoveReplicatorDispatchRate(utils.TopicName) error
 
-	// GetOffloadPolicies Get offload policies for a topic
+	// RemoveReplicatorDispatchRateWithContext removes replicator dispatch rate for a topic
+	RemoveReplicatorDispatchRateWithContext(context.Context, utils.TopicName) error
+
+	// GetOffloadPolicies returns offload policies for a topic
 	GetOffloadPolicies(utils.TopicName) (*utils.OffloadPolicies, error)
 
-	// SetOffloadPolicies Set offload policies for a topic
+	// GetOffloadPoliciesWithContext returns offload policies for a topic
+	GetOffloadPoliciesWithContext(context.Context, utils.TopicName) (*utils.OffloadPolicies, error)
+
+	// SetOffloadPolicies sets offload policies for a topic
 	SetOffloadPolicies(utils.TopicName, utils.OffloadPolicies) error
 
-	// RemoveOffloadPolicies Remove offload policies for a topic
+	// SetOffloadPoliciesWithContext sets offload policies for a topic
+	SetOffloadPoliciesWithContext(context.Context, utils.TopicName, utils.OffloadPolicies) error
+
+	// RemoveOffloadPolicies removes offload policies for a topic
 	RemoveOffloadPolicies(utils.TopicName) error
 
-	// GetAutoSubscriptionCreation Get auto subscription creation override for a topic
+	// RemoveOffloadPoliciesWithContext removes offload policies for a topic
+	RemoveOffloadPoliciesWithContext(context.Context, utils.TopicName) error
+
+	// GetAutoSubscriptionCreation returns auto subscription creation override for a topic
 	GetAutoSubscriptionCreation(utils.TopicName) (*utils.AutoSubscriptionCreationOverride, error)
 
-	// SetAutoSubscriptionCreation Set auto subscription creation override for a topic
+	// GetAutoSubscriptionCreationWithContext returns auto subscription creation override for a topic
+	GetAutoSubscriptionCreationWithContext(context.Context, utils.TopicName) (*utils.AutoSubscriptionCreationOverride, error)
+
+	// SetAutoSubscriptionCreation sets auto subscription creation override for a topic
 	SetAutoSubscriptionCreation(utils.TopicName,
+		utils.AutoSubscriptionCreationOverride) error
+
+	// SetAutoSubscriptionCreationWithContext sets auto subscription creation override for a topic
+	SetAutoSubscriptionCreationWithContext(context.Context, utils.TopicName,
 		utils.AutoSubscriptionCreationOverride) error
 
 	// RemoveAutoSubscriptionCreation Remove auto subscription creation override for a topic
 	RemoveAutoSubscriptionCreation(utils.TopicName) error
 
-	// GetSchemaCompatibilityStrategy Get schema compatibility strategy for a topic
+	// RemoveAutoSubscriptionCreationWithContext Remove auto subscription creation override for a topic
+	RemoveAutoSubscriptionCreationWithContext(context.Context, utils.TopicName) error
+
+	// GetSchemaCompatibilityStrategy returns schema compatibility strategy for a topic
 	GetSchemaCompatibilityStrategy(utils.TopicName) (utils.SchemaCompatibilityStrategy, error)
 
-	// SetSchemaCompatibilityStrategy Set schema compatibility strategy for a topic
+	// GetSchemaCompatibilityStrategyWithContext returns schema compatibility strategy for a topic
+	GetSchemaCompatibilityStrategyWithContext(context.Context, utils.TopicName) (utils.SchemaCompatibilityStrategy, error)
+
+	// SetSchemaCompatibilityStrategy sets schema compatibility strategy for a topic
 	SetSchemaCompatibilityStrategy(utils.TopicName,
 		utils.SchemaCompatibilityStrategy) error
 
-	// RemoveSchemaCompatibilityStrategy Remove schema compatibility strategy for a topic
+	// SetSchemaCompatibilityStrategyWithContext sets schema compatibility strategy for a topic
+	SetSchemaCompatibilityStrategyWithContext(context.Context, utils.TopicName,
+		utils.SchemaCompatibilityStrategy) error
+
+	// RemoveSchemaCompatibilityStrategy removes schema compatibility strategy for a topic
 	RemoveSchemaCompatibilityStrategy(utils.TopicName) error
+
+	// RemoveSchemaCompatibilityStrategyWithContext removes schema compatibility strategy for a topic
+	RemoveSchemaCompatibilityStrategyWithContext(context.Context, utils.TopicName) error
 }
 
 type topics struct {
@@ -515,13 +1023,22 @@ func (c *pulsarClient) Topics() Topics {
 }
 
 func (t *topics) Create(topic utils.TopicName, partitions int) error {
-	return t.CreateWithProperties(topic, partitions, nil)
+	return t.CreateWithContext(context.Background(), topic, partitions)
 }
+
+func (t *topics) CreateWithContext(ctx context.Context, topic utils.TopicName, partitions int) error {
+	return t.CreateWithPropertiesWithContext(ctx, topic, partitions, nil)
+}
+
 func (t *topics) CreateWithProperties(topic utils.TopicName, partitions int, meta map[string]string) error {
+	return t.CreateWithPropertiesWithContext(context.Background(), topic, partitions, meta)
+}
+
+func (t *topics) CreateWithPropertiesWithContext(ctx context.Context, topic utils.TopicName, partitions int, meta map[string]string) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitions")
 	if partitions == 0 {
 		endpoint = t.pulsar.endpoint(t.basePath, topic.GetRestPath())
-		return t.pulsar.Client.Put(endpoint, meta)
+		return t.pulsar.Client.Put(ctx, endpoint, meta)
 	}
 	data := struct {
 		Meta       map[string]string `json:"properties"`
@@ -530,27 +1047,43 @@ func (t *topics) CreateWithProperties(topic utils.TopicName, partitions int, met
 		Meta:       meta,
 		Partitions: partitions,
 	}
-	return t.pulsar.Client.PutWithCustomMediaType(endpoint, &data, nil, nil, rest.PartitionedTopicMetaJSON)
+	return t.pulsar.Client.PutWithCustomMediaType(ctx, endpoint, &data, nil, nil, rest.PartitionedTopicMetaJSON)
 }
 
 func (t *topics) GetProperties(topic utils.TopicName) (map[string]string, error) {
+	return t.GetPropertiesWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetPropertiesWithContext(ctx context.Context, topic utils.TopicName) (map[string]string, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "properties")
 	var properties map[string]string
-	err := t.pulsar.Client.Get(endpoint, &properties)
+	err := t.pulsar.Client.Get(ctx, endpoint, &properties)
 	return properties, err
 }
 
 func (t *topics) UpdateProperties(topic utils.TopicName, properties map[string]string) error {
+	return t.UpdatePropertiesWithContext(context.Background(), topic, properties)
+}
+
+func (t *topics) UpdatePropertiesWithContext(ctx context.Context, topic utils.TopicName, properties map[string]string) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "properties")
-	return t.pulsar.Client.Put(endpoint, properties)
+	return t.pulsar.Client.Put(ctx, endpoint, properties)
 }
 
 func (t *topics) RemoveProperty(topic utils.TopicName, key string) error {
+	return t.RemovePropertyWithContext(context.Background(), topic, key)
+}
+
+func (t *topics) RemovePropertyWithContext(ctx context.Context, topic utils.TopicName, key string) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "properties")
-	return t.pulsar.Client.DeleteWithQueryParams(endpoint, map[string]string{"key": key})
+	return t.pulsar.Client.DeleteWithQueryParams(ctx, endpoint, map[string]string{"key": key})
 }
 
 func (t *topics) Delete(topic utils.TopicName, force bool, nonPartitioned bool) error {
+	return t.DeleteWithContext(context.Background(), topic, force, nonPartitioned)
+}
+
+func (t *topics) DeleteWithContext(ctx context.Context, topic utils.TopicName, force bool, nonPartitioned bool) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitions")
 	if nonPartitioned {
 		endpoint = t.pulsar.endpoint(t.basePath, topic.GetRestPath())
@@ -558,22 +1091,34 @@ func (t *topics) Delete(topic utils.TopicName, force bool, nonPartitioned bool) 
 	params := map[string]string{
 		"force": strconv.FormatBool(force),
 	}
-	return t.pulsar.Client.DeleteWithQueryParams(endpoint, params)
+	return t.pulsar.Client.DeleteWithQueryParams(ctx, endpoint, params)
 }
 
 func (t *topics) Update(topic utils.TopicName, partitions int) error {
+	return t.UpdateWithContext(context.Background(), topic, partitions)
+}
+
+func (t *topics) UpdateWithContext(ctx context.Context, topic utils.TopicName, partitions int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitions")
-	return t.pulsar.Client.Post(endpoint, partitions)
+	return t.pulsar.Client.Post(ctx, endpoint, partitions)
 }
 
 func (t *topics) GetMetadata(topic utils.TopicName) (utils.PartitionedTopicMetadata, error) {
+	return t.GetMetadataWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMetadataWithContext(ctx context.Context, topic utils.TopicName) (utils.PartitionedTopicMetadata, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitions")
 	var partitionedMeta utils.PartitionedTopicMetadata
-	err := t.pulsar.Client.Get(endpoint, &partitionedMeta)
+	err := t.pulsar.Client.Get(ctx, endpoint, &partitionedMeta)
 	return partitionedMeta, err
 }
 
 func (t *topics) List(namespace utils.NameSpaceName) ([]string, []string, error) {
+	return t.ListWithContext(context.Background(), namespace)
+}
+
+func (t *topics) ListWithContext(ctx context.Context, namespace utils.NameSpaceName) ([]string, []string, error) {
 	var partitionedTopics, nonPartitionedTopics []string
 	partitionedTopicsChan := make(chan []string)
 	nonPartitionedTopicsChan := make(chan []string)
@@ -584,10 +1129,10 @@ func (t *topics) List(namespace utils.NameSpaceName) ([]string, []string, error)
 	p := t.pulsar.endpoint(t.persistentPath, namespace.String())
 	n := t.pulsar.endpoint(t.nonPersistentPath, namespace.String())
 
-	go t.getTopics(pp, partitionedTopicsChan, errChan)
-	go t.getTopics(np, partitionedTopicsChan, errChan)
-	go t.getTopics(p, nonPartitionedTopicsChan, errChan)
-	go t.getTopics(n, nonPartitionedTopicsChan, errChan)
+	go t.getTopics(ctx, pp, partitionedTopicsChan, errChan)
+	go t.getTopics(ctx, np, partitionedTopicsChan, errChan)
+	go t.getTopics(ctx, p, nonPartitionedTopicsChan, errChan)
+	go t.getTopics(ctx, n, nonPartitionedTopicsChan, errChan)
 
 	requestCount := 4
 	for {
@@ -611,74 +1156,115 @@ func (t *topics) List(namespace utils.NameSpaceName) ([]string, []string, error)
 	return partitionedTopics, nonPartitionedTopics, nil
 }
 
-func (t *topics) getTopics(endpoint string, out chan<- []string, err chan<- error) {
+func (t *topics) getTopics(ctx context.Context, endpoint string, out chan<- []string, err chan<- error) {
 	var topics []string
-	err <- t.pulsar.Client.Get(endpoint, &topics)
+	err <- t.pulsar.Client.Get(ctx, endpoint, &topics)
 	out <- topics
 }
 
 func (t *topics) GetInternalInfo(topic utils.TopicName) (utils.ManagedLedgerInfo, error) {
+	return t.GetInternalInfoWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetInternalInfoWithContext(ctx context.Context, topic utils.TopicName) (utils.ManagedLedgerInfo, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "internal-info")
 	var info utils.ManagedLedgerInfo
-	err := t.pulsar.Client.Get(endpoint, &info)
+	err := t.pulsar.Client.Get(ctx, endpoint, &info)
 	return info, err
 }
 
 func (t *topics) GetPermissions(topic utils.TopicName) (map[string][]utils.AuthAction, error) {
+	return t.GetPermissionsWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetPermissionsWithContext(ctx context.Context, topic utils.TopicName) (map[string][]utils.AuthAction, error) {
 	var permissions map[string][]utils.AuthAction
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "permissions")
-	err := t.pulsar.Client.Get(endpoint, &permissions)
+	err := t.pulsar.Client.Get(ctx, endpoint, &permissions)
 	return permissions, err
 }
 
 func (t *topics) GrantPermission(topic utils.TopicName, role string, action []utils.AuthAction) error {
+	return t.GrantPermissionWithContext(context.Background(), topic, role, action)
+}
+
+func (t *topics) GrantPermissionWithContext(ctx context.Context, topic utils.TopicName, role string, action []utils.AuthAction) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "permissions", role)
 	s := []string{}
 	for _, v := range action {
 		s = append(s, v.String())
 	}
-	return t.pulsar.Client.Post(endpoint, s)
+	return t.pulsar.Client.Post(ctx, endpoint, s)
 }
 
 func (t *topics) RevokePermission(topic utils.TopicName, role string) error {
+	return t.RevokePermissionWithContext(context.Background(), topic, role)
+}
+
+func (t *topics) RevokePermissionWithContext(ctx context.Context, topic utils.TopicName, role string) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "permissions", role)
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) Lookup(topic utils.TopicName) (utils.LookupData, error) {
+	return t.LookupWithContext(context.Background(), topic)
+}
+
+func (t *topics) LookupWithContext(ctx context.Context, topic utils.TopicName) (utils.LookupData, error) {
 	var lookup utils.LookupData
 	endpoint := fmt.Sprintf("%s/%s", t.lookupPath, topic.GetRestPath())
-	err := t.pulsar.Client.Get(endpoint, &lookup)
+	err := t.pulsar.Client.Get(ctx, endpoint, &lookup)
 	return lookup, err
 }
 
 func (t *topics) GetBundleRange(topic utils.TopicName) (string, error) {
+	return t.GetBundleRangeWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetBundleRangeWithContext(ctx context.Context, topic utils.TopicName) (string, error) {
 	endpoint := fmt.Sprintf("%s/%s/%s", t.lookupPath, topic.GetRestPath(), "bundle")
-	data, err := t.pulsar.Client.GetWithQueryParams(endpoint, nil, nil, false)
+	data, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, nil, nil, false)
 	return string(data), err
 }
 
 func (t *topics) GetLastMessageID(topic utils.TopicName) (utils.MessageID, error) {
+	return t.GetLastMessageIDWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetLastMessageIDWithContext(ctx context.Context, topic utils.TopicName) (utils.MessageID, error) {
 	var messageID utils.MessageID
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "lastMessageId")
-	err := t.pulsar.Client.Get(endpoint, &messageID)
+	err := t.pulsar.Client.Get(ctx, endpoint, &messageID)
 	return messageID, err
 }
 
 func (t *topics) GetMessageID(topic utils.TopicName, timestamp int64) (utils.MessageID, error) {
+	return t.GetMessageIDWithContext(context.Background(), topic, timestamp)
+}
+
+func (t *topics) GetMessageIDWithContext(ctx context.Context, topic utils.TopicName, timestamp int64) (utils.MessageID, error) {
 	var messageID utils.MessageID
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "messageid", strconv.FormatInt(timestamp, 10))
-	err := t.pulsar.Client.Get(endpoint, &messageID)
+	err := t.pulsar.Client.Get(ctx, endpoint, &messageID)
 	return messageID, err
 }
 
 func (t *topics) GetStats(topic utils.TopicName) (utils.TopicStats, error) {
+	return t.GetStatsWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetStatsWithContext(ctx context.Context, topic utils.TopicName) (utils.TopicStats, error) {
 	var stats utils.TopicStats
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "stats")
-	err := t.pulsar.Client.Get(endpoint, &stats)
+	err := t.pulsar.Client.Get(ctx, endpoint, &stats)
 	return stats, err
 }
+
 func (t *topics) GetStatsWithOption(topic utils.TopicName, option utils.GetStatsOptions) (utils.TopicStats, error) {
+	return t.GetStatsWithOptionWithContext(context.Background(), topic, option)
+}
+
+func (t *topics) GetStatsWithOptionWithContext(ctx context.Context, topic utils.TopicName, option utils.GetStatsOptions) (utils.TopicStats, error) {
 	var stats utils.TopicStats
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "stats")
 	params := map[string]string{
@@ -688,27 +1274,41 @@ func (t *topics) GetStatsWithOption(topic utils.TopicName, option utils.GetStats
 		"excludePublishers":        strconv.FormatBool(option.ExcludePublishers),
 		"excludeConsumers":         strconv.FormatBool(option.ExcludeConsumers),
 	}
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &stats, params, true)
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &stats, params, true)
 	return stats, err
 }
 
 func (t *topics) GetInternalStats(topic utils.TopicName) (utils.PersistentTopicInternalStats, error) {
+	return t.GetInternalStatsWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetInternalStatsWithContext(ctx context.Context, topic utils.TopicName) (utils.PersistentTopicInternalStats, error) {
 	var stats utils.PersistentTopicInternalStats
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "internalStats")
-	err := t.pulsar.Client.Get(endpoint, &stats)
+	err := t.pulsar.Client.Get(ctx, endpoint, &stats)
 	return stats, err
 }
 
 func (t *topics) GetPartitionedStats(topic utils.TopicName, perPartition bool) (utils.PartitionedTopicStats, error) {
+	return t.GetPartitionedStatsWithContext(context.Background(), topic, perPartition)
+}
+
+func (t *topics) GetPartitionedStatsWithContext(ctx context.Context, topic utils.TopicName, perPartition bool) (utils.PartitionedTopicStats, error) {
 	var stats utils.PartitionedTopicStats
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitioned-stats")
 	params := map[string]string{
 		"perPartition": strconv.FormatBool(perPartition),
 	}
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &stats, params, true)
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &stats, params, true)
 	return stats, err
 }
+
 func (t *topics) GetPartitionedStatsWithOption(topic utils.TopicName, perPartition bool,
+	option utils.GetStatsOptions) (utils.PartitionedTopicStats, error) {
+	return t.GetPartitionedStatsWithOptionWithContext(context.Background(), topic, perPartition, option)
+}
+
+func (t *topics) GetPartitionedStatsWithOptionWithContext(ctx context.Context, topic utils.TopicName, perPartition bool,
 	option utils.GetStatsOptions) (utils.PartitionedTopicStats, error) {
 	var stats utils.PartitionedTopicStats
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "partitioned-stats")
@@ -720,506 +1320,844 @@ func (t *topics) GetPartitionedStatsWithOption(topic utils.TopicName, perPartiti
 		"excludePublishers":        strconv.FormatBool(option.ExcludePublishers),
 		"excludeConsumers":         strconv.FormatBool(option.ExcludeConsumers),
 	}
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &stats, params, true)
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &stats, params, true)
 	return stats, err
 }
 
 func (t *topics) Terminate(topic utils.TopicName) (utils.MessageID, error) {
+	return t.TerminateWithContext(context.Background(), topic)
+}
+
+func (t *topics) TerminateWithContext(ctx context.Context, topic utils.TopicName) (utils.MessageID, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "terminate")
 	var messageID utils.MessageID
-	err := t.pulsar.Client.PostWithObj(endpoint, nil, &messageID)
+	err := t.pulsar.Client.PostWithObj(ctx, endpoint, nil, &messageID)
 	return messageID, err
 }
 
 func (t *topics) Offload(topic utils.TopicName, messageID utils.MessageID) error {
+	return t.OffloadWithContext(context.Background(), topic, messageID)
+}
+
+func (t *topics) OffloadWithContext(ctx context.Context, topic utils.TopicName, messageID utils.MessageID) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "offload")
-	return t.pulsar.Client.Put(endpoint, messageID)
+	return t.pulsar.Client.Put(ctx, endpoint, messageID)
 }
 
 func (t *topics) OffloadStatus(topic utils.TopicName) (utils.OffloadProcessStatus, error) {
+	return t.OffloadStatusWithContext(context.Background(), topic)
+}
+
+func (t *topics) OffloadStatusWithContext(ctx context.Context, topic utils.TopicName) (utils.OffloadProcessStatus, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "offload")
 	var status utils.OffloadProcessStatus
-	err := t.pulsar.Client.Get(endpoint, &status)
+	err := t.pulsar.Client.Get(ctx, endpoint, &status)
 	return status, err
 }
 
 func (t *topics) Unload(topic utils.TopicName) error {
+	return t.UnloadWithContext(context.Background(), topic)
+}
+
+func (t *topics) UnloadWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "unload")
-	return t.pulsar.Client.Put(endpoint, nil)
+	return t.pulsar.Client.Put(ctx, endpoint, nil)
 }
 
 func (t *topics) Compact(topic utils.TopicName) error {
+	return t.CompactWithContext(context.Background(), topic)
+}
+
+func (t *topics) CompactWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compaction")
-	return t.pulsar.Client.Put(endpoint, nil)
+	return t.pulsar.Client.Put(ctx, endpoint, nil)
 }
 
 func (t *topics) CompactStatus(topic utils.TopicName) (utils.LongRunningProcessStatus, error) {
+	return t.CompactStatusWithContext(context.Background(), topic)
+}
+
+func (t *topics) CompactStatusWithContext(ctx context.Context, topic utils.TopicName) (utils.LongRunningProcessStatus, error) {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compaction")
 	var status utils.LongRunningProcessStatus
-	err := t.pulsar.Client.Get(endpoint, &status)
+	err := t.pulsar.Client.Get(ctx, endpoint, &status)
 	return status, err
 }
 
 func (t *topics) GetMessageTTL(topic utils.TopicName) (int, error) {
+	return t.GetMessageTTLWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMessageTTLWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var ttl int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "messageTTL")
-	err := t.pulsar.Client.Get(endpoint, &ttl)
+	err := t.pulsar.Client.Get(ctx, endpoint, &ttl)
 	return ttl, err
 }
 
 func (t *topics) SetMessageTTL(topic utils.TopicName, messageTTL int) error {
+	return t.SetMessageTTLWithContext(context.Background(), topic, messageTTL)
+}
+
+func (t *topics) SetMessageTTLWithContext(ctx context.Context, topic utils.TopicName, messageTTL int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "messageTTL")
 	var params = make(map[string]string)
 	params["messageTTL"] = strconv.Itoa(messageTTL)
-	err := t.pulsar.Client.PostWithQueryParams(endpoint, nil, params)
+	err := t.pulsar.Client.PostWithQueryParams(ctx, endpoint, nil, params)
 	return err
 }
 
 func (t *topics) RemoveMessageTTL(topic utils.TopicName) error {
+	return t.RemoveMessageTTLWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMessageTTLWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "messageTTL")
 	var params = make(map[string]string)
 	params["messageTTL"] = strconv.Itoa(0)
-	err := t.pulsar.Client.DeleteWithQueryParams(endpoint, params)
+	err := t.pulsar.Client.DeleteWithQueryParams(ctx, endpoint, params)
 	return err
 }
 
 func (t *topics) GetMaxProducers(topic utils.TopicName) (int, error) {
+	return t.GetMaxProducersWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxProducersWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxProducers int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxProducers")
-	err := t.pulsar.Client.Get(endpoint, &maxProducers)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxProducers)
 	return maxProducers, err
 }
 
 func (t *topics) SetMaxProducers(topic utils.TopicName, maxProducers int) error {
+	return t.SetMaxProducersWithContext(context.Background(), topic, maxProducers)
+}
+
+func (t *topics) SetMaxProducersWithContext(ctx context.Context, topic utils.TopicName, maxProducers int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxProducers")
-	err := t.pulsar.Client.Post(endpoint, &maxProducers)
+	err := t.pulsar.Client.Post(ctx, endpoint, &maxProducers)
 	return err
 }
 
 func (t *topics) RemoveMaxProducers(topic utils.TopicName) error {
+	return t.RemoveMaxProducersWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxProducersWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxProducers")
-	err := t.pulsar.Client.Delete(endpoint)
+	err := t.pulsar.Client.Delete(ctx, endpoint)
 	return err
 }
 
 func (t *topics) GetMaxConsumers(topic utils.TopicName) (int, error) {
+	return t.GetMaxConsumersWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxConsumersWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxConsumers int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxConsumers")
-	err := t.pulsar.Client.Get(endpoint, &maxConsumers)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxConsumers)
 	return maxConsumers, err
 }
 
 func (t *topics) SetMaxConsumers(topic utils.TopicName, maxConsumers int) error {
+	return t.SetMaxConsumersWithContext(context.Background(), topic, maxConsumers)
+}
+
+func (t *topics) SetMaxConsumersWithContext(ctx context.Context, topic utils.TopicName, maxConsumers int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxConsumers")
-	err := t.pulsar.Client.Post(endpoint, &maxConsumers)
+	err := t.pulsar.Client.Post(ctx, endpoint, &maxConsumers)
 	return err
 }
 
 func (t *topics) RemoveMaxConsumers(topic utils.TopicName) error {
+	return t.RemoveMaxConsumersWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxConsumersWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxConsumers")
-	err := t.pulsar.Client.Delete(endpoint)
+	err := t.pulsar.Client.Delete(ctx, endpoint)
 	return err
 }
 
 func (t *topics) GetMaxUnackMessagesPerConsumer(topic utils.TopicName) (int, error) {
+	return t.GetMaxUnackMessagesPerConsumerWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxUnackMessagesPerConsumerWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxNum int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnConsumer")
-	err := t.pulsar.Client.Get(endpoint, &maxNum)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxNum)
 	return maxNum, err
 }
 
 func (t *topics) SetMaxUnackMessagesPerConsumer(topic utils.TopicName, maxUnackedNum int) error {
+	return t.SetMaxUnackMessagesPerConsumerWithContext(context.Background(), topic, maxUnackedNum)
+}
+
+func (t *topics) SetMaxUnackMessagesPerConsumerWithContext(ctx context.Context, topic utils.TopicName, maxUnackedNum int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnConsumer")
-	return t.pulsar.Client.Post(endpoint, &maxUnackedNum)
+	return t.pulsar.Client.Post(ctx, endpoint, &maxUnackedNum)
 }
 
 func (t *topics) RemoveMaxUnackMessagesPerConsumer(topic utils.TopicName) error {
+	return t.RemoveMaxUnackMessagesPerConsumerWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxUnackMessagesPerConsumerWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnConsumer")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetMaxUnackMessagesPerSubscription(topic utils.TopicName) (int, error) {
+	return t.GetMaxUnackMessagesPerSubscriptionWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxUnackMessagesPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxNum int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnSubscription")
-	err := t.pulsar.Client.Get(endpoint, &maxNum)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxNum)
 	return maxNum, err
 }
 
 func (t *topics) SetMaxUnackMessagesPerSubscription(topic utils.TopicName, maxUnackedNum int) error {
+	return t.SetMaxUnackMessagesPerSubscriptionWithContext(context.Background(), topic, maxUnackedNum)
+}
+
+func (t *topics) SetMaxUnackMessagesPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName, maxUnackedNum int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnSubscription")
-	return t.pulsar.Client.Post(endpoint, &maxUnackedNum)
+	return t.pulsar.Client.Post(ctx, endpoint, &maxUnackedNum)
 }
 
 func (t *topics) RemoveMaxUnackMessagesPerSubscription(topic utils.TopicName) error {
+	return t.RemoveMaxUnackMessagesPerSubscriptionWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxUnackMessagesPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxUnackedMessagesOnSubscription")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetPersistence(topic utils.TopicName) (*utils.PersistenceData, error) {
+	return t.GetPersistenceWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetPersistenceWithContext(ctx context.Context, topic utils.TopicName) (*utils.PersistenceData, error) {
 	var persistenceData utils.PersistenceData
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "persistence")
-	err := t.pulsar.Client.Get(endpoint, &persistenceData)
+	err := t.pulsar.Client.Get(ctx, endpoint, &persistenceData)
 	return &persistenceData, err
 }
 
 func (t *topics) SetPersistence(topic utils.TopicName, persistenceData utils.PersistenceData) error {
+	return t.SetPersistenceWithContext(context.Background(), topic, persistenceData)
+}
+
+func (t *topics) SetPersistenceWithContext(ctx context.Context, topic utils.TopicName, persistenceData utils.PersistenceData) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "persistence")
-	return t.pulsar.Client.Post(endpoint, &persistenceData)
+	return t.pulsar.Client.Post(ctx, endpoint, &persistenceData)
 }
 
 func (t *topics) RemovePersistence(topic utils.TopicName) error {
+	return t.RemovePersistenceWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemovePersistenceWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "persistence")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetDelayedDelivery(topic utils.TopicName) (*utils.DelayedDeliveryData, error) {
+	return t.GetDelayedDeliveryWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetDelayedDeliveryWithContext(ctx context.Context, topic utils.TopicName) (*utils.DelayedDeliveryData, error) {
 	var delayedDeliveryData utils.DelayedDeliveryData
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "delayedDelivery")
-	err := t.pulsar.Client.Get(endpoint, &delayedDeliveryData)
+	err := t.pulsar.Client.Get(ctx, endpoint, &delayedDeliveryData)
 	return &delayedDeliveryData, err
 }
 
 func (t *topics) SetDelayedDelivery(topic utils.TopicName, delayedDeliveryData utils.DelayedDeliveryData) error {
+	return t.SetDelayedDeliveryWithContext(context.Background(), topic, delayedDeliveryData)
+}
+
+func (t *topics) SetDelayedDeliveryWithContext(ctx context.Context, topic utils.TopicName, delayedDeliveryData utils.DelayedDeliveryData) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "delayedDelivery")
-	return t.pulsar.Client.Post(endpoint, &delayedDeliveryData)
+	return t.pulsar.Client.Post(ctx, endpoint, &delayedDeliveryData)
 }
 
 func (t *topics) RemoveDelayedDelivery(topic utils.TopicName) error {
+	return t.RemoveDelayedDeliveryWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveDelayedDeliveryWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "delayedDelivery")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetDispatchRate(topic utils.TopicName) (*utils.DispatchRateData, error) {
+	return t.GetDispatchRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetDispatchRateWithContext(ctx context.Context, topic utils.TopicName) (*utils.DispatchRateData, error) {
 	var dispatchRateData utils.DispatchRateData
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "dispatchRate")
-	err := t.pulsar.Client.Get(endpoint, &dispatchRateData)
+	err := t.pulsar.Client.Get(ctx, endpoint, &dispatchRateData)
 	return &dispatchRateData, err
 }
 
 func (t *topics) SetDispatchRate(topic utils.TopicName, dispatchRateData utils.DispatchRateData) error {
+	return t.SetDispatchRateWithContext(context.Background(), topic, dispatchRateData)
+}
+
+func (t *topics) SetDispatchRateWithContext(ctx context.Context, topic utils.TopicName, dispatchRateData utils.DispatchRateData) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "dispatchRate")
-	return t.pulsar.Client.Post(endpoint, &dispatchRateData)
+	return t.pulsar.Client.Post(ctx, endpoint, &dispatchRateData)
 }
 
 func (t *topics) RemoveDispatchRate(topic utils.TopicName) error {
+	return t.RemoveDispatchRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveDispatchRateWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "dispatchRate")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetPublishRate(topic utils.TopicName) (*utils.PublishRateData, error) {
+	return t.GetPublishRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetPublishRateWithContext(ctx context.Context, topic utils.TopicName) (*utils.PublishRateData, error) {
 	var publishRateData utils.PublishRateData
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "publishRate")
-	err := t.pulsar.Client.Get(endpoint, &publishRateData)
+	err := t.pulsar.Client.Get(ctx, endpoint, &publishRateData)
 	return &publishRateData, err
 }
 
 func (t *topics) SetPublishRate(topic utils.TopicName, publishRateData utils.PublishRateData) error {
+	return t.SetPublishRateWithContext(context.Background(), topic, publishRateData)
+}
+
+func (t *topics) SetPublishRateWithContext(ctx context.Context, topic utils.TopicName, publishRateData utils.PublishRateData) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "publishRate")
-	return t.pulsar.Client.Post(endpoint, &publishRateData)
+	return t.pulsar.Client.Post(ctx, endpoint, &publishRateData)
 }
 
 func (t *topics) RemovePublishRate(topic utils.TopicName) error {
-	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "publishRate")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.RemovePublishRateWithContext(context.Background(), topic)
 }
+
+func (t *topics) RemovePublishRateWithContext(ctx context.Context, topic utils.TopicName) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "publishRate")
+	return t.pulsar.Client.Delete(ctx, endpoint)
+}
+
 func (t *topics) GetDeduplicationStatus(topic utils.TopicName) (bool, error) {
+	return t.GetDeduplicationStatusWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetDeduplicationStatusWithContext(ctx context.Context, topic utils.TopicName) (bool, error) {
 	var enabled bool
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationEnabled")
-	err := t.pulsar.Client.Get(endpoint, &enabled)
+	err := t.pulsar.Client.Get(ctx, endpoint, &enabled)
 	return enabled, err
 }
 
 func (t *topics) SetDeduplicationStatus(topic utils.TopicName, enabled bool) error {
-	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationEnabled")
-	return t.pulsar.Client.Post(endpoint, enabled)
+	return t.SetDeduplicationStatusWithContext(context.Background(), topic, enabled)
 }
-func (t *topics) RemoveDeduplicationStatus(topic utils.TopicName) error {
+
+func (t *topics) SetDeduplicationStatusWithContext(ctx context.Context, topic utils.TopicName, enabled bool) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationEnabled")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Post(ctx, endpoint, enabled)
+}
+
+func (t *topics) RemoveDeduplicationStatus(topic utils.TopicName) error {
+	return t.RemoveDeduplicationStatusWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveDeduplicationStatusWithContext(ctx context.Context, topic utils.TopicName) error {
+	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationEnabled")
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetRetention(topic utils.TopicName, applied bool) (*utils.RetentionPolicies, error) {
+	return t.GetRetentionWithContext(context.Background(), topic, applied)
+}
+
+func (t *topics) GetRetentionWithContext(ctx context.Context, topic utils.TopicName, applied bool) (*utils.RetentionPolicies, error) {
 	var policy utils.RetentionPolicies
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "retention")
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &policy, map[string]string{
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &policy, map[string]string{
 		"applied": strconv.FormatBool(applied),
 	}, true)
 	return &policy, err
 }
 
 func (t *topics) RemoveRetention(topic utils.TopicName) error {
+	return t.RemoveRetentionWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveRetentionWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "retention")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) SetRetention(topic utils.TopicName, data utils.RetentionPolicies) error {
+	return t.SetRetentionWithContext(context.Background(), topic, data)
+}
+
+func (t *topics) SetRetentionWithContext(ctx context.Context, topic utils.TopicName, data utils.RetentionPolicies) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "retention")
-	return t.pulsar.Client.Post(endpoint, data)
+	return t.pulsar.Client.Post(ctx, endpoint, data)
 }
 
 func (t *topics) GetCompactionThreshold(topic utils.TopicName, applied bool) (int64, error) {
+	return t.GetCompactionThresholdWithContext(context.Background(), topic, applied)
+}
+
+func (t *topics) GetCompactionThresholdWithContext(ctx context.Context, topic utils.TopicName, applied bool) (int64, error) {
 	var threshold int64
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compactionThreshold")
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &threshold, map[string]string{
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &threshold, map[string]string{
 		"applied": strconv.FormatBool(applied),
 	}, true)
 	return threshold, err
 }
 
 func (t *topics) SetCompactionThreshold(topic utils.TopicName, threshold int64) error {
+	return t.SetCompactionThresholdWithContext(context.Background(), topic, threshold)
+}
+
+func (t *topics) SetCompactionThresholdWithContext(ctx context.Context, topic utils.TopicName, threshold int64) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compactionThreshold")
-	err := t.pulsar.Client.Post(endpoint, threshold)
+	err := t.pulsar.Client.Post(ctx, endpoint, threshold)
 	return err
 }
 
 func (t *topics) RemoveCompactionThreshold(topic utils.TopicName) error {
+	return t.RemoveCompactionThresholdWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveCompactionThresholdWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "compactionThreshold")
-	err := t.pulsar.Client.Delete(endpoint)
+	err := t.pulsar.Client.Delete(ctx, endpoint)
 	return err
 }
 
 func (t *topics) GetBacklogQuotaMap(topic utils.TopicName, applied bool) (map[utils.BacklogQuotaType]utils.BacklogQuota,
 	error) {
+	return t.GetBacklogQuotaMapWithContext(context.Background(), topic, applied)
+}
+
+func (t *topics) GetBacklogQuotaMapWithContext(ctx context.Context, topic utils.TopicName, applied bool) (map[utils.BacklogQuotaType]utils.BacklogQuota,
+	error) {
 	var backlogQuotaMap map[utils.BacklogQuotaType]utils.BacklogQuota
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "backlogQuotaMap")
 
 	queryParams := map[string]string{"applied": strconv.FormatBool(applied)}
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &backlogQuotaMap, queryParams, true)
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &backlogQuotaMap, queryParams, true)
 
 	return backlogQuotaMap, err
 }
 
 func (t *topics) SetBacklogQuota(topic utils.TopicName, backlogQuota utils.BacklogQuota,
 	backlogQuotaType utils.BacklogQuotaType) error {
+	return t.SetBacklogQuotaWithContext(context.Background(), topic, backlogQuota, backlogQuotaType)
+}
+
+func (t *topics) SetBacklogQuotaWithContext(ctx context.Context, topic utils.TopicName, backlogQuota utils.BacklogQuota,
+	backlogQuotaType utils.BacklogQuotaType) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "backlogQuota")
 	params := make(map[string]string)
 	params["backlogQuotaType"] = string(backlogQuotaType)
-	return t.pulsar.Client.PostWithQueryParams(endpoint, &backlogQuota, params)
+	return t.pulsar.Client.PostWithQueryParams(ctx, endpoint, &backlogQuota, params)
 }
 
 func (t *topics) RemoveBacklogQuota(topic utils.TopicName, backlogQuotaType utils.BacklogQuotaType) error {
+	return t.RemoveBacklogQuotaWithContext(context.Background(), topic, backlogQuotaType)
+}
+
+func (t *topics) RemoveBacklogQuotaWithContext(ctx context.Context, topic utils.TopicName, backlogQuotaType utils.BacklogQuotaType) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "backlogQuota")
-	return t.pulsar.Client.DeleteWithQueryParams(endpoint, map[string]string{
+	return t.pulsar.Client.DeleteWithQueryParams(ctx, endpoint, map[string]string{
 		"backlogQuotaType": string(backlogQuotaType),
 	})
 }
 
 func (t *topics) GetInactiveTopicPolicies(topic utils.TopicName, applied bool) (utils.InactiveTopicPolicies, error) {
+	return t.GetInactiveTopicPoliciesWithContext(context.Background(), topic, applied)
+}
+
+func (t *topics) GetInactiveTopicPoliciesWithContext(ctx context.Context, topic utils.TopicName, applied bool) (utils.InactiveTopicPolicies, error) {
 	var out utils.InactiveTopicPolicies
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "inactiveTopicPolicies")
-	_, err := t.pulsar.Client.GetWithQueryParams(endpoint, &out, map[string]string{
+	_, err := t.pulsar.Client.GetWithQueryParams(ctx, endpoint, &out, map[string]string{
 		"applied": strconv.FormatBool(applied),
 	}, true)
 	return out, err
 }
 
 func (t *topics) RemoveInactiveTopicPolicies(topic utils.TopicName) error {
+	return t.RemoveInactiveTopicPoliciesWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveInactiveTopicPoliciesWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "inactiveTopicPolicies")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) SetInactiveTopicPolicies(topic utils.TopicName, data utils.InactiveTopicPolicies) error {
+	return t.SetInactiveTopicPoliciesWithContext(context.Background(), topic, data)
+}
+
+func (t *topics) SetInactiveTopicPoliciesWithContext(ctx context.Context, topic utils.TopicName, data utils.InactiveTopicPolicies) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "inactiveTopicPolicies")
-	return t.pulsar.Client.Post(endpoint, data)
+	return t.pulsar.Client.Post(ctx, endpoint, data)
 }
 
 func (t *topics) SetReplicationClusters(topic utils.TopicName, data []string) error {
+	return t.SetReplicationClustersWithContext(context.Background(), topic, data)
+}
+
+func (t *topics) SetReplicationClustersWithContext(ctx context.Context, topic utils.TopicName, data []string) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "replication")
-	return t.pulsar.Client.Post(endpoint, data)
+	return t.pulsar.Client.Post(ctx, endpoint, data)
 }
 
 func (t *topics) GetReplicationClusters(topic utils.TopicName) ([]string, error) {
+	return t.GetReplicationClustersWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetReplicationClustersWithContext(ctx context.Context, topic utils.TopicName) ([]string, error) {
 	var data []string
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "replication")
-	err := t.pulsar.Client.Get(endpoint, &data)
+	err := t.pulsar.Client.Get(ctx, endpoint, &data)
 	return data, err
 }
 
 func (t *topics) GetSubscribeRate(topic utils.TopicName) (*utils.SubscribeRate, error) {
+	return t.GetSubscribeRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetSubscribeRateWithContext(ctx context.Context, topic utils.TopicName) (*utils.SubscribeRate, error) {
 	var subscribeRate utils.SubscribeRate
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "subscribeRate")
-	err := t.pulsar.Client.Get(endpoint, &subscribeRate)
+	err := t.pulsar.Client.Get(ctx, endpoint, &subscribeRate)
 	return &subscribeRate, err
 }
 
 func (t *topics) SetSubscribeRate(topic utils.TopicName, subscribeRate utils.SubscribeRate) error {
+	return t.SetSubscribeRateWithContext(context.Background(), topic, subscribeRate)
+}
+
+func (t *topics) SetSubscribeRateWithContext(ctx context.Context, topic utils.TopicName, subscribeRate utils.SubscribeRate) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "subscribeRate")
-	return t.pulsar.Client.Post(endpoint, &subscribeRate)
+	return t.pulsar.Client.Post(ctx, endpoint, &subscribeRate)
 }
 
 func (t *topics) RemoveSubscribeRate(topic utils.TopicName) error {
+	return t.RemoveSubscribeRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveSubscribeRateWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "subscribeRate")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetSubscriptionDispatchRate(topic utils.TopicName) (*utils.DispatchRateData, error) {
+	return t.GetSubscriptionDispatchRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetSubscriptionDispatchRateWithContext(ctx context.Context, topic utils.TopicName) (*utils.DispatchRateData, error) {
 	var dispatchRate utils.DispatchRateData
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "subscriptionDispatchRate")
-	err := t.pulsar.Client.Get(endpoint, &dispatchRate)
+	err := t.pulsar.Client.Get(ctx, endpoint, &dispatchRate)
 	return &dispatchRate, err
 }
 
 func (t *topics) SetSubscriptionDispatchRate(topic utils.TopicName, dispatchRate utils.DispatchRateData) error {
+	return t.SetSubscriptionDispatchRateWithContext(context.Background(), topic, dispatchRate)
+}
+
+func (t *topics) SetSubscriptionDispatchRateWithContext(ctx context.Context, topic utils.TopicName, dispatchRate utils.DispatchRateData) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "subscriptionDispatchRate")
-	return t.pulsar.Client.Post(endpoint, &dispatchRate)
+	return t.pulsar.Client.Post(ctx, endpoint, &dispatchRate)
 }
 
 func (t *topics) RemoveSubscriptionDispatchRate(topic utils.TopicName) error {
+	return t.RemoveSubscriptionDispatchRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveSubscriptionDispatchRateWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "subscriptionDispatchRate")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetMaxConsumersPerSubscription(topic utils.TopicName) (int, error) {
+	return t.GetMaxConsumersPerSubscriptionWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxConsumersPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxConsumers int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxConsumersPerSubscription")
-	err := t.pulsar.Client.Get(endpoint, &maxConsumers)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxConsumers)
 	return maxConsumers, err
 }
 
 func (t *topics) SetMaxConsumersPerSubscription(topic utils.TopicName, maxConsumers int) error {
+	return t.SetMaxConsumersPerSubscriptionWithContext(context.Background(), topic, maxConsumers)
+}
+
+func (t *topics) SetMaxConsumersPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName, maxConsumers int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxConsumersPerSubscription")
-	return t.pulsar.Client.Post(endpoint, &maxConsumers)
+	return t.pulsar.Client.Post(ctx, endpoint, &maxConsumers)
 }
 
 func (t *topics) RemoveMaxConsumersPerSubscription(topic utils.TopicName) error {
+	return t.RemoveMaxConsumersPerSubscriptionWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxConsumersPerSubscriptionWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxConsumersPerSubscription")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetMaxMessageSize(topic utils.TopicName) (int, error) {
+	return t.GetMaxMessageSizeWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxMessageSizeWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxMessageSize int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxMessageSize")
-	err := t.pulsar.Client.Get(endpoint, &maxMessageSize)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxMessageSize)
 	return maxMessageSize, err
 }
 
 func (t *topics) SetMaxMessageSize(topic utils.TopicName, maxMessageSize int) error {
+	return t.SetMaxMessageSizeWithContext(context.Background(), topic, maxMessageSize)
+}
+
+func (t *topics) SetMaxMessageSizeWithContext(ctx context.Context, topic utils.TopicName, maxMessageSize int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxMessageSize")
-	return t.pulsar.Client.Post(endpoint, &maxMessageSize)
+	return t.pulsar.Client.Post(ctx, endpoint, &maxMessageSize)
 }
 
 func (t *topics) RemoveMaxMessageSize(topic utils.TopicName) error {
+	return t.RemoveMaxMessageSizeWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxMessageSizeWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxMessageSize")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetMaxSubscriptionsPerTopic(topic utils.TopicName) (int, error) {
+	return t.GetMaxSubscriptionsPerTopicWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetMaxSubscriptionsPerTopicWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var maxSubscriptions int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxSubscriptionsPerTopic")
-	err := t.pulsar.Client.Get(endpoint, &maxSubscriptions)
+	err := t.pulsar.Client.Get(ctx, endpoint, &maxSubscriptions)
 	return maxSubscriptions, err
 }
 
 func (t *topics) SetMaxSubscriptionsPerTopic(topic utils.TopicName, maxSubscriptions int) error {
+	return t.SetMaxSubscriptionsPerTopicWithContext(context.Background(), topic, maxSubscriptions)
+}
+
+func (t *topics) SetMaxSubscriptionsPerTopicWithContext(ctx context.Context, topic utils.TopicName, maxSubscriptions int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxSubscriptionsPerTopic")
-	return t.pulsar.Client.Post(endpoint, &maxSubscriptions)
+	return t.pulsar.Client.Post(ctx, endpoint, &maxSubscriptions)
 }
 
 func (t *topics) RemoveMaxSubscriptionsPerTopic(topic utils.TopicName) error {
+	return t.RemoveMaxSubscriptionsPerTopicWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveMaxSubscriptionsPerTopicWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "maxSubscriptionsPerTopic")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetSchemaValidationEnforced(topic utils.TopicName) (bool, error) {
+	return t.GetSchemaValidationEnforcedWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetSchemaValidationEnforcedWithContext(ctx context.Context, topic utils.TopicName) (bool, error) {
 	var enabled bool
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "schemaValidationEnforced")
-	err := t.pulsar.Client.Get(endpoint, &enabled)
+	err := t.pulsar.Client.Get(ctx, endpoint, &enabled)
 	return enabled, err
 }
 
 func (t *topics) SetSchemaValidationEnforced(topic utils.TopicName, enabled bool) error {
+	return t.SetSchemaValidationEnforcedWithContext(context.Background(), topic, enabled)
+}
+
+func (t *topics) SetSchemaValidationEnforcedWithContext(ctx context.Context, topic utils.TopicName, enabled bool) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "schemaValidationEnforced")
-	return t.pulsar.Client.Post(endpoint, enabled)
+	return t.pulsar.Client.Post(ctx, endpoint, enabled)
 }
 
 func (t *topics) RemoveSchemaValidationEnforced(topic utils.TopicName) error {
+	return t.RemoveSchemaValidationEnforcedWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveSchemaValidationEnforcedWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "schemaValidationEnforced")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetDeduplicationSnapshotInterval(topic utils.TopicName) (int, error) {
+	return t.GetDeduplicationSnapshotIntervalWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetDeduplicationSnapshotIntervalWithContext(ctx context.Context, topic utils.TopicName) (int, error) {
 	var interval int
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationSnapshotInterval")
-	err := t.pulsar.Client.Get(endpoint, &interval)
+	err := t.pulsar.Client.Get(ctx, endpoint, &interval)
 	return interval, err
 }
 
 func (t *topics) SetDeduplicationSnapshotInterval(topic utils.TopicName, interval int) error {
+	return t.SetDeduplicationSnapshotIntervalWithContext(context.Background(), topic, interval)
+}
+
+func (t *topics) SetDeduplicationSnapshotIntervalWithContext(ctx context.Context, topic utils.TopicName, interval int) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationSnapshotInterval")
-	return t.pulsar.Client.Post(endpoint, &interval)
+	return t.pulsar.Client.Post(ctx, endpoint, &interval)
 }
 
 func (t *topics) RemoveDeduplicationSnapshotInterval(topic utils.TopicName) error {
+	return t.RemoveDeduplicationSnapshotIntervalWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveDeduplicationSnapshotIntervalWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "deduplicationSnapshotInterval")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetReplicatorDispatchRate(topic utils.TopicName) (*utils.DispatchRateData, error) {
+	return t.GetReplicatorDispatchRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetReplicatorDispatchRateWithContext(ctx context.Context, topic utils.TopicName) (*utils.DispatchRateData, error) {
 	var dispatchRate utils.DispatchRateData
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "replicatorDispatchRate")
-	err := t.pulsar.Client.Get(endpoint, &dispatchRate)
+	err := t.pulsar.Client.Get(ctx, endpoint, &dispatchRate)
 	return &dispatchRate, err
 }
 
 func (t *topics) SetReplicatorDispatchRate(topic utils.TopicName, dispatchRate utils.DispatchRateData) error {
+	return t.SetReplicatorDispatchRateWithContext(context.Background(), topic, dispatchRate)
+}
+
+func (t *topics) SetReplicatorDispatchRateWithContext(ctx context.Context, topic utils.TopicName, dispatchRate utils.DispatchRateData) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "replicatorDispatchRate")
-	return t.pulsar.Client.Post(endpoint, &dispatchRate)
+	return t.pulsar.Client.Post(ctx, endpoint, &dispatchRate)
 }
 
 func (t *topics) RemoveReplicatorDispatchRate(topic utils.TopicName) error {
+	return t.RemoveReplicatorDispatchRateWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveReplicatorDispatchRateWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "replicatorDispatchRate")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetAutoSubscriptionCreation(topic utils.TopicName) (*utils.AutoSubscriptionCreationOverride, error) {
+	return t.GetAutoSubscriptionCreationWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetAutoSubscriptionCreationWithContext(ctx context.Context, topic utils.TopicName) (*utils.AutoSubscriptionCreationOverride, error) {
 	var autoSubCreation utils.AutoSubscriptionCreationOverride
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "autoSubscriptionCreation")
-	err := t.pulsar.Client.Get(endpoint, &autoSubCreation)
+	err := t.pulsar.Client.Get(ctx, endpoint, &autoSubCreation)
 	return &autoSubCreation, err
 }
 
 func (t *topics) SetAutoSubscriptionCreation(topic utils.TopicName,
 	autoSubCreation utils.AutoSubscriptionCreationOverride) error {
+	return t.SetAutoSubscriptionCreationWithContext(context.Background(), topic, autoSubCreation)
+}
+
+func (t *topics) SetAutoSubscriptionCreationWithContext(ctx context.Context, topic utils.TopicName,
+	autoSubCreation utils.AutoSubscriptionCreationOverride) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "autoSubscriptionCreation")
-	return t.pulsar.Client.Post(endpoint, &autoSubCreation)
+	return t.pulsar.Client.Post(ctx, endpoint, &autoSubCreation)
 }
 
 func (t *topics) RemoveAutoSubscriptionCreation(topic utils.TopicName) error {
+	return t.RemoveAutoSubscriptionCreationWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveAutoSubscriptionCreationWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "autoSubscriptionCreation")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetSchemaCompatibilityStrategy(topic utils.TopicName) (utils.SchemaCompatibilityStrategy, error) {
+	return t.GetSchemaCompatibilityStrategyWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetSchemaCompatibilityStrategyWithContext(ctx context.Context, topic utils.TopicName) (utils.SchemaCompatibilityStrategy, error) {
 	var strategy utils.SchemaCompatibilityStrategy
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "schemaCompatibilityStrategy")
-	err := t.pulsar.Client.Get(endpoint, &strategy)
+	err := t.pulsar.Client.Get(ctx, endpoint, &strategy)
 	return strategy, err
 }
 
 func (t *topics) SetSchemaCompatibilityStrategy(topic utils.TopicName,
 	strategy utils.SchemaCompatibilityStrategy) error {
+	return t.SetSchemaCompatibilityStrategyWithContext(context.Background(), topic, strategy)
+}
+
+func (t *topics) SetSchemaCompatibilityStrategyWithContext(ctx context.Context, topic utils.TopicName,
+	strategy utils.SchemaCompatibilityStrategy) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "schemaCompatibilityStrategy")
-	return t.pulsar.Client.Put(endpoint, strategy)
+	return t.pulsar.Client.Put(ctx, endpoint, strategy)
 }
 
 func (t *topics) RemoveSchemaCompatibilityStrategy(topic utils.TopicName) error {
+	return t.RemoveSchemaCompatibilityStrategyWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveSchemaCompatibilityStrategyWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "schemaCompatibilityStrategy")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }
 
 func (t *topics) GetOffloadPolicies(topic utils.TopicName) (*utils.OffloadPolicies, error) {
+	return t.GetOffloadPoliciesWithContext(context.Background(), topic)
+}
+
+func (t *topics) GetOffloadPoliciesWithContext(ctx context.Context, topic utils.TopicName) (*utils.OffloadPolicies, error) {
 	var offloadPolicies utils.OffloadPolicies
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "offloadPolicies")
-	err := t.pulsar.Client.Get(endpoint, &offloadPolicies)
+	err := t.pulsar.Client.Get(ctx, endpoint, &offloadPolicies)
 	return &offloadPolicies, err
 }
 
 func (t *topics) SetOffloadPolicies(topic utils.TopicName, offloadPolicies utils.OffloadPolicies) error {
+	return t.SetOffloadPoliciesWithContext(context.Background(), topic, offloadPolicies)
+}
+
+func (t *topics) SetOffloadPoliciesWithContext(ctx context.Context, topic utils.TopicName, offloadPolicies utils.OffloadPolicies) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "offloadPolicies")
-	return t.pulsar.Client.Post(endpoint, &offloadPolicies)
+	return t.pulsar.Client.Post(ctx, endpoint, &offloadPolicies)
 }
 
 func (t *topics) RemoveOffloadPolicies(topic utils.TopicName) error {
+	return t.RemoveOffloadPoliciesWithContext(context.Background(), topic)
+}
+
+func (t *topics) RemoveOffloadPoliciesWithContext(ctx context.Context, topic utils.TopicName) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "offloadPolicies")
-	return t.pulsar.Client.Delete(endpoint)
+	return t.pulsar.Client.Delete(ctx, endpoint)
 }


### PR DESCRIPTION
### Motivation

The admin client does not carry / accept the context `context.Context`. Accepting a context as a first parameter is Go idiom, and can be useful when a consumer wants to set a request timeout instead of tracking manually a timeout with separate goroutine.

### Modifications

In order to accept that context and make this a non-breaking change, a `WithContext()` method equivalent  is added to each of the methods in the admin client. Existing methods are now calling internally the `WithContext` method, with a `context.Background()` for the required context.

### Verifying this change

This change can be verified with existing E2E tests on the admin client for regression.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
