### PR TITLE
docs(producer): clarify SendAsync description

### DIFF
--- a/pulsar/producer.go
+++ b/pulsar/producer.go
@@ -231,8 +231,11 @@ type Producer interface {
 	// producer.Send(ctx, pulsar.ProducerMessage{ Payload: myPayload })
 	Send(context.Context, *ProducerMessage) (MessageID, error)
 
-	// SendAsync a message in asynchronous mode
-	// This call is blocked when the `maxPendingMessages` becomes full (default: 1000)
+	// SendAsync a message in asynchronous mode. The send operation completes in the background
+	// and the provided callback is invoked once the broker acknowledges the message (or when
+	// the publish fails), so the caller can continue without waiting for the result.
+	// This call is blocked when the `maxPendingMessages` becomes full (default: 1000) unless
+	// `DisableBlockIfQueueFull` is set to true, in which case it returns an error immediately.
 	// The callback will report back the message being published and
 	// the eventual error in publishing
 	// The context passed in the call is only used for the duration of the SendAsync call itself


### PR DESCRIPTION
## Why

Closes apache/pulsar#23643.

The current `Producer.SendAsync` GoDoc says "This call is blocked when the `maxPendingMessages` becomes full (default: 1000)" without context, which makes the asynchronous API sound blocking by default. As noted in the issue thread, the call only blocks when the queue is full **and** `DisableBlockIfQueueFull` is left at its default (`false`). It also never says, in plain words, that the send happens in the background and the callback is what signals completion — which is the actual mental model users need.

## What

`pulsar/producer.go`:

- Add a one-sentence lead clarifying that `SendAsync` runs the send in the background and invokes the supplied callback on completion (success or failure).
- Qualify the existing "is blocked when `maxPendingMessages` becomes full" sentence with the `DisableBlockIfQueueFull` exception, instead of describing it as unconditional.

The context paragraph, callback description, example, and signature are intentionally untouched.

## Tested

- Verified the GoDoc renders as expected by reading the diff (`gh api .../compare/...` shows +5 / -2 in `pulsar/producer.go`).
- No code paths changed, so no test impact.
