### PR TITLE
fix: avoid infinite retry in blue-green migration test

### DIFF
--- a/pulsar/blue_green_migration_test.go
+++ b/pulsar/blue_green_migration_test.go
@@ -21,6 +21,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -148,6 +149,7 @@ func testTopicMigrate(
 	// Signals both producer and consumer have processed `messageCountBeforeUnload` messages
 	wgSendAndReceiveMessages := sync.WaitGroup{}
 	wgSendAndReceiveMessages.Add(2)
+	errCh := make(chan error, 1)
 
 	// Producer
 	go func() {
@@ -159,6 +161,7 @@ func testTopicMigrate(
 			}
 
 			pm := ProducerMessage{Payload: []byte(fmt.Sprintf("hello-%d", i))}
+			retryStarted := time.Now()
 
 			for true {
 				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -166,6 +169,20 @@ func testTopicMigrate(
 				cancel()
 				if err == nil {
 					break
+				}
+				if errors.Is(err, ErrTopicTerminated) || errors.Is(err, ErrProducerClosed) {
+					select {
+					case errCh <- fmt.Errorf("producer became terminal during migration at message %d: %w", i, err):
+					default:
+					}
+					return
+				}
+				if time.Since(retryStarted) > 30*time.Second {
+					select {
+					case errCh <- fmt.Errorf("producer send retry exceeded 30s at message %d: %w", i, err):
+					default:
+					}
+					return
 				}
 				time.Sleep(1000 * time.Millisecond)
 			}
@@ -185,6 +202,7 @@ func testTopicMigrate(
 				wgUnload.Wait()
 			}
 
+			retryStarted := time.Now()
 			for true {
 				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 				m, err := consumer.Receive(ctx)
@@ -194,6 +212,13 @@ func testTopicMigrate(
 					if err == nil {
 						break
 					}
+				}
+				if time.Since(retryStarted) > 30*time.Second {
+					select {
+					case errCh <- fmt.Errorf("consumer receive/ack retry exceeded 30s at message %d: %w", i, err):
+					default:
+					}
+					return
 				}
 				time.Sleep(100 * time.Millisecond)
 			}
@@ -205,7 +230,27 @@ func testTopicMigrate(
 	}()
 
 	// Unload the bundle, triggering the producers and consumers to reconnect to the specified broker.
-	wgSendAndReceiveMessages.Wait()
+	waitWithError := func(wg *sync.WaitGroup, stage string) bool {
+		doneCh := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(doneCh)
+		}()
+
+		select {
+		case <-doneCh:
+			return true
+		case err := <-errCh:
+			req.NoError(err, stage)
+			return false
+		case <-time.After(90 * time.Second):
+			req.FailNow(stage + " timeout")
+			return false
+		}
+	}
+	if !waitWithError(&wgSendAndReceiveMessages, "waiting for pre-unload send/receive") {
+		return
+	}
 
 	topicMigrationURL = fmt.Sprintf(
 		"/admin/v2/clusters/%s/migrate?migrated=true", cluster)
@@ -248,5 +293,7 @@ func testTopicMigrate(
 		return req.Equal(dstTopicBrokerURL, topicBrokerURL)
 	})
 
-	wgRoutines.Wait()
+	if !waitWithError(&wgRoutines, "waiting for producer/consumer routines") {
+		return
+	}
 }

--- a/pulsar/blue_green_migration_test.go
+++ b/pulsar/blue_green_migration_test.go
@@ -164,9 +164,12 @@ func testTopicMigrate(
 			retryStarted := time.Now()
 
 			for true {
-				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-				_, err := producer.Send(ctx, &pm)
-				cancel()
+				err := func() error {
+					ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+					defer cancel()
+					_, err := producer.Send(ctx, &pm)
+					return err
+				}
 				if err == nil {
 					break
 				}

--- a/pulsar/blue_green_migration_test.go
+++ b/pulsar/blue_green_migration_test.go
@@ -162,8 +162,8 @@ func testTopicMigrate(
 
 			for true {
 				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-				defer cancel()
 				_, err := producer.Send(ctx, &pm)
+				cancel()
 				if err == nil {
 					break
 				}
@@ -187,8 +187,8 @@ func testTopicMigrate(
 
 			for true {
 				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-				defer cancel()
 				m, err := consumer.Receive(ctx)
+				cancel()
 				if err == nil {
 					err = consumer.Ack(m)
 					if err == nil {

--- a/pulsar/blue_green_migration_test.go
+++ b/pulsar/blue_green_migration_test.go
@@ -169,7 +169,7 @@ func testTopicMigrate(
 					defer cancel()
 					_, err := producer.Send(ctx, &pm)
 					return err
-				}
+				}()
 				if err == nil {
 					break
 				}
@@ -242,6 +242,12 @@ func testTopicMigrate(
 
 		select {
 		case <-doneCh:
+			select {
+			case err := <-errCh:
+				req.NoError(err, stage)
+				return false
+			default:
+			}
 			return true
 		case err := <-errCh:
 			req.NoError(err, stage)


### PR DESCRIPTION
### Motivation

The extensible-load-manager CI job timed out in TestBlueGreenMigrationTestSuite/TestTopicMigration/proxyConnection after 5 minutes.

From the stack and logs, the test was stuck waiting on WaitGroup while producer/consumer goroutines were still looping in retry paths. During migration, producer can enter terminal states (for example TopicTerminated or ProducerClosed), but the test retry loops had no terminal-exit logic, causing effectively unbounded retries and suite timeout.

### Modifications

- Add terminal error handling in producer send retry loop:
  - if error is ErrTopicTerminated or ErrProducerClosed, fail fast instead of retrying forever.
- Add bounded retry windows for both producer and consumer loops (30 seconds per message stage).
- Add an error channel and stage-level wait helper around WaitGroup waits to fail early on goroutine errors.
- Add stage timeout protection while waiting for:
  - pre-unload send/receive synchronization
  - producer/consumer goroutine completion
- Keep per-iteration context cancellation immediate (cancel after each send/receive attempt).

These changes make the test deterministic under migration failures and prevent hanging until global test timeout.
