### PR TITLE
fix: change producer reconnect error logs to warn logs

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -508,7 +508,6 @@ func (p *partitionProducer) reconnectToBroker(connectionClosed *connectionClosed
 			bo.Reset()
 			return struct{}{}, nil
 		}
-		p.log.WithError(err).Error("Failed to create producer at reconnect")
 		errMsg := err.Error()
 		if strings.Contains(errMsg, errMsgTopicNotFound) {
 			// when topic is deleted, we should give up reconnection.
@@ -534,6 +533,7 @@ func (p *partitionProducer) reconnectToBroker(connectionClosed *connectionClosed
 			p.doClose(errors.Join(ErrProducerFenced, err))
 			return struct{}{}, nil
 		}
+		p.log.WithError(err).Warn("Failed to reconnect to broker, will retry later.")
 
 		if maxRetry > 0 {
 			maxRetry--


### PR DESCRIPTION
### Motivation

During producer reconnection, retryable errors are currently logged at the error level. These cases are expected and should not be treated as hard failures. They should be logged at the warning level instead.

### Modifications

* Change producer reconnect error logs from error to warning level

### Preview

```
time="2025-12-08T16:52:35+08:00" level=warning msg="Failed to reconnect to broker, will retry later." error="expected error" producerID=1 producer_name=standalone-425-5 topic="persistent://public/default/my-topic-878937000"

```


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
