### PR TITLE
fix: add batchIdx to messageID.String() when batched message

### DIFF
--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -194,6 +194,9 @@ func (id *messageID) BatchSize() int32 {
 }
 
 func (id *messageID) String() string {
+	if id.batchIdx > -1 {
+		return fmt.Sprintf("%d:%d:%d:%d", id.ledgerID, id.entryID, id.partitionIdx, id.batchIdx)
+	}
 	return fmt.Sprintf("%d:%d:%d", id.ledgerID, id.entryID, id.partitionIdx)
 }
 

--- a/pulsar/impl_message_test.go
+++ b/pulsar/impl_message_test.go
@@ -129,3 +129,15 @@ func TestAckingMessageIDBatchTwo(t *testing.T) {
 	assert.Equal(t, true, ids[0].ack())
 	assert.Equal(t, true, tracker.completed())
 }
+
+func TestMessageStringOnMessage(t *testing.T) {
+	id := newMessageID(1, 2, -1, 4, 0)
+
+	assert.Equal(t, "1:2:4", id.String())
+}
+
+func TestMessageStringOnBatchMessage(t *testing.T) {
+	id := newMessageID(1, 2, 3, 4, 5)
+
+	assert.Equal(t, "1:2:4:3", id.String())
+}

--- a/pulsaradmin/pkg/admin/subscription_test.go
+++ b/pulsaradmin/pkg/admin/subscription_test.go
@@ -64,24 +64,28 @@ func TestGetMessagesByID(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(numberMessages)
-	messageIDMap := make(map[string]int32)
+	// Group by ledger:entry (ignoring batchIdx) to count batch sizes
+	type ledgerEntry struct {
+		LedgerID int64
+		EntryID  int64
+	}
+	messageIDMap := make(map[ledgerEntry]int32)
 	for i := 0; i <= numberMessages; i++ {
 		producer.SendAsync(ctx, &pulsar.ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
 		}, func(id pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
 			assert.Nil(t, err)
-			messageIDMap[id.String()]++
+			key := ledgerEntry{LedgerID: id.LedgerID(), EntryID: id.EntryID()}
+			messageIDMap[key]++
 			wg.Done()
 		})
 	}
 	wg.Wait()
 	topicName, err := utils.GetTopicName(topic)
 	assert.NoError(t, err)
-	for id, i := range messageIDMap {
+	for key, i := range messageIDMap {
 		assert.Equal(t, i, int32(batchingMaxMessages))
-		messageID, err := utils.ParseMessageID(id)
-		assert.Nil(t, err)
-		messages, err := admin.Subscriptions().GetMessagesByID(*topicName, messageID.LedgerID, messageID.EntryID)
+		messages, err := admin.Subscriptions().GetMessagesByID(*topicName, key.LedgerID, key.EntryID)
 		assert.Nil(t, err)
 		assert.Equal(t, batchingMaxMessages, len(messages))
 	}


### PR DESCRIPTION
### Motivation

MessageID contains a batchIdx that is being skipped on String(), adding the same functionality as in java - BatchMessageIdImpl overrides the toString() to add the batchId

### Modifications

add batchIdx if > -1

### Verifying this change

- [x] Make sure that the change passes the CI checks.

  - *Extended unit test*
  - check https://github.com/adrianiacobghiula/pulsar-client-go/actions/runs/25611371370

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
