### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/oauth2/oidc_endpoint_provider.go
+++ b/oauth2/oidc_endpoint_provider.go
@@ -40,6 +40,17 @@ func GetOIDCWellKnownEndpointsFromIssuerURL(issuerURL string) (*OIDCWellKnownEnd
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse issuer url to build well known endpoints")
 	}
+
+	// Validate URL scheme - only allow HTTPS to prevent SSRF attacks
+	if u.Scheme != "https" {
+		return nil, errors.New("issuer URL must use HTTPS scheme")
+	}
+
+	// Validate host is not empty
+	if u.Host == "" {
+		return nil, errors.New("issuer URL must have a host")
+	}
+
 	u.Path = path.Join(u.Path, ".well-known/openid-configuration")
 
 	r, err := http.Get(u.String())

--- a/pulsar/negative_backoff_policy.go
+++ b/pulsar/negative_backoff_policy.go
@@ -41,11 +41,10 @@ func (nbp *defaultNackBackoffPolicy) Next(redeliveryCount uint32) time.Duration 
 	minNackTime := 1 * time.Second  // 1sec
 	maxNackTime := 10 * time.Minute // 10min
 
-	backoff := float64(minNackTime << redeliveryCount)
-	if backoff == 0 {
-		// Overflow so we assign the maximum value of the backoff.
-		backoff = float64(maxNackTime)
+	if redeliveryCount >= 63 {
+		return maxNackTime
 	}
 
+	backoff := float64(minNackTime << redeliveryCount)
 	return time.Duration(math.Min(backoff, float64(maxNackTime)))
 }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `pulsar/negative_backoff_policy.go:L30`

In pulsar/negative_backoff_policy.go, the backoff calculation uses bit shift (minNackTime << redeliveryCount) which can overflow when redeliveryCount is large. The overflow causes backoff to become 0, resulting in immediate retry without any delay, potentially causing a denial of service.

## Solution

Add overflow check before the shift operation: if redeliveryCount >= 63 { return maxNackTime }. Also consider using math.Min with a pre-computed maximum to avoid the overflow entirely.

## Changes

- `pulsar/negative_backoff_policy.go` (modified)
- `oauth2/oidc_endpoint_provider.go` (modified)