### PR TITLE
[Issue 1094][doc] Enhance ConnectionTimeout/KeepAliveInterval comments

### DIFF
--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -90,7 +90,17 @@ type ClientOptions struct {
 	// This parameter is required
 	URL string
 
-	// Timeout for the establishment of a TCP connection (default: 5 seconds)
+	// Timeout for the establishment of a TCP connection (default: 0).
+	// This parameter only controls the TCP connection establishment phase (including TLS handshake
+	// if TLS is enabled). It does NOT affect the timeout for connection disruption detection after
+	// the connection is established. Once connected, connection liveness is monitored by the
+	// Ping/Pong heartbeat mechanism controlled by KeepAliveInterval — if no data is received
+	// within 2 × KeepAliveInterval, the connection is considered stale and will be closed.
+	//
+	// 0 means no application-level timeout, the actual TCP connection timeout
+	// will fall back to the OS kernel's TCP settings (on Linux, controlled by
+	// net.ipv4.tcp_syn_retries, which defaults to 6 retries, ~127s in total).
+	// If your application is sensitive to service disruption, set this explicitly (e.g., 10s or 15s).
 	ConnectionTimeout time.Duration
 
 	// Set the operation timeout (default: 30 seconds)
@@ -99,6 +109,11 @@ type ClientOptions struct {
 	OperationTimeout time.Duration
 
 	// Configure the ping send and check interval, default to 30 seconds.
+	//
+	// The client sends PING every KeepAliveInterval and considers the connection stale if no data
+	// is received within 2 × KeepAliveInterval, then closes it and triggers automatic reconnection.
+	// The timeout for the reconnection TCP dial is controlled by ConnectionTimeout.
+	// To speed up reconnection, reduce this value (e.g., 10s or 15s).
 	KeepAliveInterval time.Duration
 
 	// Configure the authentication provider. (default: no authentication)

--- a/pulsar/client_impl_test.go
+++ b/pulsar/client_impl_test.go
@@ -1238,3 +1238,33 @@ func TestMultipleCloseClient(t *testing.T) {
 	client.Close()
 	client.Close()
 }
+
+func TestDefaultConnectionTimeout(t *testing.T) {
+	// Verify that the default ConnectionTimeout is 0 (no application-level timeout)
+	// when the user does not explicitly set it.
+	cli, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.Nil(t, err)
+	defer cli.Close()
+
+	pool := cli.(*client).cnxPool
+	connectionTimeout := internal.GetConnectionTimeout(&pool)
+	assert.Equal(t, time.Duration(0), connectionTimeout,
+		"Default ConnectionTimeout should be 0 (no application-level timeout)")
+}
+
+func TestDefaultKeepAliveInterval(t *testing.T) {
+	// Verify that the default KeepAliveInterval is 30s
+	// when the user does not explicitly set it.
+	cli, err := NewClient(ClientOptions{
+		URL: serviceURL,
+	})
+	assert.Nil(t, err)
+	defer cli.Close()
+
+	pool := cli.(*client).cnxPool
+	keepAliveInterval := internal.GetKeepAliveInterval(&pool)
+	assert.Equal(t, 30*time.Second, keepAliveInterval,
+		"Default KeepAliveInterval should be 30s")
+}

--- a/pulsar/internal/helper.go
+++ b/pulsar/internal/helper.go
@@ -31,3 +31,13 @@ func GetConnectionsCount(p *ConnectionPool) int {
 	defer pool.Unlock()
 	return len(pool.connections)
 }
+
+func GetConnectionTimeout(p *ConnectionPool) time.Duration {
+	pool := (*p).(*connectionPool)
+	return pool.connectionTimeout
+}
+
+func GetKeepAliveInterval(p *ConnectionPool) time.Duration {
+	pool := (*p).(*connectionPool)
+	return pool.keepAliveInterval
+}


### PR DESCRIPTION
Fixes #1094 and #1095

### Motivation

In Issue #1094, the default value of `ConnectionTimeout` was changed from `10s` to `0` (falling back to the OS kernel's TCP timeout), but the corresponding GoDoc comment was not updated accordingly — it still stated "default: 5 seconds". This stale comment is misleading and can cause confusion for users trying to understand the actual connection behavior.

Additionally, the existing comments for both `ConnectionTimeout` and `KeepAliveInterval` lack sufficient detail about their respective roles and how they interact during connection lifecycle management (TCP dial phase vs. post-connection liveness detection via Ping/Pong), making it difficult for users to properly tune reconnection behavior.

### Modifications

- **`pulsar/client.go`**: Fixed the stale `ConnectionTimeout` default value in the comment, and enhanced the GoDoc for both `ConnectionTimeout` and `KeepAliveInterval` to clarify their roles, default behaviors, and interaction during reconnection.
- **`pulsar/internal/helper.go`**: Added test helper functions to expose `connectionTimeout` and `keepAliveInterval` from the connection pool.
- **`pulsar/client_impl_test.go`**: Added unit tests to verify the default values of `ConnectionTimeout` (0) and `KeepAliveInterval` (30s).

### Verifying this change

This change added tests and can be verified as follows:

- Added `TestDefaultConnectionTimeout` to verify the default ConnectionTimeout is 0 (no application-level timeout).
- Added `TestDefaultKeepAliveInterval` to verify the default KeepAliveInterval is 30s.

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API: no
- The schema: no
- The default values of configurations: no
- The wire protocol: no

### Documentation

- Does this pull request introduce a new feature? no
