### PR TITLE
Update golang to 1.25 and also update linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.24', '1.26']
+        go-version: [ '1.25', '1.26']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
@@ -36,19 +36,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Check license header
         run: docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 check
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
-          version: latest
+          version: v2.12.2
 
   integration-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.24', '1.26' ]
+        go-version: [ '1.25', '1.26' ]
     steps:
       - uses: actions/checkout@v3      
       - uses: actions/setup-go@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,7 @@
 
 # Run `make lint` from the root path of this project to check code with golangci-lint.
 
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   # Uncomment this line to run only the explicitly enabled linters
   # disable-all: true
@@ -27,12 +25,10 @@ linters:
   # Run these linters in addition to the default ones
   enable:
     - bodyclose
-    - goimports
     - lll
     - misspell
     - prealloc
     - revive
-    - stylecheck
     - unconvert
     - unparam
 
@@ -40,3 +36,29 @@ linters:
   disable:
     - errcheck
     - staticcheck
+  settings:
+    govet:
+      disable:
+        # Keep govet enabled, but suppress noisy inline suggestions that
+        # conflict with unconvert and add style churn without behavior changes.
+        - inline
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,13 @@
 IMAGE_NAME = pulsar-client-go-test:latest
 PULSAR_VERSION ?= latest
 PULSAR_IMAGE = apachepulsar/pulsar:$(PULSAR_VERSION)
-GO_VERSION ?= 1.24
+GO_VERSION ?= 1.25
 CONTAINER_ARCH ?= $(shell uname -m | sed s/x86_64/amd64/)
+
+# golangci-lint version used for local install and docker invocation.
+# Bump this when upgrading Go to ensure analyzer compatibility (pin to a
+# specific release or set to @latest for most recent).
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # Golang standard bin directory.
 GOPATH ?= $(shell go env GOPATH)
@@ -44,13 +49,13 @@ lint: bin/golangci-lint
 	bin/golangci-lint run
 
 bin/golangci-lint:
-	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.2
+	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 # an alternative to above `make lint` command
 # use golangCi-lint docker to avoid local golang env issues
 # https://golangci-lint.run/welcome/install/
 lint-docker:
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.64.2 golangci-lint run -v
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint run -v
 
 container:
 	docker build -t ${IMAGE_NAME} \

--- a/examples/producer/producer.go
+++ b/examples/producer/producer.go
@@ -65,13 +65,14 @@ func main() {
 
 	ctx := context.Background()
 	for i := 0; i < 10; i++ {
-		if msgId, err := producer.Send(ctx, &pulsar.ProducerMessage{
+		msgID, err := producer.Send(ctx, &pulsar.ProducerMessage{
 			Payload: []byte(fmt.Sprintf("hello-%d", i)),
-		}); err != nil {
+		})
+		if err != nil {
 			logger.Error("send message error", "error", err)
 			return
-		} else {
-			logger.Info("Published message", "msgId", msgId.String())
 		}
+
+		logger.Info("Published message", "msgId", msgID.String())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/pulsar-client-go
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/99designs/keyring v1.2.1

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -4796,7 +4796,7 @@ func TestBatchIndexAck(t *testing.T) {
 		cumulative         bool
 		ackGroupingOptions *AckGroupingOptions
 	}
-	configs := make([]config, 0)
+	configs := make([]config, 0, 12)
 	for _, option := range []*AckGroupingOptions{
 		nil, // MaxSize: 1000, MaxTime: 10ms
 		{MaxSize: 0, MaxTime: 0},

--- a/pulsar/crypto/message_metadata.go
+++ b/pulsar/crypto/message_metadata.go
@@ -48,7 +48,7 @@ func NewMessageMetadataSupplier(messageMetadata *pb.MessageMetadata) MessageMeta
 
 func (m *MessageMetadata) EncryptionKeys() []EncryptionKeyInfo {
 	if m.messageMetadata != nil {
-		encInfo := []EncryptionKeyInfo{}
+		encInfo := make([]EncryptionKeyInfo, 0, len(m.messageMetadata.EncryptionKeys))
 		for _, k := range m.messageMetadata.EncryptionKeys {
 			key := NewEncryptionKeyInfo(k.GetKey(), k.GetValue(), getKeyMetaMap(k.GetMetadata()))
 			encInfo = append(encInfo, *key)
@@ -101,7 +101,7 @@ func (m *MessageMetadata) encryptionKeyPresent(keyInfo EncryptionKeyInfo) int {
 
 func getKeyMeta(metaMap map[string]string) []*pb.KeyValue {
 	if len(metaMap) > 0 {
-		var meta []*pb.KeyValue
+		meta := make([]*pb.KeyValue, 0, len(metaMap))
 		for k, v := range metaMap {
 			meta = append(meta, &pb.KeyValue{Key: &k, Value: &v})
 		}

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -104,21 +104,21 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 	for k, v := range userDefinedLabels {
 		constLabels[k] = v
 	}
-	var metricsLevelLabels []string
-
 	// note: ints here mirror MetricsCardinality in client.go to avoid import cycle
-	switch metricsCardinality {
-	case 1: //MetricsCardinalityNone
-		metricsLevelLabels = []string{}
-	case 2: //MetricsCardinalityTenant
-		metricsLevelLabels = []string{"pulsar_tenant"}
-	case 3: //MetricsCardinalityNamespace
-		metricsLevelLabels = []string{"pulsar_tenant", "pulsar_namespace"}
-	case 4: //MetricsCardinalityTopic
-		metricsLevelLabels = []string{"pulsar_tenant", "pulsar_namespace", "topic"}
-	default: //Anything else is namespace
-		metricsLevelLabels = []string{"pulsar_tenant", "pulsar_namespace"}
-	}
+	metricsLevelLabels := func() []string {
+		switch metricsCardinality {
+		case 1: //MetricsCardinalityNone
+			return []string{}
+		case 2: //MetricsCardinalityTenant
+			return []string{"pulsar_tenant"}
+		case 3: //MetricsCardinalityNamespace
+			return []string{"pulsar_tenant", "pulsar_namespace"}
+		case 4: //MetricsCardinalityTopic
+			return []string{"pulsar_tenant", "pulsar_namespace", "topic"}
+		default: //Anything else is namespace
+			return []string{"pulsar_tenant", "pulsar_namespace"}
+		}
+	}()
 
 	metrics := &Metrics{
 		metricsLevel: metricsCardinality,

--- a/pulsar/primitiveSerDe.go
+++ b/pulsar/primitiveSerDe.go
@@ -167,8 +167,7 @@ func (b BinaryFreeList) PutDouble(datum interface{}) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("serialize failed: expected: Go numeric; received: %T", datum)
 	}
-	var buf []byte
-	buf = append(buf, 0, 0, 0, 0, 0, 0, 0, 0)
+	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf[len(buf)-8:], math.Float64bits(value))
 	return buf, nil
 }
@@ -195,8 +194,7 @@ func (b BinaryFreeList) PutFloat(datum interface{}) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("serialize failed: expected: Go numeric; received: %T", datum)
 	}
-	var buf []byte
-	buf = append(buf, 0, 0, 0, 0)
+	buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf[len(buf)-4:], math.Float32bits(value))
 	return buf, nil
 }

--- a/pulsaradmin/pkg/admin/namespace.go
+++ b/pulsaradmin/pkg/admin/namespace.go
@@ -1694,7 +1694,7 @@ func (n *namespaces) GrantNamespacePermissionWithContext(
 	role string,
 	action []utils.AuthAction) error {
 	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "permissions", role)
-	s := make([]string, 0)
+	s := make([]string, 0, len(action))
 	for _, v := range action {
 		s = append(s, v.String())
 	}

--- a/pulsaradmin/pkg/admin/topic.go
+++ b/pulsaradmin/pkg/admin/topic.go
@@ -1326,7 +1326,7 @@ func (t *topics) GrantPermissionWithContext(
 	action []utils.AuthAction,
 ) error {
 	endpoint := t.pulsar.endpoint(t.basePath, topic.GetRestPath(), "permissions", role)
-	s := []string{}
+	s := make([]string, 0, len(action))
 	for _, v := range action {
 		s = append(s, v.String())
 	}


### PR DESCRIPTION
### Motivation
* As a prelude to updating testcontainers (to fix a CVE in the underlying docker dependency) we need
to upgrade Go to 1.25 and this requires a linter update too
* See #1513 which depends on this


### Modifications

- bump Go version from 1.24 to 1.25 in go.mod, Makefile, and CI matrices
- upgrade golangci-lint to v2.12.2 and fix Makefile install path to /v2 module
- migrate golangci config to v2 format and disable noisy govet inline analyzer
   - See https://golangci-lint.run/docs/product/migration-guide/ for more details 
   - the v2 file was generated via ` golangci-lint migrate` and then some tweaks based on failures.
- update GitHub Action to golangci-lint-action v9.2.1 (pinned SHA) and pin linter version
- fix lint findings across codebase (prealloc, revive naming/flow, ineffassign)
- verify lint passes: `make lint` reports 0 issues

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): No
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
 