### PR TITLE
[fix][consumer] Use resolved partition topic for single-partition zero queue consumer

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -284,7 +284,7 @@ func newInternalConsumer(client *client, options ConsumerOptions, topic string,
 	}
 
 	if len(partitions) == 1 && options.EnableZeroQueueConsumer {
-		return newZeroConsumer(client, options, topic, messageCh, dlq, rlq, disableForceTopicCreation)
+		return newZeroConsumer(client, options, partitions[0], messageCh, dlq, rlq, disableForceTopicCreation)
 	}
 
 	consumer := &consumer{

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -662,14 +662,12 @@ func TestZeroQueueConsumerUsesOnlyPartitionForSinglePartitionTopic(t *testing.T)
 	require.NoError(t, err)
 	defer client.Close()
 
-	topic := newTopicName()
+	topic := "persistent://public/default/" + newTopicName()
 	err = createPartitionedTopic(topic, 1)
 	require.NoError(t, err)
 	topics, err := client.TopicPartitions(topic)
 	require.NoError(t, err)
 	require.Len(t, topics, 1)
-	topicName, err := internal.ParseTopicName(topics[0])
-	require.NoError(t, err)
 
 	consumer, err := client.Subscribe(ConsumerOptions{
 		Topic:                   topic,
@@ -681,7 +679,7 @@ func TestZeroQueueConsumerUsesOnlyPartitionForSinglePartitionTopic(t *testing.T)
 
 	zeroConsumer, ok := consumer.(*zeroQueueConsumer)
 	require.True(t, ok)
-	assert.Equal(t, topicName.Name, zeroConsumer.pc.topic)
+	assert.Equal(t, topics[0], zeroConsumer.pc.topic)
 }
 
 func TestZeroQueueConsumerGetLastMessageIDs(t *testing.T) {

--- a/pulsar/consumer_zero_queue_test.go
+++ b/pulsar/consumer_zero_queue_test.go
@@ -654,6 +654,36 @@ func TestSpecifiedPartitionZeroQueueConsumer(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestZeroQueueConsumerUsesOnlyPartitionForSinglePartitionTopic(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+
+	require.NoError(t, err)
+	defer client.Close()
+
+	topic := newTopicName()
+	err = createPartitionedTopic(topic, 1)
+	require.NoError(t, err)
+	topics, err := client.TopicPartitions(topic)
+	require.NoError(t, err)
+	require.Len(t, topics, 1)
+	topicName, err := internal.ParseTopicName(topics[0])
+	require.NoError(t, err)
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:                   topic,
+		SubscriptionName:        "my-sub",
+		EnableZeroQueueConsumer: true,
+	})
+	require.NoError(t, err)
+	defer consumer.Close()
+
+	zeroConsumer, ok := consumer.(*zeroQueueConsumer)
+	require.True(t, ok)
+	assert.Equal(t, topicName.Name, zeroConsumer.pc.topic)
+}
+
 func TestZeroQueueConsumerGetLastMessageIDs(t *testing.T) {
 	client, err := NewClient(ClientOptions{
 		URL: lookupURL,


### PR DESCRIPTION

### Motivation

When a partitioned topic has exactly one partition, TopicPartitions returns the physical partition topic, e.g. topic-partition-0. However, the zero queue consumer path ignored that resolved topic and still created the internal consumer with the original base topic.

With newer brokers that enforce topic consistency, subscribing to the base topic after partitioned metadata exists is rejected with "Found partitioned metadata for non-partitioned topic". This change makes zero queue consumers use the resolved single partition topic, matching the normal consumer path and avoiding repeated failed subscribe attempts.


### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / GoDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
