### PR TITLE
fix: escape configuration values in UpdateDynamicConfiguration

### DIFF
--- a/pulsaradmin/pkg/admin/admin.go
+++ b/pulsaradmin/pkg/admin/admin.go
@@ -112,8 +112,3 @@ func (c *pulsarClient) endpoint(componentPath string, parts ...string) string {
 		path.Join(escapedParts...),
 	)
 }
-
-// this function won't do any escaping
-func (c *pulsarClient) endpointWithFullPath(componentPath string, fullPath string) string {
-	return path.Join(utils.MakeHTTPPath(c.APIVersion.String(), componentPath), fullPath)
-}

--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -20,6 +20,8 @@ package admin
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
@@ -187,9 +189,25 @@ func (b *broker) UpdateDynamicConfiguration(configName, configValue string) erro
 }
 
 func (b *broker) UpdateDynamicConfigurationWithContext(ctx context.Context, configName, configValue string) error {
-	value := fmt.Sprintf("/configuration/%s/%s", configName, configValue)
-	endpoint := b.pulsar.endpointWithFullPath(b.basePath, value)
-	return b.pulsar.Client.PostWithContext(ctx, endpoint, nil)
+	escapedConfigPath := fmt.Sprintf(
+		"/configuration/%s/%s",
+		url.PathEscape(configName),
+		url.PathEscape(configValue),
+	)
+	escapedEndpoint := b.pulsar.endpointWithFullPath(b.basePath, escapedConfigPath)
+
+	// Build the URL from the escaped string so url.Parse derives a matching Path and RawPath.
+	// The regular newRequest path decodes escaped path segments and would turn %2F back into '/'.
+	requestURL, err := url.Parse(strings.TrimRight(b.pulsar.Client.ServiceURL, "/") + escapedEndpoint)
+	if err != nil {
+		return err
+	}
+	resp, err := b.pulsar.Client.MakeRequestWithURLWithContext(ctx, http.MethodPost, requestURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
 }
 
 func (b *broker) DeleteDynamicConfiguration(configName string) error {

--- a/pulsaradmin/pkg/admin/brokers.go
+++ b/pulsaradmin/pkg/admin/brokers.go
@@ -194,7 +194,8 @@ func (b *broker) UpdateDynamicConfigurationWithContext(ctx context.Context, conf
 		url.PathEscape(configName),
 		url.PathEscape(configValue),
 	)
-	escapedEndpoint := b.pulsar.endpointWithFullPath(b.basePath, escapedConfigPath)
+	adminPath := strings.TrimRight(utils.MakeHTTPPath(b.pulsar.APIVersion.String(), b.basePath), "/")
+	escapedEndpoint := adminPath + escapedConfigPath
 
 	// Build the URL from the escaped string so url.Parse derives a matching Path and RawPath.
 	// The regular newRequest path decodes escaped path segments and would turn %2F back into '/'.

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -107,6 +107,28 @@ func TestUpdateDynamicConfiguration(t *testing.T) {
 	assert.NotEmpty(t, configurations)
 }
 
+func TestUpdateDynamicConfigurationEscapedValueE2E(t *testing.T) {
+	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
+	require.NoError(t, err)
+	cfg := &config.Config{
+		Token: string(readFile),
+	}
+	admin, err := New(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+	t.Cleanup(func() {
+		assert.NoError(t, admin.Brokers().DeleteDynamicConfiguration("loadBalancerSheddingExcludedNamespaces"))
+	})
+
+	err = admin.Brokers().UpdateDynamicConfiguration("loadBalancerSheddingExcludedNamespaces", "my-tenant/my-namespace")
+	require.NoError(t, err)
+
+	configurations, err := admin.Brokers().GetAllDynamicConfigurations()
+	require.NoError(t, err)
+	require.NotEmpty(t, configurations)
+	assert.Equal(t, "my-tenant/my-namespace", configurations["loadBalancerSheddingExcludedNamespaces"])
+}
+
 func TestUpdateDynamicConfigurationEscapesConfigValue(t *testing.T) {
 	admin := &pulsarClient{
 		APIVersion: config.V2,
@@ -117,7 +139,7 @@ func TestUpdateDynamicConfigurationEscapesConfigValue(t *testing.T) {
 					require.Equal(t, http.MethodPost, r.Method)
 					require.Equal(
 						t,
-						"/admin/v2/brokers/configuration/testConfigName/public%2Fdefault",
+						"/admin/v2/brokers/configuration/loadBalancerSheddingExcludedNamespaces/my-tenant%2Fmy-namespace",
 						r.URL.EscapedPath(),
 					)
 					return &http.Response{
@@ -131,7 +153,7 @@ func TestUpdateDynamicConfigurationEscapesConfigValue(t *testing.T) {
 		},
 	}
 
-	err := admin.Brokers().UpdateDynamicConfiguration("testConfigName", "public/default")
+	err := admin.Brokers().UpdateDynamicConfiguration("loadBalancerSheddingExcludedNamespaces", "my-tenant/my-namespace")
 	require.NoError(t, err)
 }
 

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -157,6 +157,34 @@ func TestUpdateDynamicConfigurationEscapesConfigValue(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUpdateDynamicConfigurationDoesNotCleanConfigPath(t *testing.T) {
+	admin := &pulsarClient{
+		APIVersion: config.V2,
+		Client: &rest.Client{
+			ServiceURL: "http://example.com",
+			HTTPClient: &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					require.Equal(t, http.MethodPost, r.Method)
+					require.Equal(
+						t,
+						"/admin/v2/brokers/configuration/loadBalancerSheddingExcludedNamespaces/..",
+						r.URL.EscapedPath(),
+					)
+					return &http.Response{
+						StatusCode: http.StatusNoContent,
+						Body:       io.NopCloser(strings.NewReader("")),
+						Header:     make(http.Header),
+						Request:    r,
+					}, nil
+				}),
+			},
+		},
+	}
+
+	err := admin.Brokers().UpdateDynamicConfiguration("loadBalancerSheddingExcludedNamespaces", "..")
+	require.NoError(t, err)
+}
+
 func TestUpdateDynamicConfigurationWithCustomURL(t *testing.T) {
 	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
 	assert.NoError(t, err)

--- a/pulsaradmin/pkg/admin/brokers_test.go
+++ b/pulsaradmin/pkg/admin/brokers_test.go
@@ -20,9 +20,11 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/auth"
@@ -30,7 +32,14 @@ import (
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestBrokerHealthCheckWithTopicVersion(t *testing.T) {
 	readFile, err := os.ReadFile("../../../integration-tests/tokens/admin-token")
@@ -96,6 +105,34 @@ func TestUpdateDynamicConfiguration(t *testing.T) {
 	configurations, err := admin.Brokers().GetDynamicConfigurationNames()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, configurations)
+}
+
+func TestUpdateDynamicConfigurationEscapesConfigValue(t *testing.T) {
+	admin := &pulsarClient{
+		APIVersion: config.V2,
+		Client: &rest.Client{
+			ServiceURL: "http://example.com",
+			HTTPClient: &http.Client{
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					require.Equal(t, http.MethodPost, r.Method)
+					require.Equal(
+						t,
+						"/admin/v2/brokers/configuration/testConfigName/public%2Fdefault",
+						r.URL.EscapedPath(),
+					)
+					return &http.Response{
+						StatusCode: http.StatusNoContent,
+						Body:       io.NopCloser(strings.NewReader("")),
+						Header:     make(http.Header),
+						Request:    r,
+					}, nil
+				}),
+			},
+		},
+	}
+
+	err := admin.Brokers().UpdateDynamicConfiguration("testConfigName", "public/default")
+	require.NoError(t, err)
 }
 
 func TestUpdateDynamicConfigurationWithCustomURL(t *testing.T) {


### PR DESCRIPTION
### Motivation

`UpdateDynamicConfiguration` build  `configValue` directly into the URL path. If either value contains path-reserved characters such as `/`, the request path can be interpreted incorrectly.

### Modifications

Escape `configValue` as URL path segments with `url.PathEscape`, and preserve escaped path values in the REST client request construction. Added tests to verify escaped slashes are kept in the final request path.
