### PR TITLE
fix: add bounds check for partition index int32 conversion

### DIFF
--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -410,6 +410,12 @@ func newPartitionConsumer(parent Consumer, client *client, options *partitionCon
 		boFunc = backoff.NewDefaultBackoff
 	}
 
+	// The partition index is parsed from the topic name; guard the int32
+	// conversion below against out-of-range values.
+	if options.partitionIdx > math.MaxInt32 || options.partitionIdx < math.MinInt32 {
+		return nil, fmt.Errorf("partition index %d is out of the valid int32 range", options.partitionIdx)
+	}
+
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	pc := &partitionConsumer{
 		parentConsumer:             parent,


### PR DESCRIPTION
### Motivation

CodeQL code-scanning alert #1 (`go/incorrect-integer-conversion`, high — CWE-190 / CWE-681) flags `pulsar/consumer_partition.go:422`, where the partition index — ultimately parsed from the topic name via `strconv.Atoi` in `getPartitionIndex` — is converted from `int` to `int32` without a bounds check.

### Modifications

Add an explicit range check in `newPartitionConsumer` before the `int32(options.partitionIdx)` conversion, returning an error if the value falls outside the `int32` range. Negative values (e.g. `-1` for non-partitioned topics) remain valid.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework without new test coverage; the conversion is exercised by the existing partitioned-consumer tests.

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API: no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no

### Documentation

  - Does this pull request introduce a new feature? no
