### PR TITLE
[Reader] fix: deliver null-value tombstones instead of discarding them

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1316,6 +1316,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 			// tombstones.
 			if isNullValue && err == internal.ErrEOM {
 				payload = nil
+				err = nil
 			} else {
 				pc.discardCorruptedMessage(pbMsgID, pb.CommandAck_BatchDeSerializeError)
 				return err

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1316,7 +1316,9 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 			// tombstones.
 			if isNullValue && err == internal.ErrEOM {
 				payload = nil
-				err = nil
+				// Explicit reset to make tombstone-acceptance
+				// intent unambiguous.
+				err = nil //nolint:ineffassign
 			} else {
 				pc.discardCorruptedMessage(pbMsgID, pb.CommandAck_BatchDeSerializeError)
 				return err

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -1308,9 +1308,24 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 	)
 	for i := 0; i < numMsgs; i++ {
 		smm, payload, err := reader.ReadMessage()
-		if err != nil || payload == nil {
+		isNullValue := msgMeta.GetNullValue() || (smm != nil && smm.GetNullValue())
+		if err != nil {
+			// A null-value (tombstone) message has no payload bytes on the wire, so
+			// the non-batched reader returns ErrEOM. Accept it instead of discarding
+			// it as corrupted, matching the Java client's behavior for compaction
+			// tombstones.
+			if isNullValue && err == internal.ErrEOM {
+				payload = nil
+			} else {
+				pc.discardCorruptedMessage(pbMsgID, pb.CommandAck_BatchDeSerializeError)
+				return err
+			}
+		} else if payload == nil && !isNullValue {
 			pc.discardCorruptedMessage(pbMsgID, pb.CommandAck_BatchDeSerializeError)
 			return err
+		}
+		if isNullValue {
+			payload = nil
 		}
 		if ackSet != nil && !ackSet.Test(uint(i)) {
 			pc.log.Debugf("Ignoring message from %vth message, which has been acknowledged", i)
@@ -1396,6 +1411,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 				index:               messageIndex,
 				brokerPublishTime:   brokerPublishTime,
 				conn:                pc._getConn(),
+				isNullValue:         isNullValue,
 			}
 		} else {
 			msg = &message{
@@ -1417,6 +1433,7 @@ func (pc *partitionConsumer) MessageReceived(response *pb.CommandMessage, header
 				index:               messageIndex,
 				brokerPublishTime:   brokerPublishTime,
 				conn:                pc._getConn(),
+				isNullValue:         isNullValue,
 			}
 		}
 

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -316,6 +316,7 @@ type message struct {
 	index               *uint64
 	brokerPublishTime   *time.Time
 	conn                internal.Connection
+	isNullValue         bool
 }
 
 func (msg *message) Topic() string {
@@ -328,6 +329,10 @@ func (msg *message) Properties() map[string]string {
 
 func (msg *message) Payload() []byte {
 	return msg.payLoad
+}
+
+func (msg *message) IsNullValue() bool {
+	return msg.isNullValue
 }
 
 func (msg *message) ID() MessageID {

--- a/pulsar/internal/pulsartracing/message_carrier_util_test.go
+++ b/pulsar/internal/pulsartracing/message_carrier_util_test.go
@@ -80,6 +80,10 @@ func (msg *mockConsumerMessage) Payload() []byte {
 	return nil
 }
 
+func (msg *mockConsumerMessage) IsNullValue() bool {
+	return false
+}
+
 func (msg *mockConsumerMessage) ID() pulsar.MessageID {
 	return nil
 }

--- a/pulsar/message.go
+++ b/pulsar/message.go
@@ -90,6 +90,12 @@ type Message interface {
 	// Payload returns the payload of the message
 	Payload() []byte
 
+	// IsNullValue reports whether the message was published as a null-value
+	// (tombstone) message, i.e. with MessageMetadata.null_value set. For such
+	// messages Payload returns nil. Applications use this flag together with
+	// Pulsar topic compaction to mark a key as deleted.
+	IsNullValue() bool
+
 	// ID returns the unique message ID associated with this message.
 	// The message id can be used to univocally refer to a message without having the keep the entire payload in memory.
 	ID() MessageID

--- a/pulsar/negative_acks_tracker_test.go
+++ b/pulsar/negative_acks_tracker_test.go
@@ -197,6 +197,10 @@ func (msg *mockMessage1) Payload() []byte {
 	return nil
 }
 
+func (msg *mockMessage1) IsNullValue() bool {
+	return false
+}
+
 func (msg *mockMessage1) ID() MessageID {
 	return &messageID{
 		ledgerID: 1,
@@ -271,6 +275,10 @@ func (msg *mockMessage2) Properties() map[string]string {
 
 func (msg *mockMessage2) Payload() []byte {
 	return nil
+}
+
+func (msg *mockMessage2) IsNullValue() bool {
+	return false
 }
 
 func (msg *mockMessage2) ID() MessageID {

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -724,6 +724,10 @@ func (p *partitionProducer) genMetadata(msg *ProducerMessage,
 		UncompressedSize: proto.Uint32(uint32(uncompressedSize)),
 	}
 
+	if msg.Value == nil && msg.Payload == nil {
+		mm.NullValue = proto.Bool(true)
+	}
+
 	if !msg.EventTime.IsZero() {
 		mm.EventTime = proto.Uint64(internal.TimestampMillis(msg.EventTime))
 	}
@@ -769,6 +773,10 @@ func (p *partitionProducer) genSingleMessageMetadataInBatch(
 ) (smm *pb.SingleMessageMetadata) {
 	smm = &pb.SingleMessageMetadata{
 		PayloadSize: proto.Int32(int32(uncompressedSize)),
+	}
+
+	if msg.Value == nil && msg.Payload == nil {
+		smm.NullValue = proto.Bool(true)
 	}
 
 	if !msg.EventTime.IsZero() {

--- a/pulsar/reader_test.go
+++ b/pulsar/reader_test.go
@@ -496,6 +496,70 @@ func TestReaderHasNext(t *testing.T) {
 	assert.Equal(t, 10, i)
 }
 
+// TestReaderNullValueTombstone verifies that a message published with a nil
+// Value / nil Payload (the Pulsar compaction tombstone convention) is delivered
+// to Reader.Next.
+func TestReaderNullValueTombstone(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	ctx := context.Background()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.Nil(t, err)
+
+	_, err = producer.Send(ctx, &ProducerMessage{
+		Key:     "k",
+		Payload: []byte("v1"),
+	})
+	assert.NoError(t, err)
+
+	tombstoneID, err := producer.Send(ctx, &ProducerMessage{
+		Key:     "k",
+		Payload: nil,
+	})
+	assert.NoError(t, err)
+	producer.Close()
+
+	reader, err := client.CreateReader(ReaderOptions{
+		Topic:                   topic,
+		StartMessageID:          EarliestMessageID(),
+		StartMessageIDInclusive: true,
+	})
+	assert.Nil(t, err)
+	defer reader.Close()
+
+	lastID, err := reader.GetLastMessageID()
+	assert.NoError(t, err)
+	assert.Equal(t, tombstoneID.LedgerID(), lastID.LedgerID())
+	assert.Equal(t, tombstoneID.EntryID(), lastID.EntryID())
+
+	firstCtx, firstCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer firstCancel()
+	msg, err := reader.Next(firstCtx)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("v1"), msg.Payload())
+	assert.False(t, msg.IsNullValue())
+
+	secondCtx, secondCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer secondCancel()
+	tombstone, err := reader.Next(secondCtx)
+	assert.NoError(t, err)
+	assert.True(t, tombstone.IsNullValue())
+	assert.Nil(t, tombstone.Payload())
+	assert.Equal(t, lastID.LedgerID(), tombstone.ID().LedgerID())
+	assert.Equal(t, lastID.EntryID(), tombstone.ID().EntryID())
+
+	assert.False(t, reader.HasNext())
+}
+
 type myMessageID struct {
 	data []byte
 }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

A message published with `MessageMetadata.null_value = true` (the Pulsar compaction tombstone convention) was conflated with a deserialization failure in `partitionConsumer.MessageReceived` and silently discarded. Because `lastDequeuedMsg` was never advanced past the tombstone, `hasMoreMessages` kept returning true and `Reader.Next` blocked forever when a tombstone was the last message on a topic.

### Modifications

Consumer: when the reader yields an empty payload and message metadata or the single-message metadata has `null_value` set, build a normal message with `payLoad == nil` and take the usual dispatch path so `lastDequeuedMsg` advances. Real corruption still routes through `discardCorruptedMessage`.

Producer: set `MessageMetadata.null_value`/`SingleMessageMetadata.null_value` when both `Value` and `Payload` are nil, matching the Java client so Go-produced tombstones carry the flag consumers need.

Message gains an `IsNullValue()` bool accessor so applications can tell tombstones apart from empty payloads.

**Note:** This PR was written with the assistance of AI Anthropic’s Opus 4.7.

### Verifying this change

This change added tests and can be verified as follows:

  - Added reader test

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (~~yes~~ / **no**)
  - The public API: (**yes** / ~~no~~) (added `IsNullValue()` to the `Message` interface)
  - The schema: (~~yes~~ / **no** / ~~don't know~~)
  - The default values of configurations: (~~yes~~ / **no**)
  - The wire protocol: (~~yes~~ / **no**)

### Documentation

  - Does this pull request introduce a new feature? (~~yes~~ / **no**)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented): **N/A.**
  - If a feature is not applicable for documentation, explain why? **N/A.**
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation. **N/A.**
