### PR TITLE
[Issue 1483] Fix `sync: WaitGroup is reused` panic in connection close path

### DIFF
--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -159,11 +159,17 @@ type connection struct {
 
 	log log.Logger
 
-	incomingRequestsWG sync.WaitGroup
-	incomingRequestsCh chan *request
-	closeCh            chan struct{}
-	readyCh            chan struct{}
-	writeRequestsCh    chan *dataRequest
+	// incomingRequestsWG tracks in-flight SendRequest/SendRequestNoWait
+	// callers. incomingRequestsLock serialises Add(1) with the Wait() in
+	// failLeftRequestsWhenClose so a late SendRequest cannot Add to a
+	// WaitGroup whose counter is already draining (which would trip
+	// "sync: WaitGroup is reused before previous Wait has returned").
+	incomingRequestsLock sync.RWMutex
+	incomingRequestsWG   sync.WaitGroup
+	incomingRequestsCh   chan *request
+	closeCh              chan struct{}
+	readyCh              chan struct{}
+	writeRequestsCh      chan *dataRequest
 
 	pendingLock sync.Mutex
 	pendingReqs map[uint64]*request
@@ -373,6 +379,14 @@ func (c *connection) waitUntilReady() error {
 }
 
 func (c *connection) failLeftRequestsWhenClose() {
+	// Stop new SendRequest/SendRequestNoWait callers from adding to the
+	// WaitGroup before draining the in-flight ones. Without this barrier,
+	// a concurrent Add(1) racing with Wait() reaching zero panics with
+	// "sync: WaitGroup is reused before previous Wait has returned".
+	c.incomingRequestsLock.Lock()
+	c.setStateClosed()
+	c.incomingRequestsLock.Unlock()
+
 	// wait for outstanding incoming requests to complete before draining
 	// and closing the channel
 	c.incomingRequestsWG.Wait()
@@ -656,33 +670,37 @@ func (c *connection) checkServerError(err *pb.ServerError) {
 
 func (c *connection) SendRequest(requestID uint64, req *pb.BaseCommand,
 	callback func(command *pb.BaseCommand, err error)) {
+	c.incomingRequestsLock.RLock()
+	if c.getState() == connectionClosed {
+		c.incomingRequestsLock.RUnlock()
+		callback(req, ErrConnectionClosed)
+		return
+	}
 	c.incomingRequestsWG.Add(1)
+	c.incomingRequestsLock.RUnlock()
 	defer c.incomingRequestsWG.Done()
 
-	if c.getState() == connectionClosed {
+	select {
+	case <-c.closeCh:
 		callback(req, ErrConnectionClosed)
 
-	} else {
-		select {
-		case <-c.closeCh:
-			callback(req, ErrConnectionClosed)
-
-		case c.incomingRequestsCh <- &request{
-			id:       &requestID,
-			cmd:      req,
-			callback: callback,
-		}:
-		}
+	case c.incomingRequestsCh <- &request{
+		id:       &requestID,
+		cmd:      req,
+		callback: callback,
+	}:
 	}
 }
 
 func (c *connection) SendRequestNoWait(req *pb.BaseCommand) error {
-	c.incomingRequestsWG.Add(1)
-	defer c.incomingRequestsWG.Done()
-
+	c.incomingRequestsLock.RLock()
 	if c.getState() == connectionClosed {
+		c.incomingRequestsLock.RUnlock()
 		return ErrConnectionClosed
 	}
+	c.incomingRequestsWG.Add(1)
+	c.incomingRequestsLock.RUnlock()
+	defer c.incomingRequestsWG.Done()
 
 	select {
 	case <-c.closeCh:


### PR DESCRIPTION
Fixes #1483.

### Motivation

`failLeftRequestsWhenClose` calls `c.incomingRequestsWG.Wait()` to drain in-flight `SendRequest` / `SendRequestNoWait` callers, but those callers do `incomingRequestsWG.Add(1)` *before* checking `c.getState() == connectionClosed`. A caller that started concurrently with the close path can therefore execute `Add(1)` at the exact moment `Wait()` is finishing draining to zero, which Go treats as a reuse violation:

```
panic: sync: WaitGroup is reused before previous Wait has returned
goroutine ...
sync.(*WaitGroup).Wait(...)
github.com/apache/pulsar-client-go/pulsar/internal.(*connection).failLeftRequestsWhenClose(...)
github.com/apache/pulsar-client-go/pulsar/internal.(*connection).run(...)
```

This is the production crash captured in #1483.

### Modifications

Add a `sync.RWMutex` (`incomingRequestsLock`) that gates the `Add(1)` so it cannot interleave with `Wait()`:

* `SendRequest` / `SendRequestNoWait` take **RLock**, check state, `Add(1)`, **RUnlock**. Multiple senders still proceed in parallel.
* `failLeftRequestsWhenClose` takes **Lock**, sets state=closed, **Unlocks**, then `Wait()`. The exclusive section guarantees:
  1. no in-flight `Add(1)` straddles the `Wait()`, and
  2. any caller arriving after this point sees `state == connectionClosed` and returns `ErrConnectionClosed` without touching the WaitGroup.

Inline comments in both call sites document why the lock is necessary so future contributors don't re-introduce the race.

### Verifying this change

- [x] `go build ./pulsar/internal/...` passes
- [x] `go vet ./pulsar/internal/...` passes
- [x] `go test -count=1 -short ./pulsar/internal/`, all internal tests still pass

### Documentation

- [x] `doc-not-needed` (bug fix in internal package; no public API change)