### PR TITLE
test: add unit test for unloading topic before consuming zero queue messages

### DIFF
--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -292,7 +292,7 @@ func TestUnloadTopicBeforeConsume(t *testing.T) {
 	log.Println("unloading topic")
 	topicName, err := utils.GetTopicName(topic)
 	assert.Nil(t, err)
-	// unload topic to trigger consumer reconnect and send a permits
+	// unload topic to trigger consumer reconnect and send permits
 	err = admin.Topics().Unload(*topicName)
 	assert.Nil(t, err)
 	log.Println("unloaded topic")


### PR DESCRIPTION

### Motivation

We discussed [here](https://github.com/apache/pulsar-client-go/issues/1421#issue-3403067854) that after a zero-queue consumer unloads a topic and then starts consuming again, the internal queue may contain multiple messages.

### Modifications

So I submitted a test case to ensure that consuming messages still works correctly after unloading the topic.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
