### PR TITLE
[improve][client] Implement tls_client_auth for OAuth2

### DIFF
--- a/oauth2/authorization_tokenretriever.go
+++ b/oauth2/authorization_tokenretriever.go
@@ -73,6 +73,7 @@ type ClientCredentialsExchangeRequest struct {
 	ClientSecret  string
 	Audience      string
 	Scopes        []string
+	AuthMethod    string
 }
 
 // DeviceCodeExchangeRequest is used to request the exchange of
@@ -193,10 +194,17 @@ func (ce *TokenRetriever) newRefreshTokenRequest(req RefreshTokenExchangeRequest
 // newClientCredentialsRequest builds a new ClientCredentialsExchangeRequest wrapped in an
 // http.Request
 func (ce *TokenRetriever) newClientCredentialsRequest(req ClientCredentialsExchangeRequest) (*http.Request, error) {
+	authMethod, err := normalizeTokenEndpointAuthMethod(req.AuthMethod)
+	if err != nil {
+		return nil, err
+	}
+
 	uv := url.Values{}
 	uv.Set("grant_type", "client_credentials")
 	uv.Set("client_id", req.ClientID)
-	uv.Set("client_secret", req.ClientSecret)
+	if authMethod == TokenEndpointAuthMethodClientSecretPost {
+		uv.Set("client_secret", req.ClientSecret)
+	}
 	if len(req.Scopes) > 0 {
 		uv.Set("scope", strings.Join(req.Scopes, " "))
 	}

--- a/oauth2/authorization_tokenretriever_test.go
+++ b/oauth2/authorization_tokenretriever_test.go
@@ -198,6 +198,31 @@ var _ = ginkgo.Describe("CodetokenExchanger", func() {
 			gomega.Expect(result.Header.Get("Content-Length")).To(gomega.Equal("93"))
 		})
 
+		ginkgo.It("omits client secret for tls client auth", func() {
+			tokenRetriever := TokenRetriever{}
+			exchangeRequest := ClientCredentialsExchangeRequest{
+				TokenEndpoint: "https://issuer/oauth/token",
+				ClientID:      "clientID",
+				ClientSecret:  "clientSecret",
+				Audience:      "audience",
+				AuthMethod:    TokenEndpointAuthMethodTLSClientAuth,
+			}
+
+			result, err := tokenRetriever.newClientCredentialsRequest(exchangeRequest)
+
+			result.ParseForm()
+
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(result.FormValue("grant_type")).To(gomega.Equal("client_credentials"))
+			gomega.Expect(result.FormValue("client_id")).To(gomega.Equal("clientID"))
+			gomega.Expect(result.FormValue("client_secret")).To(gomega.Equal(""))
+			gomega.Expect(result.FormValue("audience")).To(gomega.Equal("audience"))
+			gomega.Expect(result.URL.String()).To(gomega.Equal("https://issuer/oauth/token"))
+
+			gomega.Expect(result.Header.Get("Content-Type")).To(gomega.Equal("application/x-www-form-urlencoded"))
+			gomega.Expect(result.Header.Get("Content-Length")).To(gomega.Equal("66"))
+		})
+
 		ginkgo.It("returns an error when NewRequest returns an error", func() {
 			tokenRetriever := TokenRetriever{}
 

--- a/oauth2/client_credentials_flow.go
+++ b/oauth2/client_credentials_flow.go
@@ -287,7 +287,10 @@ type ClientCredentialsGrantRefresher struct {
 	authMethod string
 }
 
-func NewDefaultClientCredentialsGrantRefresher(clock clock.Clock, options ClientCredentialsFlowOptions) (*ClientCredentialsGrantRefresher, error) {
+func NewDefaultClientCredentialsGrantRefresher(
+	clock clock.Clock,
+	options ClientCredentialsFlowOptions,
+) (*ClientCredentialsGrantRefresher, error) {
 	authMethod, err := normalizeTokenEndpointAuthMethod(options.TokenEndpointAuthMethod)
 	if err != nil {
 		return nil, err

--- a/oauth2/client_credentials_flow.go
+++ b/oauth2/client_credentials_flow.go
@@ -18,8 +18,10 @@
 package oauth2
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"net/http"
-
+	"os"
 	"strings"
 
 	"github.com/apache/pulsar-client-go/oauth2/clock"
@@ -51,14 +53,32 @@ type GrantProvider interface {
 	GetGrant(audience string, options *ClientCredentialsFlowOptions) (*AuthorizationGrant, error)
 }
 
+const (
+	TokenEndpointAuthMethodClientSecretPost = "client_secret_post"
+	TokenEndpointAuthMethodTLSClientAuth    = "tls_client_auth"
+	defaultTLSClientID                      = "pulsar-client"
+)
+
+// ClientCredentialsFlowOptions configures OAuth 2.0 client credentials authentication.
+//
+// TokenEndpointAuthMethod defaults to client_secret_post.
+// Required parameters:
+//   - client_secret_post: KeyFile
+//   - tls_client_auth: IssuerURL, TLSCertFile, TLSKeyFile
 type ClientCredentialsFlowOptions struct {
-	KeyFile          string
-	IssuerURL        string
-	AdditionalScopes []string
+	KeyFile                 string
+	ClientID                string
+	IssuerURL               string
+	AdditionalScopes        []string
+	TokenEndpointAuthMethod string
+	TLSCertFile             string
+	TLSKeyFile              string
+	TrustCertsFilePath      string
 }
 
 // DefaultGrantProvider provides authorization grants by loading credentials from a key file
 type DefaultGrantProvider struct {
+	oidcClient *http.Client
 }
 
 // GetGrant creates an authorization grant by loading credentials from the key file and
@@ -68,6 +88,36 @@ func (p *DefaultGrantProvider) GetGrant(audience string, options *ClientCredenti
 	if options == nil {
 		return nil, errors.New("client credentials flow options cannot be nil")
 	}
+
+	authMethod, err := normalizeTokenEndpointAuthMethod(options.TokenEndpointAuthMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	if authMethod == TokenEndpointAuthMethodTLSClientAuth {
+		if options.IssuerURL == "" {
+			return nil, errors.New("issuer url is required for client credentials flow")
+		}
+
+		wellKnownEndpoints, err := GetOIDCWellKnownEndpointsFromIssuerURLWithClient(options.IssuerURL, p.oidcClient)
+		if err != nil {
+			return nil, err
+		}
+
+		clientID := options.ClientID
+		if clientID == "" {
+			clientID = defaultTLSClientID
+		}
+
+		return &AuthorizationGrant{
+			Type:          GrantTypeClientCredentials,
+			Audience:      audience,
+			ClientID:      clientID,
+			TokenEndpoint: wellKnownEndpoints.TokenEndpoint,
+			Scopes:        normalizeScopes(options.AdditionalScopes),
+		}, nil
+	}
+
 	credsProvider := NewClientCredentialsProviderFromKeyFile(options.KeyFile)
 	keyFile, err := credsProvider.GetClientCredentials()
 	if err != nil {
@@ -82,15 +132,12 @@ func (p *DefaultGrantProvider) GetGrant(audience string, options *ClientCredenti
 		return nil, errors.New("issuer url is required for client credentials flow")
 	}
 
-	wellKnownEndpoints, err := GetOIDCWellKnownEndpointsFromIssuerURL(issuerURL)
+	wellKnownEndpoints, err := GetOIDCWellKnownEndpointsFromIssuerURLWithClient(issuerURL, p.oidcClient)
 	if err != nil {
 		return nil, err
 	}
 	// Merge the scopes of the options AdditionalScopes with the scopes read from the keyFile config
-	var scopesToAdd []string
-	if len(options.AdditionalScopes) > 0 {
-		scopesToAdd = append(scopesToAdd, options.AdditionalScopes...)
-	}
+	scopesToAdd := normalizeScopes(options.AdditionalScopes)
 
 	if keyFile.Scope != "" {
 		scopesSplit := strings.Fields(keyFile.Scope)
@@ -120,15 +167,96 @@ func newClientCredentialsFlow(
 	}
 }
 
+func normalizeScopes(scopes []string) []string {
+	filtered := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		if scope != "" {
+			filtered = append(filtered, scope)
+		}
+	}
+	return filtered
+}
+
+func normalizeTokenEndpointAuthMethod(method string) (string, error) {
+	if method == "" {
+		return TokenEndpointAuthMethodClientSecretPost, nil
+	}
+
+	switch method {
+	case TokenEndpointAuthMethodClientSecretPost, TokenEndpointAuthMethodTLSClientAuth:
+		return method, nil
+	default:
+		return "", errors.Errorf("unsupported token endpoint auth method: %s", method)
+	}
+}
+
+func newClientCredentialsHTTPClient(options ClientCredentialsFlowOptions) (*http.Client, error) {
+	authMethod, err := normalizeTokenEndpointAuthMethod(options.TokenEndpointAuthMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	} else {
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	}
+
+	if options.TrustCertsFilePath != "" {
+		rootCA, err := os.ReadFile(options.TrustCertsFilePath)
+		if err != nil {
+			return nil, err
+		}
+		transport.TLSClientConfig.RootCAs = x509.NewCertPool()
+		transport.TLSClientConfig.RootCAs.AppendCertsFromPEM(rootCA)
+	}
+
+	hasTLSCertFile := options.TLSCertFile != ""
+	hasTLSKeyFile := options.TLSKeyFile != ""
+	if hasTLSCertFile != hasTLSKeyFile {
+		return nil, errors.New("tlsCertFile and tlsKeyFile must be specified together")
+	}
+
+	if authMethod == TokenEndpointAuthMethodTLSClientAuth && !hasTLSCertFile {
+		return nil, errors.New("tlsCertFile and tlsKeyFile are required for tls_client_auth")
+	}
+
+	if hasTLSCertFile {
+		if _, err := tls.LoadX509KeyPair(options.TLSCertFile, options.TLSKeyFile); err != nil {
+			return nil, err
+		}
+
+		transport.TLSClientConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(options.TLSCertFile, options.TLSKeyFile)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		}
+	}
+
+	return &http.Client{Transport: transport}, nil
+}
+
 // NewDefaultClientCredentialsFlow provides an easy way to build up a default
 // client credentials flow with all the correct configuration.
 func NewDefaultClientCredentialsFlow(options ClientCredentialsFlowOptions) (*ClientCredentialsFlow, error) {
+	authMethod, err := normalizeTokenEndpointAuthMethod(options.TokenEndpointAuthMethod)
+	if err != nil {
+		return nil, err
+	}
+	options.TokenEndpointAuthMethod = authMethod
 
-	tokenRetriever := NewTokenRetriever(&http.Client{})
+	httpClient, err := newClientCredentialsHTTPClient(options)
+	if err != nil {
+		return nil, err
+	}
+	tokenRetriever := NewTokenRetriever(httpClient)
 	return newClientCredentialsFlow(
 		options,
 		tokenRetriever,
-		&DefaultGrantProvider{},
+		&DefaultGrantProvider{oidcClient: httpClient},
 		clock.RealClock{}), nil
 }
 
@@ -142,8 +270,9 @@ func (c *ClientCredentialsFlow) Authorize(audience string) (*AuthorizationGrant,
 
 	// test the credentials and obtain an initial access token
 	refresher := &ClientCredentialsGrantRefresher{
-		exchanger: c.exchanger,
-		clock:     c.clock,
+		exchanger:  c.exchanger,
+		clock:      c.clock,
+		authMethod: c.options.TokenEndpointAuthMethod,
 	}
 	grant, err = refresher.Refresh(grant)
 	if err != nil {
@@ -153,15 +282,28 @@ func (c *ClientCredentialsFlow) Authorize(audience string) (*AuthorizationGrant,
 }
 
 type ClientCredentialsGrantRefresher struct {
-	exchanger ClientCredentialsExchanger
-	clock     clock.Clock
+	exchanger  ClientCredentialsExchanger
+	clock      clock.Clock
+	authMethod string
 }
 
-func NewDefaultClientCredentialsGrantRefresher(clock clock.Clock) (*ClientCredentialsGrantRefresher, error) {
-	tokenRetriever := NewTokenRetriever(&http.Client{})
+func NewDefaultClientCredentialsGrantRefresher(clock clock.Clock, options ClientCredentialsFlowOptions) (*ClientCredentialsGrantRefresher, error) {
+	authMethod, err := normalizeTokenEndpointAuthMethod(options.TokenEndpointAuthMethod)
+	if err != nil {
+		return nil, err
+	}
+	options.TokenEndpointAuthMethod = authMethod
+
+	httpClient, err := newClientCredentialsHTTPClient(options)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenRetriever := NewTokenRetriever(httpClient)
 	return &ClientCredentialsGrantRefresher{
-		exchanger: tokenRetriever,
-		clock:     clock,
+		exchanger:  tokenRetriever,
+		clock:      clock,
+		authMethod: authMethod,
 	}, nil
 }
 
@@ -171,13 +313,31 @@ func (g *ClientCredentialsGrantRefresher) Refresh(grant *AuthorizationGrant) (*A
 	if grant.Type != GrantTypeClientCredentials {
 		return nil, errors.New("unsupported grant type")
 	}
+	authMethod := g.authMethod
+	if authMethod == "" {
+		if grant.ClientCredentials == nil {
+			authMethod = TokenEndpointAuthMethodTLSClientAuth
+		} else {
+			authMethod = TokenEndpointAuthMethodClientSecretPost
+		}
+	}
+
+	clientID := grant.ClientID
+	clientSecret := ""
+	if grant.ClientCredentials != nil {
+		if clientID == "" {
+			clientID = grant.ClientCredentials.ClientID
+		}
+		clientSecret = grant.ClientCredentials.ClientSecret
+	}
 
 	exchangeRequest := ClientCredentialsExchangeRequest{
 		TokenEndpoint: grant.TokenEndpoint,
 		Audience:      grant.Audience,
-		ClientID:      grant.ClientCredentials.ClientID,
-		ClientSecret:  grant.ClientCredentials.ClientSecret,
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
 		Scopes:        grant.Scopes,
+		AuthMethod:    authMethod,
 	}
 	tr, err := g.exchanger.ExchangeClientCredentials(exchangeRequest)
 	if err != nil {

--- a/oauth2/client_credentials_flow_test.go
+++ b/oauth2/client_credentials_flow_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/apache/pulsar-client-go/oauth2/clock"
@@ -44,6 +45,17 @@ func (m *MockClientCredentialsProvider) GetClientCredentials() (*KeyFile, error)
 
 var _ ClientCredentialsProvider = &MockClientCredentialsProvider{}
 
+type StaticGrantProvider struct {
+	Grant *AuthorizationGrant
+	Error error
+}
+
+func (s *StaticGrantProvider) GetGrant(_ string, _ *ClientCredentialsFlowOptions) (*AuthorizationGrant, error) {
+	return s.Grant, s.Error
+}
+
+var _ GrantProvider = &StaticGrantProvider{}
+
 var clientCredentials = KeyFile{
 	Type:         "resource",
 	ClientID:     "test_clientID",
@@ -51,6 +63,10 @@ var clientCredentials = KeyFile{
 	ClientEmail:  "test_clientEmail",
 	IssuerURL:    "http://issuer",
 	Scope:        "test_scope",
+}
+
+func oauth2TestCertPath(name string) string {
+	return filepath.Join("..", "integration-tests", "certs", name)
 }
 
 func mockWellKnownServer(tokenEndpoint string) *httptest.Server {
@@ -140,6 +156,66 @@ var _ = ginkgo.Describe("ClientCredentialsFlow", func() {
 				ClientSecret:  clientCredentials.ClientSecret,
 				Audience:      "test_audience",
 				Scopes:        []string{clientCredentials.Scope},
+				AuthMethod:    TokenEndpointAuthMethodClientSecretPost,
+			}))
+		})
+
+		ginkgo.It("passes tls client auth to the token exchanger without key file credentials", func() {
+			provider := newClientCredentialsFlow(
+				ClientCredentialsFlowOptions{
+					ClientID:                defaultTLSClientID,
+					TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+				},
+				mockTokenExchanger,
+				&StaticGrantProvider{
+					Grant: &AuthorizationGrant{
+						Type:          GrantTypeClientCredentials,
+						Audience:      "test_audience",
+						ClientID:      defaultTLSClientID,
+						TokenEndpoint: oidcEndpoints.TokenEndpoint,
+						Scopes:        []string{"scope1", "scope2"},
+					},
+				},
+				mockClock,
+			)
+
+			_, err := provider.Authorize("test_audience")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(mockTokenExchanger.CalledWithRequest).To(gomega.Equal(&ClientCredentialsExchangeRequest{
+				TokenEndpoint: oidcEndpoints.TokenEndpoint,
+				ClientID:      defaultTLSClientID,
+				ClientSecret:  "",
+				Audience:      "test_audience",
+				Scopes:        []string{"scope1", "scope2"},
+				AuthMethod:    TokenEndpointAuthMethodTLSClientAuth,
+			}))
+		})
+
+		ginkgo.It("uses the default client id for tls client auth when options client id is unset", func() {
+			tokenEndpoint := "https://options.example/token"
+			serverFromOptions := mockWellKnownServer(tokenEndpoint)
+			defer serverFromOptions.Close()
+
+			provider := newClientCredentialsFlow(
+				ClientCredentialsFlowOptions{
+					IssuerURL:               serverFromOptions.URL,
+					AdditionalScopes:        []string{"scope1", "scope2"},
+					TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+				},
+				mockTokenExchanger,
+				&DefaultGrantProvider{oidcClient: serverFromOptions.Client()},
+				mockClock,
+			)
+
+			_, err := provider.Authorize("test_audience")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(mockTokenExchanger.CalledWithRequest).To(gomega.Equal(&ClientCredentialsExchangeRequest{
+				TokenEndpoint: tokenEndpoint,
+				ClientID:      defaultTLSClientID,
+				ClientSecret:  "",
+				Audience:      "test_audience",
+				Scopes:        []string{"scope1", "scope2"},
+				AuthMethod:    TokenEndpointAuthMethodTLSClientAuth,
 			}))
 		})
 
@@ -213,9 +289,182 @@ var _ = ginkgo.Describe("DefaultGrantProvider", func() {
 		gomega.Expect(err).To(gomega.HaveOccurred())
 		gomega.Expect(err.Error()).To(gomega.Equal("issuer url is required for client credentials flow"))
 	})
+
+	ginkgo.It("builds tls client auth grant without reading key file", func() {
+		tokenEndpoint := "https://options.example/token"
+		serverFromOptions := mockWellKnownServer(tokenEndpoint)
+		defer serverFromOptions.Close()
+
+		provider := DefaultGrantProvider{}
+		grant, err := provider.GetGrant("test-audience", &ClientCredentialsFlowOptions{
+			KeyFile:                 "/not-exist-key.json",
+			ClientID:                "explicit-client-id",
+			IssuerURL:               serverFromOptions.URL,
+			AdditionalScopes:        []string{"scope1", "scope2"},
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(grant.ClientID).To(gomega.Equal("explicit-client-id"))
+		gomega.Expect(grant.ClientCredentials).To(gomega.BeNil())
+		gomega.Expect(grant.Scopes).To(gomega.Equal([]string{"scope1", "scope2"}))
+		gomega.Expect(grant.TokenEndpoint).To(gomega.Equal(tokenEndpoint))
+	})
+
+	ginkgo.It("uses the default client id for tls client auth when unset", func() {
+		tokenEndpoint := "https://options.example/token"
+		serverFromOptions := mockWellKnownServer(tokenEndpoint)
+		defer serverFromOptions.Close()
+
+		provider := DefaultGrantProvider{}
+		grant, err := provider.GetGrant("test-audience", &ClientCredentialsFlowOptions{
+			IssuerURL:               serverFromOptions.URL,
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(grant.ClientID).To(gomega.Equal(defaultTLSClientID))
+	})
+})
+
+var _ = ginkgo.Describe("NewDefaultClientCredentialsFlow", func() {
+	ginkgo.It("uses client_secret_post by default", func() {
+		flow, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(flow.options.TokenEndpointAuthMethod).To(gomega.Equal(TokenEndpointAuthMethodClientSecretPost))
+	})
+
+	ginkgo.It("returns an error for an unsupported auth method", func() {
+		_, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			TokenEndpointAuthMethod: "unsupported",
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.Equal("unsupported token endpoint auth method: unsupported"))
+	})
+
+	ginkgo.It("returns an error when tls client auth cert files are missing", func() {
+		_, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			IssuerURL:               "https://issuer.example",
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.Equal("tlsCertFile and tlsKeyFile are required for tls_client_auth"))
+	})
+
+	ginkgo.It("allows tls client auth flow creation when issuer url is missing", func() {
+		flow, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+			TLSCertFile:             oauth2TestCertPath("client-cert.pem"),
+			TLSKeyFile:              oauth2TestCertPath("client-key.pem"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(flow).ToNot(gomega.BeNil())
+	})
+
+	ginkgo.It("allows client_secret_post without cert files", func() {
+		flow, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodClientSecretPost,
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(flow).ToNot(gomega.BeNil())
+	})
+
+	ginkgo.It("configures client certificate for client_secret_post when cert files are provided", func() {
+		flow, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodClientSecretPost,
+			TLSCertFile:             oauth2TestCertPath("client-cert.pem"),
+			TLSKeyFile:              oauth2TestCertPath("client-key.pem"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		retriever, ok := flow.exchanger.(*TokenRetriever)
+		gomega.Expect(ok).To(gomega.BeTrue())
+		httpClient, ok := retriever.transport.(*http.Client)
+		gomega.Expect(ok).To(gomega.BeTrue())
+		transport, ok := httpClient.Transport.(*http.Transport)
+		gomega.Expect(ok).To(gomega.BeTrue())
+		gomega.Expect(transport.TLSClientConfig).ToNot(gomega.BeNil())
+		gomega.Expect(transport.TLSClientConfig.GetClientCertificate).ToNot(gomega.BeNil())
+	})
+
+	ginkgo.It("returns an error when only one cert file is provided for client_secret_post", func() {
+		_, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodClientSecretPost,
+			TLSCertFile:             oauth2TestCertPath("client-cert.pem"),
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.Equal("tlsCertFile and tlsKeyFile must be specified together"))
+	})
+
+	ginkgo.It("configures root CAs when trustCertsFilePath is provided", func() {
+		flow, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			TrustCertsFilePath: oauth2TestCertPath("cacert.pem"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		retriever, ok := flow.exchanger.(*TokenRetriever)
+		gomega.Expect(ok).To(gomega.BeTrue())
+		httpClient, ok := retriever.transport.(*http.Client)
+		gomega.Expect(ok).To(gomega.BeTrue())
+		transport, ok := httpClient.Transport.(*http.Transport)
+		gomega.Expect(ok).To(gomega.BeTrue())
+		gomega.Expect(transport.TLSClientConfig).ToNot(gomega.BeNil())
+		gomega.Expect(transport.TLSClientConfig.RootCAs).ToNot(gomega.BeNil())
+	})
+
+	ginkgo.It("allows tls client auth without a key file", func() {
+		flow, err := NewDefaultClientCredentialsFlow(ClientCredentialsFlowOptions{
+			IssuerURL:               "https://issuer.example",
+			TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+			TLSCertFile:             oauth2TestCertPath("client-cert.pem"),
+			TLSKeyFile:              oauth2TestCertPath("client-key.pem"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(flow).ToNot(gomega.BeNil())
+	})
 })
 
 var _ = ginkgo.Describe("ClientCredentialsGrantRefresher", func() {
+	ginkgo.Describe("NewDefaultClientCredentialsGrantRefresher", func() {
+		var mockClock clock.Clock
+
+		ginkgo.BeforeEach(func() {
+			mockClock = testing.NewFakeClock(time.Unix(0, 0))
+		})
+
+		ginkgo.It("accepts tls client auth", func() {
+			refresher, err := NewDefaultClientCredentialsGrantRefresher(mockClock, ClientCredentialsFlowOptions{
+				TokenEndpointAuthMethod: TokenEndpointAuthMethodTLSClientAuth,
+				TLSCertFile:             oauth2TestCertPath("client-cert.pem"),
+				TLSKeyFile:              oauth2TestCertPath("client-key.pem"),
+			})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(refresher.authMethod).To(gomega.Equal(TokenEndpointAuthMethodTLSClientAuth))
+
+			retriever, ok := refresher.exchanger.(*TokenRetriever)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			httpClient, ok := retriever.transport.(*http.Client)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			transport, ok := httpClient.Transport.(*http.Transport)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(transport.TLSClientConfig).ToNot(gomega.BeNil())
+			gomega.Expect(transport.TLSClientConfig.GetClientCertificate).ToNot(gomega.BeNil())
+		})
+
+		ginkgo.It("configures root CAs from options", func() {
+			refresher, err := NewDefaultClientCredentialsGrantRefresher(mockClock, ClientCredentialsFlowOptions{
+				TrustCertsFilePath: oauth2TestCertPath("cacert.pem"),
+			})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			retriever, ok := refresher.exchanger.(*TokenRetriever)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			httpClient, ok := retriever.transport.(*http.Client)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			transport, ok := httpClient.Transport.(*http.Transport)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(transport.TLSClientConfig).ToNot(gomega.BeNil())
+			gomega.Expect(transport.TLSClientConfig.RootCAs).ToNot(gomega.BeNil())
+		})
+	})
 
 	ginkgo.Describe("Refresh", func() {
 		var mockClock clock.Clock
@@ -250,6 +499,7 @@ var _ = ginkgo.Describe("ClientCredentialsGrantRefresher", func() {
 				ClientSecret:  clientCredentials.ClientSecret,
 				Audience:      og.Audience,
 				Scopes:        og.Scopes,
+				AuthMethod:    TokenEndpointAuthMethodClientSecretPost,
 			}))
 		})
 
@@ -275,6 +525,56 @@ var _ = ginkgo.Describe("ClientCredentialsGrantRefresher", func() {
 			expected := convertToOAuth2Token(mockTokenExchanger.ReturnsTokens, mockClock)
 			gomega.Expect(*ng.Token).To(gomega.Equal(expected))
 			gomega.Expect(ng.Scopes).To(gomega.Equal([]string{"profile"}))
+		})
+
+		ginkgo.It("passes tls client auth during refresh", func() {
+			refresher := &ClientCredentialsGrantRefresher{
+				clock:      mockClock,
+				exchanger:  mockTokenExchanger,
+				authMethod: TokenEndpointAuthMethodTLSClientAuth,
+			}
+			og := &AuthorizationGrant{
+				Type:          GrantTypeClientCredentials,
+				Audience:      "test_audience",
+				ClientID:      defaultTLSClientID,
+				TokenEndpoint: oidcEndpoints.TokenEndpoint,
+				Token:         nil,
+				Scopes:        []string{"profile"},
+			}
+			_, err := refresher.Refresh(og)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(mockTokenExchanger.CalledWithRequest).To(gomega.Equal(&ClientCredentialsExchangeRequest{
+				TokenEndpoint: oidcEndpoints.TokenEndpoint,
+				ClientID:      defaultTLSClientID,
+				ClientSecret:  "",
+				Audience:      og.Audience,
+				Scopes:        og.Scopes,
+				AuthMethod:    TokenEndpointAuthMethodTLSClientAuth,
+			}))
+		})
+
+		ginkgo.It("infers tls client auth when grant credentials are nil", func() {
+			refresher := &ClientCredentialsGrantRefresher{
+				clock:     mockClock,
+				exchanger: mockTokenExchanger,
+			}
+			og := &AuthorizationGrant{
+				Type:          GrantTypeClientCredentials,
+				Audience:      "test_audience",
+				ClientID:      defaultTLSClientID,
+				TokenEndpoint: oidcEndpoints.TokenEndpoint,
+				Scopes:        []string{"profile"},
+			}
+			_, err := refresher.Refresh(og)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(mockTokenExchanger.CalledWithRequest).To(gomega.Equal(&ClientCredentialsExchangeRequest{
+				TokenEndpoint: oidcEndpoints.TokenEndpoint,
+				ClientID:      defaultTLSClientID,
+				ClientSecret:  "",
+				Audience:      og.Audience,
+				Scopes:        og.Scopes,
+				AuthMethod:    TokenEndpointAuthMethodTLSClientAuth,
+			}))
 		})
 	})
 })

--- a/oauth2/oidc_endpoint_provider.go
+++ b/oauth2/oidc_endpoint_provider.go
@@ -36,13 +36,24 @@ type OIDCWellKnownEndpoints struct {
 // GetOIDCWellKnownEndpointsFromIssuerURL gets the well known endpoints for the
 // passed in issuer url
 func GetOIDCWellKnownEndpointsFromIssuerURL(issuerURL string) (*OIDCWellKnownEndpoints, error) {
+	return GetOIDCWellKnownEndpointsFromIssuerURLWithClient(issuerURL, http.DefaultClient)
+}
+
+// GetOIDCWellKnownEndpointsFromIssuerURLWithClient gets the well known endpoints
+// for the passed in issuer url using the provided HTTP client.
+func GetOIDCWellKnownEndpointsFromIssuerURLWithClient(
+	issuerURL string, httpClient *http.Client) (*OIDCWellKnownEndpoints, error) {
 	u, err := url.Parse(issuerURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not parse issuer url to build well known endpoints")
 	}
 	u.Path = path.Join(u.Path, ".well-known/openid-configuration")
 
-	r, err := http.Get(u.String())
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	r, err := httpClient.Get(u.String())
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get well known endpoints from url %s", u.String())
 	}

--- a/oauth2/oidc_endpoint_provider_test.go
+++ b/oauth2/oidc_endpoint_provider_test.go
@@ -136,7 +136,7 @@ var _ = ginkgo.Describe("GetOIDCWellKnownEndpointsFromIssuerURL", func() {
 		serverCert, err := tls.LoadX509KeyPair(oidcTestCertPath("broker-cert.pem"), oidcTestCertPath("broker-key.pem"))
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"token_endpoint":"https://issuer/token"}`))
 		}))

--- a/oauth2/oidc_endpoint_provider_test.go
+++ b/oauth2/oidc_endpoint_provider_test.go
@@ -18,13 +18,24 @@
 package oauth2
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"strings"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 )
+
+func oidcTestCertPath(name string) string {
+	return filepath.Join("..", "integration-tests", "certs", name)
+}
+
+func oidcIssuerURL(serverURL string) string {
+	return strings.Replace(serverURL, "127.0.0.1", "localhost", 1)
+}
 
 var _ = ginkgo.Describe("GetOIDCWellKnownEndpointsFromIssuerURL", func() {
 	ginkgo.It("calls and gets the well known data from the correct endpoint for the issuer", func() {
@@ -88,5 +99,53 @@ var _ = ginkgo.Describe("GetOIDCWellKnownEndpointsFromIssuerURL", func() {
 			" known endpoints: invalid character '<' looking for beginning of value"))
 		gomega.Expect(endpoints).To(gomega.BeNil())
 		gomega.Expect(req.URL.Path).To(gomega.Equal("/.well-known/openid-configuration"))
+	})
+
+	ginkgo.It("supports custom CA when using a configured client", func() {
+		var req *http.Request
+		wkEndpointsResp := OIDCWellKnownEndpoints{
+			AuthorizationEndpoint: "the-auth-endpoint", TokenEndpoint: "the-token-endpoint"}
+		responseBytes, err := json.Marshal(wkEndpointsResp)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		serverCert, err := tls.LoadX509KeyPair(oidcTestCertPath("broker-cert.pem"), oidcTestCertPath("broker-key.pem"))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req = r
+			w.WriteHeader(http.StatusOK)
+			w.Write(responseBytes)
+		}))
+		ts.TLS = &tls.Config{Certificates: []tls.Certificate{serverCert}}
+		ts.StartTLS()
+		defer ts.Close()
+
+		client, err := newClientCredentialsHTTPClient(ClientCredentialsFlowOptions{
+			TrustCertsFilePath: oidcTestCertPath("cacert.pem"),
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		endpoints, err := GetOIDCWellKnownEndpointsFromIssuerURLWithClient(oidcIssuerURL(ts.URL), client)
+
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(*endpoints).To(gomega.Equal(wkEndpointsResp))
+		gomega.Expect(req.URL.Path).To(gomega.Equal("/.well-known/openid-configuration"))
+	})
+
+	ginkgo.It("fails against custom CA https issuer without trust certs", func() {
+		serverCert, err := tls.LoadX509KeyPair(oidcTestCertPath("broker-cert.pem"), oidcTestCertPath("broker-key.pem"))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"token_endpoint":"https://issuer/token"}`))
+		}))
+		ts.TLS = &tls.Config{Certificates: []tls.Certificate{serverCert}}
+		ts.StartTLS()
+		defer ts.Close()
+
+		endpoints, err := GetOIDCWellKnownEndpointsFromIssuerURL(oidcIssuerURL(ts.URL))
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(endpoints).To(gomega.BeNil())
 	})
 })

--- a/pulsar/auth/oauth2.go
+++ b/pulsar/auth/oauth2.go
@@ -31,13 +31,17 @@ import (
 )
 
 const (
-	ConfigParamType                  = "type"
-	ConfigParamTypeClientCredentials = "client_credentials"
-	ConfigParamIssuerURL             = "issuerUrl"
-	ConfigParamAudience              = "audience"
-	ConfigParamScope                 = "scope"
-	ConfigParamKeyFile               = "privateKey"
-	ConfigParamClientID              = "clientId"
+	ConfigParamType                    = "type"
+	ConfigParamTypeClientCredentials   = "client_credentials"
+	ConfigParamIssuerURL               = "issuerUrl"
+	ConfigParamAudience                = "audience"
+	ConfigParamScope                   = "scope"
+	ConfigParamKeyFile                 = "privateKey"
+	ConfigParamClientID                = "clientId"
+	ConfigParamTokenEndpointAuthMethod = "tokenEndpointAuthMethod"
+	ConfigParamTLSCertFile             = "tlsCertFile"
+	ConfigParamTLSKeyFile              = "tlsKeyFile"
+	ConfigParamTrustCertsFilePath      = "trustCertsFilePath"
 )
 
 type oauth2AuthProvider struct {
@@ -49,7 +53,12 @@ type oauth2AuthProvider struct {
 	flow             *oauth2.ClientCredentialsFlow
 }
 
-// NewAuthenticationOAuth2WithParams return a interface of Provider with string map.
+// NewAuthenticationOAuth2WithParams creates an OAuth2 auth provider from string params.
+//
+// For client_credentials, tokenEndpointAuthMethod defaults to client_secret_post.
+// Required params:
+//   - client_secret_post: privateKey
+//   - tls_client_auth: issuerUrl, tlsCertFile, tlsKeyFile
 func NewAuthenticationOAuth2WithParams(params map[string]string) (Provider, error) {
 	issuer := oauth2.Issuer{
 		IssuerEndpoint: params[ConfigParamIssuerURL],
@@ -60,9 +69,14 @@ func NewAuthenticationOAuth2WithParams(params map[string]string) (Provider, erro
 	switch params[ConfigParamType] {
 	case ConfigParamTypeClientCredentials:
 		flow, err := oauth2.NewDefaultClientCredentialsFlow(oauth2.ClientCredentialsFlowOptions{
-			KeyFile:          params[ConfigParamKeyFile],
-			IssuerURL:        params[ConfigParamIssuerURL],
-			AdditionalScopes: strings.Split(params[ConfigParamScope], " "),
+			KeyFile:                 params[ConfigParamKeyFile],
+			ClientID:                params[ConfigParamClientID],
+			IssuerURL:               params[ConfigParamIssuerURL],
+			AdditionalScopes:        strings.Split(params[ConfigParamScope], " "),
+			TokenEndpointAuthMethod: params[ConfigParamTokenEndpointAuthMethod],
+			TLSCertFile:             params[ConfigParamTLSCertFile],
+			TLSKeyFile:              params[ConfigParamTLSKeyFile],
+			TrustCertsFilePath:      params[ConfigParamTrustCertsFilePath],
 		})
 		if err != nil {
 			return nil, err

--- a/pulsar/auth/oauth2_test.go
+++ b/pulsar/auth/oauth2_test.go
@@ -18,10 +18,14 @@
 package auth
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -33,6 +37,14 @@ import (
 
 var expectedClientID atomic.Value
 var expectedClientSecret atomic.Value
+
+func oauth2TLSCertPath(name string) string {
+	return filepath.Join("..", "..", "integration-tests", "certs", name)
+}
+
+func oauth2IssuerURL(serverURL string) string {
+	return strings.Replace(serverURL, "127.0.0.1", "localhost", 1)
+}
 
 // mockOAuthServer will mock a oauth service for the tests
 func mockOAuthServer() *httptest.Server {
@@ -78,8 +90,59 @@ func mockOAuthServerWithToken(token string) *httptest.Server {
 	return server
 }
 
+func mockOAuthTLSServer(
+	t *testing.T,
+	token string,
+	requireClientCert bool,
+	tokenHandler func(*testing.T, http.ResponseWriter, *http.Request, string),
+) *httptest.Server {
+	t.Helper()
+
+	serverCert, err := tls.LoadX509KeyPair(oauth2TLSCertPath("broker-cert.pem"), oauth2TLSCertPath("broker-key.pem"))
+	require.NoError(t, err)
+
+	server := httptest.NewUnstartedServer(http.DefaultServeMux)
+	mockedHandler := http.NewServeMux()
+	mockedHandler.HandleFunc("/.well-known/openid-configuration", func(writer http.ResponseWriter, _ *http.Request) {
+		issuerURL := oauth2IssuerURL(server.URL)
+		s := fmt.Sprintf(`{
+    "issuer":"%s",
+    "authorization_endpoint":"%s/authorize",
+    "token_endpoint":"%s/oauth/token",
+    "device_authorization_endpoint":"%s/oauth/device/code"
+}`, issuerURL, issuerURL, issuerURL, issuerURL)
+		fmt.Fprintln(writer, s)
+	})
+	mockedHandler.HandleFunc("/oauth/token", func(writer http.ResponseWriter, r *http.Request) {
+		tokenHandler(t, writer, r, token)
+	})
+	mockedHandler.HandleFunc("/authorize", func(writer http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(writer, "true")
+	})
+
+	server.Config.Handler = mockedHandler
+	server.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	}
+
+	if requireClientCert {
+		caCerts, err := os.ReadFile(oauth2TLSCertPath("cacert.pem"))
+		require.NoError(t, err)
+		server.TLS.ClientCAs = x509.NewCertPool()
+		server.TLS.ClientCAs.AppendCertsFromPEM(caCerts)
+		server.TLS.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	server.StartTLS()
+	return server
+}
+
 // mockKeyFile will mock a temp key file for testing.
 func mockKeyFile(server string) (string, error) {
+	return mockKeyFileWithClientID(server, "client-id")
+}
+
+func mockKeyFileWithClientID(server string, clientID string) (string, error) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -90,12 +153,12 @@ func mockKeyFile(server string) (string, error) {
 	}
 	_, err = kf.WriteString(fmt.Sprintf(`{
   "type":"resource",
-  "client_id":"client-id",
+  "client_id":"%s",
   "client_secret":"client-secret",
   "client_email":"oauth@test.org",
   "issuer_url":"%s",
   "scope": "test-scope"
-}`, server))
+}`, clientID, server))
 	if err != nil {
 		return "", err
 	}
@@ -242,6 +305,175 @@ func TestOAuth2MissingIssuerReturnsError(t *testing.T) {
 	_, err = auth.GetData()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "issuer url is required for client credentials flow")
+}
+
+func TestOAuth2ClientSecretPostWithTrustCertsFilePath(t *testing.T) {
+	expectedClientID.Store("client-id")
+	expectedClientSecret.Store("client-secret")
+	server := mockOAuthTLSServer(t, "token-content", false, func(
+		t *testing.T, writer http.ResponseWriter, r *http.Request, token string,
+	) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, expectedClientID.Load().(string), r.FormValue("client_id"))
+		assert.Equal(t, expectedClientSecret.Load().(string), r.FormValue("client_secret"))
+		fmt.Fprintf(writer, "{\n  \"access_token\": \"%s\",\n  \"token_type\": \"Bearer\"\n}\n", token)
+	})
+	defer server.Close()
+
+	kf, err := mockKeyFile(oauth2IssuerURL(server.URL))
+	require.NoError(t, err)
+	defer os.Remove(kf)
+
+	auth, err := NewAuthenticationOAuth2WithParams(map[string]string{
+		ConfigParamType:               ConfigParamTypeClientCredentials,
+		ConfigParamIssuerURL:          oauth2IssuerURL(server.URL),
+		ConfigParamClientID:           "client-id",
+		ConfigParamAudience:           "audience",
+		ConfigParamKeyFile:            kf,
+		ConfigParamScope:              "profile",
+		ConfigParamTrustCertsFilePath: oauth2TLSCertPath("cacert.pem"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, auth.Init())
+
+	token, err := auth.GetData()
+	require.NoError(t, err)
+	assert.Equal(t, "token-content", string(token))
+}
+
+func TestOAuth2ClientSecretPostWithoutTrustCertsFilePathFailsAgainstCustomCA(t *testing.T) {
+	expectedClientID.Store("client-id")
+	expectedClientSecret.Store("client-secret")
+	server := mockOAuthTLSServer(t, "token-content", false, func(
+		t *testing.T, writer http.ResponseWriter, r *http.Request, token string,
+	) {
+		require.NoError(t, r.ParseForm())
+		fmt.Fprintf(writer, "{\n  \"access_token\": \"%s\",\n  \"token_type\": \"Bearer\"\n}\n", token)
+	})
+	defer server.Close()
+
+	kf, err := mockKeyFile(oauth2IssuerURL(server.URL))
+	require.NoError(t, err)
+	defer os.Remove(kf)
+
+	auth, err := NewAuthenticationOAuth2WithParams(map[string]string{
+		ConfigParamType:      ConfigParamTypeClientCredentials,
+		ConfigParamIssuerURL: oauth2IssuerURL(server.URL),
+		ConfigParamClientID:  "client-id",
+		ConfigParamAudience:  "audience",
+		ConfigParamKeyFile:   kf,
+		ConfigParamScope:     "profile",
+	})
+	require.NoError(t, err)
+	require.NoError(t, auth.Init())
+
+	_, err = auth.GetData()
+	require.Error(t, err)
+}
+
+func TestOAuth2ClientSecretPostWithClientCertificate(t *testing.T) {
+	expectedClientID.Store("client-id")
+	expectedClientSecret.Store("client-secret")
+	server := mockOAuthTLSServer(t, "token-content", true, func(
+		t *testing.T, writer http.ResponseWriter, r *http.Request, token string,
+	) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, expectedClientID.Load().(string), r.FormValue("client_id"))
+		assert.Equal(t, expectedClientSecret.Load().(string), r.FormValue("client_secret"))
+		require.NotNil(t, r.TLS)
+		require.NotEmpty(t, r.TLS.PeerCertificates)
+		fmt.Fprintf(writer, "{\n  \"access_token\": \"%s\",\n  \"token_type\": \"Bearer\"\n}\n", token)
+	})
+	defer server.Close()
+
+	kf, err := mockKeyFile(oauth2IssuerURL(server.URL))
+	require.NoError(t, err)
+	defer os.Remove(kf)
+
+	auth, err := NewAuthenticationOAuth2WithParams(map[string]string{
+		ConfigParamType:               ConfigParamTypeClientCredentials,
+		ConfigParamIssuerURL:          oauth2IssuerURL(server.URL),
+		ConfigParamClientID:           "client-id",
+		ConfigParamAudience:           "audience",
+		ConfigParamKeyFile:            kf,
+		ConfigParamScope:              "profile",
+		ConfigParamTLSCertFile:        oauth2TLSCertPath("client-cert.pem"),
+		ConfigParamTLSKeyFile:         oauth2TLSCertPath("client-key.pem"),
+		ConfigParamTrustCertsFilePath: oauth2TLSCertPath("cacert.pem"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, auth.Init())
+
+	token, err := auth.GetData()
+	require.NoError(t, err)
+	assert.Equal(t, "token-content", string(token))
+}
+
+func TestOAuth2TLSClientAuth(t *testing.T) {
+	expectedClientID.Store("pulsar-client")
+	server := mockOAuthTLSServer(t, "mtls-token", true, func(
+		t *testing.T, writer http.ResponseWriter, r *http.Request, token string,
+	) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, expectedClientID.Load().(string), r.FormValue("client_id"))
+		assert.Empty(t, r.FormValue("client_secret"))
+		assert.Equal(t, "profile", r.FormValue("scope"))
+		require.NotNil(t, r.TLS)
+		require.NotEmpty(t, r.TLS.PeerCertificates)
+		fmt.Fprintf(writer, "{\n  \"access_token\": \"%s\",\n  \"token_type\": \"Bearer\"\n}\n", token)
+	})
+	defer server.Close()
+
+	auth, err := NewAuthenticationOAuth2WithParams(map[string]string{
+		ConfigParamType:                    ConfigParamTypeClientCredentials,
+		ConfigParamIssuerURL:               oauth2IssuerURL(server.URL),
+		ConfigParamAudience:                "audience",
+		ConfigParamScope:                   "profile",
+		ConfigParamTokenEndpointAuthMethod: oauth2.TokenEndpointAuthMethodTLSClientAuth,
+		ConfigParamTLSCertFile:             oauth2TLSCertPath("client-cert.pem"),
+		ConfigParamTLSKeyFile:              oauth2TLSCertPath("client-key.pem"),
+		ConfigParamTrustCertsFilePath:      oauth2TLSCertPath("cacert.pem"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, auth.Init())
+
+	token, err := auth.GetData()
+	require.NoError(t, err)
+	assert.Equal(t, "mtls-token", string(token))
+}
+
+func TestOAuth2TLSClientAuthIgnoresKeyFileClientID(t *testing.T) {
+	expectedClientID.Store("pulsar-client")
+	server := mockOAuthTLSServer(t, "mtls-token", true, func(
+		t *testing.T, writer http.ResponseWriter, r *http.Request, token string,
+	) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, expectedClientID.Load().(string), r.FormValue("client_id"))
+		assert.Empty(t, r.FormValue("client_secret"))
+		fmt.Fprintf(writer, "{\n  \"access_token\": \"%s\",\n  \"token_type\": \"Bearer\"\n}\n", token)
+	})
+	defer server.Close()
+
+	kf, err := mockKeyFileWithClientID(oauth2IssuerURL(server.URL), "wrong-client-id")
+	require.NoError(t, err)
+	defer os.Remove(kf)
+
+	auth, err := NewAuthenticationOAuth2WithParams(map[string]string{
+		ConfigParamType:                    ConfigParamTypeClientCredentials,
+		ConfigParamIssuerURL:               oauth2IssuerURL(server.URL),
+		ConfigParamAudience:                "audience",
+		ConfigParamKeyFile:                 kf,
+		ConfigParamTokenEndpointAuthMethod: oauth2.TokenEndpointAuthMethodTLSClientAuth,
+		ConfigParamTLSCertFile:             oauth2TLSCertPath("client-cert.pem"),
+		ConfigParamTLSKeyFile:              oauth2TLSCertPath("client-key.pem"),
+		ConfigParamTrustCertsFilePath:      oauth2TLSCertPath("cacert.pem"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, auth.Init())
+
+	token, err := auth.GetData()
+	require.NoError(t, err)
+	assert.Equal(t, "mtls-token", string(token))
 }
 
 func TestOAuth2KeyFileReloading(t *testing.T) {


### PR DESCRIPTION
### Motivation

Currently, `ClientCredentialsFlow` of AuthOauth2 supports only `client_secret_post`.
This PR adds `tls_client_auth`.
cf. https://github.com/apache/pulsar/pull/25538

### Modifications

- Add `clientId`, `tlsCertFile`, `tlsKeyFile`, and `trustCertsFilePath` params.
  - `tlsCertFile` and `tlsKeyFile` params are required for `tls_client_auth`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
  - https://github.com/izumo27/pulsar-client-go/pull/1

This change added tests and can be verified as follows:

- Added tests for tls_client_auth

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? GoDocs