### PR TITLE
fix: return error when the client transaction coordinator is nil to p…

### DIFF
--- a/pulsar/client_impl.go
+++ b/pulsar/client_impl.go
@@ -41,7 +41,7 @@ const (
 	minConnMaxIdleTime                 = 60 * time.Second
 )
 
-var errClientTransactionsNotEnabled = errors.New("transactions are not enabled with the client")
+var ErrClientTransactionsNotEnabled = errors.New("transactions are not enabled with the client")
 
 type client struct {
 	cnxPool          internal.ConnectionPool
@@ -201,7 +201,7 @@ func newClient(options ClientOptions) (Client, error) {
 
 func (c *client) NewTransaction(timeout time.Duration) (Transaction, error) {
 	if c.tcClient == nil {
-		return nil, errClientTransactionsNotEnabled
+		return nil, ErrClientTransactionsNotEnabled
 	}
 
 	id, err := c.tcClient.newTransaction(timeout)


### PR DESCRIPTION
### Motivation


When the Pulsar client is created, if `EnableTransaction` is `true` then the transaction coordinator client is created.

If an application tries to create a transaction with  `NewTransaction()` when `EnableTransaction` is `false`, the application will panic; returning an error when the transaction coordinator is `nil` will prevent this.

### Modifications

In `NewTransaction()`, a nil check is added . If the transaction coordination client is `nil`, the method now returns an error.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
