### PR TITLE
[feat] Add consumer PriorityLevel support

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -132,6 +132,26 @@ type ConsumerOptions struct {
 	// This argument is required when subscribing
 	SubscriptionName string
 
+	// PriorityLevel sets the priority level for this consumer.
+	//
+	// Shared subscription:
+	// Sets priority level for the consumer to determine which consumers the broker
+	// prioritizes when dispatching messages. The broker follows descending priorities
+	// (0 = max priority, 1, 2, ...).
+	// The broker first dispatches messages to max priority consumers if they have
+	// permits, otherwise considers next priority level consumers.
+	// e.g. if consumer-A has priorityLevel 0 and consumer-B has priorityLevel 1,
+	// the broker dispatches messages to only consumer-A until it runs out of permits,
+	// then starts dispatching to consumer-B.
+	//
+	// Failover subscription (partitioned topics only):
+	// The broker selects the active consumer based on priority level and lexicographic
+	// sorting of consumer name. Higher priority (lower number) consumers are preferred.
+	// Priority level has no effect on failover subscriptions for non-partitioned topics.
+	//
+	// Default is 0 (max priority).
+	PriorityLevel int
+
 	// Properties represents a set of application defined properties for the consumer.
 	// Those properties will be visible in the topic stats
 	Properties map[string]string

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -84,6 +84,10 @@ func newConsumer(client *client, options ConsumerOptions) (Consumer, error) {
 		return nil, newError(SubscriptionNotFound, "subscription name is required for consumer")
 	}
 
+	if options.PriorityLevel < 0 {
+		return nil, newError(InvalidConfiguration, "priority level must be >= 0")
+	}
+
 	if options.ReceiverQueueSize <= 0 {
 		options.ReceiverQueueSize = defaultReceiverQueueSize
 	}
@@ -455,6 +459,7 @@ func newPartitionConsumerOpts(topic, consumerName string, idx int, options Consu
 		subscriptionType:            options.Type,
 		subscriptionInitPos:         options.SubscriptionInitialPosition,
 		partitionIdx:                idx,
+		priorityLevel:               options.PriorityLevel,
 		receiverQueueSize:           options.ReceiverQueueSize,
 		nackRedeliveryDelay:         nackRedeliveryDelay,
 		nackBackoffPolicy:           options.NackBackoffPolicy,

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -100,6 +100,7 @@ type partitionConsumerOpts struct {
 	subscriptionType            SubscriptionType
 	subscriptionInitPos         SubscriptionInitialPosition
 	partitionIdx                int
+	priorityLevel               int
 	receiverQueueSize           int
 	autoReceiverQueueSize       bool
 	nackRedeliveryDelay         time.Duration
@@ -2145,7 +2146,7 @@ func (pc *partitionConsumer) grabConn(assignedBrokerURL string) error {
 		ConsumerId:                 proto.Uint64(pc.consumerID),
 		RequestId:                  proto.Uint64(requestID),
 		ConsumerName:               proto.String(pc.name),
-		PriorityLevel:              nil,
+		PriorityLevel:              proto.Int32(int32(pc.options.priorityLevel)),
 		Durable:                    proto.Bool(pc.options.subscriptionMode == Durable),
 		Metadata:                   internal.ConvertFromStringMap(pc.options.metadata),
 		SubscriptionProperties:     internal.ConvertFromStringMap(pc.options.subProperties),

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -228,6 +228,151 @@ func TestConsumerWithInvalidConf(t *testing.T) {
 	assert.Equal(t, err.(*Error).Result(), TopicNotFound)
 }
 
+func TestConsumerWithInvalidPriorityLevel(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            "my-topic",
+		SubscriptionName: "my-sub",
+		PriorityLevel:    -1,
+	})
+
+	assert.Nil(t, consumer)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.(*Error).Result(), InvalidConfiguration)
+}
+
+func TestConsumerSharedWithPriorityLevel(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	sub := "sub-shared-priority"
+
+	consumer1, err := client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		SubscriptionName: sub,
+		Type:             Shared,
+		PriorityLevel:    0,
+	})
+	assert.Nil(t, err)
+	defer consumer1.Close()
+
+	consumer2, err := client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		SubscriptionName: sub,
+		Type:             Shared,
+		PriorityLevel:    1,
+	})
+	assert.Nil(t, err)
+	defer consumer2.Close()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topic,
+		DisableBatching: true,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	for i := 0; i < 10; i++ {
+		if _, err := producer.Send(context.Background(), &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		}); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	readMsgs := 0
+	messages := make(map[string]struct{})
+	for readMsgs < 10 {
+		select {
+		case cm, ok := <-consumer1.Chan():
+			if !ok {
+				break
+			}
+			readMsgs++
+			payload := string(cm.Message.Payload())
+			messages[payload] = struct{}{}
+			consumer1.Ack(cm.Message)
+		case cm, ok := <-consumer2.Chan():
+			if !ok {
+				break
+			}
+			readMsgs++
+			payload := string(cm.Message.Payload())
+			messages[payload] = struct{}{}
+			consumer2.Ack(cm.Message)
+		}
+	}
+
+	assert.Equal(t, 10, len(messages))
+}
+
+func TestPartitionTopic_ActiveConsumerChangedWithPriority(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	randomName := newTopicName()
+	topic := "persistent://public/default/" + randomName
+	testURL := adminURL + "/" + "admin/v2/persistent/public/default/" + randomName + "/partitions"
+
+	makeHTTPCall(t, http.MethodPut, testURL, "3")
+
+	listener := &TestActiveConsumerListener{
+		t:                t,
+		nameToPartitions: map[string]map[int32]struct{}{},
+	}
+
+	// Subscribe low-priority consumer first
+	consumer1, err := client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		Name:             "consumer-low",
+		SubscriptionName: "my-sub",
+		Type:             Failover,
+		PriorityLevel:    1,
+		EventListener:    listener,
+	})
+	assert.Nil(t, err)
+	defer consumer1.Close()
+
+	allConsume([]Consumer{consumer1})
+	assert.Equal(t, 3, listener.getPartitionCount("consumer-low"))
+
+	// Subscribe high-priority consumer -- should take over
+	consumer2, err := client.Subscribe(ConsumerOptions{
+		Topic:            topic,
+		Name:             "consumer-high",
+		SubscriptionName: "my-sub",
+		Type:             Failover,
+		PriorityLevel:    0,
+		EventListener:    listener,
+	})
+	assert.Nil(t, err)
+	defer consumer2.Close()
+
+	allConsume([]Consumer{consumer1, consumer2})
+	time.Sleep(time.Second * 3)
+	allConsume([]Consumer{consumer1, consumer2})
+
+	// High-priority consumer should be active on all partitions
+	assert.Equal(t, 3, listener.getPartitionCount("consumer-high"))
+
+	consumer1.Close()
+	consumer2.Close()
+}
+
 func TestConsumerSubscriptionEarliestPosition(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION
### Motivation

The Pulsar wire protocol's `CommandSubscribe` has a `priority_level` field, and the Java client exposes it via `ConsumerBuilder.priorityLevel(int)`. The Go client currently hardcodes `PriorityLevel: nil`, making it impossible for Go consumers to set their priority level.

This is needed for:
- **Shared subscriptions**: controlling which consumers the broker prioritizes when dispatching messages (0 = max priority, higher numbers = lower priority)
- **Failover subscriptions on partitioned topics**: controlling which consumer becomes the active consumer based on priority level and lexicographic consumer name sorting

Master Issue: https://github.com/apache/pulsar/issues/134

A prior attempt was made in #783 but was closed without merge because it lacked tests and had a validation bug (rejecting priority level 0, which is the valid default/max priority). This PR addresses both issues.


