### PR TITLE
fix: remove default case in waitWithContext to prevent busy-spin deadlock

### DIFF
--- a/pulsar/internal/channel_cond.go
+++ b/pulsar/internal/channel_cond.go
@@ -47,6 +47,7 @@ func (c *chCond) wait() {
 }
 
 // waitWithContext Same as wait() call, but the end condition can also be controlled through the context.
+// It blocks until either a broadcast occurs or the context is done.
 func (c *chCond) waitWithContext(ctx context.Context) bool {
 	n := c.notifyChan()
 	c.L.Unlock()
@@ -56,8 +57,6 @@ func (c *chCond) waitWithContext(ctx context.Context) bool {
 		return true
 	case <-ctx.Done():
 		return false
-	default:
-		return true
 	}
 }
 

--- a/pulsar/internal/channel_cond_test.go
+++ b/pulsar/internal/channel_cond_test.go
@@ -53,3 +53,38 @@ func TestChCondWithContext(_ *testing.T) {
 	cancel()
 	wg.Wait()
 }
+
+func TestChCondWithContextBlocks(t *testing.T) {
+	// Verify that waitWithContext actually blocks (does not return via a default case)
+	// until either a broadcast or context cancellation occurs.
+	cond := newCond(&sync.Mutex{})
+	started := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		cond.L.Lock()
+		close(started)
+		cond.waitWithContext(context.Background())
+		cond.L.Unlock()
+		close(done)
+	}()
+
+	<-started
+	// Give the goroutine time to enter the select. If there were a default case,
+	// it would return immediately and close done before the broadcast below.
+	time.Sleep(20 * time.Millisecond)
+
+	select {
+	case <-done:
+		t.Fatal("waitWithContext returned before broadcast — default case must have fired")
+	default:
+	}
+
+	cond.broadcast()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitWithContext did not unblock after broadcast")
+	}
+}


### PR DESCRIPTION
Fixes #1455

### Motivation

When the memory limit is exhausted, `ReserveMemory()` enters a loop that calls `waitWithContext()` to block until memory is released. However, `waitWithContext()` contained a `default` branch in its `select` statement that caused it to **return immediately without ever blocking**:

```go
select {
case <-n:
    return true
case <-ctx.Done():
    return false
default:
    return true  // ← always fires, never waits
}
```


1. Consumer messages fill the shared memory limit via `ForceReserveMemory`
2. App goroutines processing those messages call `producer.Send()` (blocking mode)
3. `ReserveMemory()` spins at 100% CPU, never sleeping
4. Since all processing goroutines are stuck spinning, no messages are ever acked — consumer memory is never released
5. `TryReserveMemory` keeps failing → the spin loop never exits

This matches the reported symptoms exactly: **apparent deadlock with very high CPU usage**.

### Modifications

- **`pulsar/internal/channel_cond.go`**: Remove the `default` branch from `waitWithContext()`. The function now properly blocks on the channel until either `ReleaseMemory()` triggers a broadcast (memory freed) or the context is cancelled. This converts the busy-spin into a correct condition-variable wait — goroutines sleep while memory is exhausted and wake up only when memory becomes available.

- **`pulsar/internal/channel_cond_test.go`**: Add `TestChCondWithContextBlocks` to explicitly verify that `waitWithContext` actually blocks and does not return via a `default` case, preventing regression.