### PR TITLE
docs: Update example code, add log initialization configurations

### DIFF
--- a/examples/consumer/consumer.go
+++ b/examples/consumer/consumer.go
@@ -19,18 +19,38 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"log"
+	"io"
+	"log/slog"
+	"os"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	pulsarlog "github.com/apache/pulsar-client-go/pulsar/log"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func main() {
-	client, err := pulsar.NewClient(pulsar.ClientOptions{URL: "pulsar://localhost:6650"})
-	if err != nil {
-		log.Fatal(err)
+	fileLogger := &lumberjack.Logger{
+		Filename:   "/tmp/pulsar-go-sdk.log",
+		MaxSize:    100,
+		MaxBackups: 5,
+		LocalTime:  true,
 	}
+	// this multiLogger prints logs to both stdout and fileLogger
+	// if we only want to print logs to file, just pass fileLogger to slog.NewJSONHandler()
+	multiLogger := io.MultiWriter(os.Stdout, fileLogger)
+	logger := slog.New(slog.NewJSONHandler(multiLogger, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
 
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL: "pulsar://localhost:6650",
+		// If we are using a logrus logger or other third-party custom loggers,
+		// we can skip the above slog logger initialization and pass the logger with its corresponding wrapper here.
+		Logger: pulsarlog.NewLoggerWithSlog(logger),
+	})
+	if err != nil {
+		logger.Error("create client err", "error", err)
+		return
+	}
 	defer client.Close()
 
 	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
@@ -39,23 +59,27 @@ func main() {
 		Type:             pulsar.Shared,
 	})
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("create consumer err", "error", err)
+		return
 	}
 	defer consumer.Close()
 
 	for i := 0; i < 10; i++ {
 		msg, err := consumer.Receive(context.Background())
 		if err != nil {
-			log.Fatal(err)
+			logger.Error("consumer receive message err", "error", err)
+			return
 		}
-
-		fmt.Printf("Received message msgId: %#v -- content: '%s'\n",
-			msg.ID(), string(msg.Payload()))
-
+		logger.Info("Received message",
+			"msgId",
+			msg.ID().String(),
+			"content",
+			string(msg.Payload()),
+		)
 		consumer.Ack(msg)
 	}
-
 	if err := consumer.Unsubscribe(); err != nil {
-		log.Fatal(err)
+		logger.Error("consumer unsubscribe err", "error", err)
+		return
 	}
 }

--- a/examples/producer/producer.go
+++ b/examples/producer/producer.go
@@ -20,40 +20,58 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"io"
+	"log/slog"
+	"os"
 
 	"github.com/apache/pulsar-client-go/pulsar"
+	pulsarlog "github.com/apache/pulsar-client-go/pulsar/log"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func main() {
+	fileLogger := &lumberjack.Logger{
+		Filename:   "/tmp/pulsar-go-sdk.log",
+		MaxSize:    100,
+		MaxBackups: 5,
+		LocalTime:  true,
+	}
+	// this multiLogger prints logs to both stdout and fileLogger
+	// if we only want to print logs to file, just pass fileLogger to slog.NewJSONHandler()
+	multiLogger := io.MultiWriter(os.Stdout, fileLogger)
+	logger := slog.New(slog.NewJSONHandler(multiLogger, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
 	client, err := pulsar.NewClient(pulsar.ClientOptions{
 		URL: "pulsar://localhost:6650",
+		// If we are using a logrus logger or other third-party custom loggers,
+		// we can skip the above slog logger initialization and pass the logger with its corresponding wrapper here.
+		Logger: pulsarlog.NewLoggerWithSlog(logger),
 	})
-
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("create client err", "error", err)
+		return
 	}
-
 	defer client.Close()
 
 	producer, err := client.CreateProducer(pulsar.ProducerOptions{
 		Topic: "topic-1",
 	})
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("create producer err", "error", err)
+		return
 	}
-
 	defer producer.Close()
 
 	ctx := context.Background()
-
 	for i := 0; i < 10; i++ {
 		if msgId, err := producer.Send(ctx, &pulsar.ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}); err != nil {
-			log.Fatal(err)
+			logger.Error("send message error", "error", err)
+			return
 		} else {
-			log.Println("Published message: ", msgId)
+			logger.Info("Published message", "msgId", msgId.String())
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	golang.org/x/oauth2 v0.28.0
 	golang.org/x/time v0.10.0
 	google.golang.org/protobuf v1.36.5
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Master Issue: https://github.com/apache/pulsar-client-go/pull/1234

### Motivation
The `log/slog` package, introduced in Go 1.21 has become the standard library for structured logging, which provides support for redirecting logs to files and enabling log rotation. 
Additionally, since pulsar default logger uses `log.NewLoggerWithLogrus(logrus.StandardLogger())`, logs cannot be output to the files when users haven't set up logrus explicit configuration. Therefore, maybe we should use `slog` and give a complete log  settings in our examples to enhance the out-of-the-box experience for users.

### Modifications
Add log initialization configurations in example files.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is a trivial rework without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)

