### PR TITLE
[fix] Bound peer-controlled sizes in the connection reader and recover from panics on connection goroutines

### DIFF
--- a/pulsar/internal/buffer.go
+++ b/pulsar/internal/buffer.go
@@ -177,9 +177,16 @@ func (b *buffer) IsWritable() bool {
 }
 
 func (b *buffer) Read(size uint32) []byte {
-	// Check []byte slice size, avoid slice bounds out of range
-	if b.readerIdx+size > uint32(len(b.data)) {
-		log.Errorf("The input size [%d] > byte slice of data size [%d]", b.readerIdx+size, len(b.data))
+	// Bound the read against b.data. Skip can move readerIdx past the end of
+	// the data, and readerIdx+size can wrap around uint32, so check each index
+	// on its own instead of comparing computed sums.
+	dataLen := uint32(len(b.data))
+	if b.readerIdx > dataLen {
+		log.Errorf("The reader index [%d] > data size [%d]", b.readerIdx, dataLen)
+		return nil
+	}
+	if size > dataLen-b.readerIdx {
+		log.Errorf("The input size [%d] > readable byte slice of data size [%d]", size, dataLen-b.readerIdx)
 		return nil
 	}
 	res := b.data[b.readerIdx : b.readerIdx+size]

--- a/pulsar/internal/buffer_test.go
+++ b/pulsar/internal/buffer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuffer(t *testing.T) {
@@ -33,4 +34,44 @@ func TestBuffer(t *testing.T) {
 	assert.Equal(t, uint32(5), b.ReadableBytes())
 	assert.Equal(t, uint32(1019), b.WritableBytes())
 	assert.Equal(t, uint32(1024), b.Capacity())
+}
+
+// Read refuses a size larger than the readable remainder, and must keep doing so
+// when readerIdx plus that size overflows uint32. Sizes reaching Read come from
+// the wire, so the overflowing case is reachable rather than theoretical.
+func TestBufferReadRefusesOversizedRead(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		readFirst uint32
+		size      uint32
+	}{
+		{"size beyond the buffer", 0, 2048},
+		{"size one past the readable remainder", 8, 1024 - 8 + 1},
+		{"readerIdx plus size overflows uint32", 8, 4294967295},
+		{"maximum size on an untouched buffer", 0, 4294967295},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBuffer(1024)
+			b.Write(make([]byte, 1024))
+
+			if tc.readFirst > 0 {
+				require.NotNil(t, b.Read(tc.readFirst))
+			}
+			readerIdxBefore := b.ReaderIndex()
+
+			assert.Nil(t, b.Read(tc.size), "oversized read should be refused")
+			assert.Equal(t, readerIdxBefore, b.ReaderIndex(), "a refused read must not advance readerIdx")
+		})
+	}
+}
+
+// Skip does not bound readerIdx, so it can leave it past the end of the data.
+// Read must refuse rather than panic in that state.
+func TestBufferReadAfterSkipPastEnd(t *testing.T) {
+	b := NewBuffer(1024)
+	b.Write(make([]byte, 1024))
+
+	b.Skip(2048)
+
+	assert.Nil(t, b.Read(1))
 }

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -226,6 +227,17 @@ func newConnection(opts connectionOptions) *connection {
 	return cnx
 }
 
+// recoverPanic closes the connection when a goroutine owned by it panics,
+// so the panic only ends the goroutine rather than the entire process.
+// Deferred at the top of each goroutine this package starts, because recover
+// only reaches the goroutine it runs in.
+func (c *connection) recoverPanic() {
+	if r := recover(); r != nil {
+		c.log.Errorf("recovered from panic on connection goroutine: %v\n%s", r, debug.Stack())
+		c.Close()
+	}
+}
+
 func (c *connection) start() {
 	if !atomic.CompareAndSwapInt32(&c.started, 0, 1) {
 		c.log.Warnf("connection has already started")
@@ -234,6 +246,8 @@ func (c *connection) start() {
 
 	// Each connection gets its own goroutine that will
 	go func() {
+		defer c.recoverPanic()
+
 		if c.connect() {
 			if c.doHandshake() {
 				c.metrics.ConnectionsOpened.Inc()
@@ -438,6 +452,8 @@ func (c *connection) run() {
 }
 
 func (c *connection) runPingCheck(pingCheckTicker *time.Ticker) {
+	defer c.recoverPanic()
+
 	for {
 		select {
 		case <-c.closeCh:

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -72,8 +72,18 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 
 	// We have enough to read frame size
 	frameSize := r.buffer.ReadUint32()
-	maxFrameSize := r.cnx.maxMessageSize + MessageFramePadding
-	if r.cnx.maxMessageSize != 0 && int32(frameSize) > maxFrameSize {
+	// maxMessageSize is only known once the handshake has completed, since it is
+	// taken from the broker's Connected response. Until then, bound the frame by
+	// the protocol maximum rather than not bounding it at all: this read happens
+	// before the peer has authenticated, and frameSize decides how large a buffer
+	// readAtLeast allocates for the rest of the frame below.
+	maxFrameSize := uint32(MaxFrameSize)
+	if r.cnx.maxMessageSize != 0 {
+		maxFrameSize = uint32(r.cnx.maxMessageSize) + MessageFramePadding
+	}
+	// Compared as uint32 so a frameSize of 2^31 or more stays large and fails
+	// this bound instead of turning negative in a signed comparison.
+	if frameSize > maxFrameSize {
 		frameSizeError := fmt.Errorf("received too big frame size=%d maxFrameSize=%d", frameSize, maxFrameSize)
 		r.cnx.log.Error(frameSizeError)
 		r.cnx.Close()

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -101,6 +101,15 @@ func (r *connectionReader) readSingleCommand() (cmd *pb.BaseCommand, headersAndP
 
 	// We have now the complete frame
 	cmdSize := r.buffer.ReadUint32()
+	// cmdSize is read off the wire and indexes into the frame, so it has to fit
+	// within it. Written as cmdSize > frameSize-4 because cmdSize+4 can wrap
+	// around uint32; the frameSize < 4 check keeps frameSize-4 from wrapping.
+	if frameSize < 4 || cmdSize > frameSize-4 {
+		cmdSizeError := fmt.Errorf("received invalid command size=%d frameSize=%d", cmdSize, frameSize)
+		r.cnx.log.Error(cmdSizeError)
+		r.cnx.Close()
+		return nil, nil, cmdSizeError
+	}
 	cmd, err = r.deserializeCmd(r.buffer.Read(cmdSize))
 	if err != nil {
 		return nil, nil, err

--- a/pulsar/internal/connection_reader.go
+++ b/pulsar/internal/connection_reader.go
@@ -38,6 +38,8 @@ func newConnectionReader(cnx *connection) *connectionReader {
 }
 
 func (r *connectionReader) readFromConnection() {
+	defer r.cnx.recoverPanic()
+
 	for {
 		cmd, headersAndPayload, err := r.readSingleCommand()
 		if err != nil {

--- a/pulsar/internal/connection_reader_test.go
+++ b/pulsar/internal/connection_reader_test.go
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package internal
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestConnectionReader returns a connectionReader whose connection reads from
+// the returned pipe, so a test can act as the peer and write arbitrary bytes.
+func newTestConnectionReader(t *testing.T) (*connectionReader, net.Conn) {
+	t.Helper()
+
+	peer, local := net.Pipe()
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = local.Close()
+	})
+
+	// Without a deadline, a regression that accepts an oversized frame blocks
+	// forever in io.ReadAtLeast waiting for bytes the peer never sends. The
+	// deadline turns that into a failed assertion instead of a hung test.
+	require.NoError(t, local.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	c := newTestConnection()
+	c.cnx = local
+
+	return newConnectionReader(c), peer
+}
+
+// A peer can send a frame size before the handshake has completed, when
+// maxMessageSize is still zero. The frame size decides how large a buffer is
+// allocated for the rest of the frame, so it has to be bounded by the protocol
+// maximum rather than not bounded at all.
+func TestReadSingleCommandRejectsOversizedFrameBeforeHandshake(t *testing.T) {
+	r, peer := newTestConnectionReader(t)
+
+	require.Zero(t, r.cnx.maxMessageSize, "handshake has not completed")
+
+	go func() {
+		// frameSize = 1 GiB, far beyond MaxFrameSize
+		_, _ = peer.Write([]byte{0x40, 0x00, 0x00, 0x00})
+	}()
+
+	cmd, payload, err := r.readSingleCommand()
+
+	assert.Nil(t, cmd)
+	assert.Nil(t, payload)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "received too big frame size")
+}
+
+// A frame size of 2^31 or more is negative once converted to int32, so comparing
+// it as a signed value let the very largest sizes through the check that exists
+// to reject them. This holds after the handshake too, when maxMessageSize is set.
+func TestReadSingleCommandRejectsFrameSizeAboveInt32Range(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		maxMessageSize int32
+		frameSize      []byte
+	}{
+		{"before handshake", 0, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+		{"after handshake", MaxMessageSize, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+		{"exactly 2^31", 0, []byte{0x80, 0x00, 0x00, 0x00}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, peer := newTestConnectionReader(t)
+			r.cnx.maxMessageSize = tc.maxMessageSize
+
+			go func() {
+				_, _ = peer.Write(tc.frameSize)
+			}()
+
+			cmd, payload, err := r.readSingleCommand()
+
+			assert.Nil(t, cmd)
+			assert.Nil(t, payload)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "received too big frame size")
+		})
+	}
+}
+
+// Once the handshake has completed the broker's own maxMessageSize applies, and
+// a frame within it is still accepted for reading.
+func TestReadSingleCommandAcceptsFrameWithinBrokerMaxMessageSize(t *testing.T) {
+	r, peer := newTestConnectionReader(t)
+
+	r.cnx.maxMessageSize = MaxMessageSize
+
+	go func() {
+		// frameSize larger than MaxFrameSize would be rejected, so use one that
+		// sits inside it and then close, to show the size check is not what fails
+		_, _ = peer.Write([]byte{0x00, 0x00, 0x10, 0x00})
+		_ = peer.Close()
+	}()
+
+	_, _, err := r.readSingleCommand()
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "received too big frame size")
+}

--- a/pulsar/internal/connection_reader_test.go
+++ b/pulsar/internal/connection_reader_test.go
@@ -101,6 +101,55 @@ func TestReadSingleCommandRejectsFrameSizeAboveInt32Range(t *testing.T) {
 	}
 }
 
+// The command size is a second length read off the wire, and it indexes into the
+// frame. A peer can declare a plausible frame size and then a command size far
+// larger than the frame holds.
+func TestReadSingleCommandRejectsCommandSizeLargerThanFrame(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame []byte
+	}{
+		{
+			name: "command size at the top of the uint32 range",
+			frame: []byte{
+				0x00, 0x00, 0x00, 0x08, // frameSize = 8, unremarkable
+				0xFF, 0xFF, 0xFF, 0xFF, // cmdSize = 4294967295
+				0x00, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "command size just past the frame",
+			frame: []byte{
+				0x00, 0x00, 0x00, 0x08, // frameSize = 8
+				0x00, 0x00, 0x00, 0x05, // cmdSize = 5, but only 4 bytes remain
+				0x00, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			name: "frame too short to hold a command size",
+			frame: []byte{
+				0x00, 0x00, 0x00, 0x02, // frameSize = 2, less than the 4 read below
+				0x00, 0x00, 0x00, 0x00,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, peer := newTestConnectionReader(t)
+
+			go func() {
+				_, _ = peer.Write(tc.frame)
+			}()
+
+			cmd, payload, err := r.readSingleCommand()
+
+			assert.Nil(t, cmd)
+			assert.Nil(t, payload)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "received invalid command size")
+		})
+	}
+}
+
 // Once the handshake has completed the broker's own maxMessageSize applies, and
 // a frame within it is still accepted for reading.
 func TestReadSingleCommandAcceptsFrameWithinBrokerMaxMessageSize(t *testing.T) {

--- a/pulsar/internal/connection_test.go
+++ b/pulsar/internal/connection_test.go
@@ -224,3 +224,52 @@ func newMockMetrics() *Metrics {
 		}),
 	}
 }
+
+// A panic on a goroutine the connection owns must not escape it. recover only
+// reaches the goroutine it runs in, so each goroutine this package starts defers
+// its own guard; without them a fault while talking to one broker terminates the
+// whole process rather than the connection.
+func TestRecoverPanicClosesConnection(t *testing.T) {
+	c := newTestConnection()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer c.recoverPanic()
+
+		panic("simulated fault on a connection goroutine")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("goroutine did not return")
+	}
+
+	assert.True(t, c.closed(), "the connection should be closed after a recovered panic")
+	assertConnectionClosed(t, c)
+}
+
+// The guard must tolerate being deferred on a connection that is already closed,
+// since the panicking path may have closed it on the way out. Close is
+// idempotent, so this must not panic a second time.
+func TestRecoverPanicOnAlreadyClosedConnection(t *testing.T) {
+	c := newTestConnection()
+	c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer c.recoverPanic()
+
+		panic("simulated fault after close")
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("goroutine did not return")
+	}
+
+	assert.True(t, c.closed())
+}


### PR DESCRIPTION
Master Issue: relates to #435 / #709 (the buffer.Read bounds check this completes)

### Motivation

The connection reader trusts two sizes a peer sends on the wire, and a panic on any connection goroutine terminates the whole process.

The frame size check was guarded on `maxMessageSize != 0`, and that field is only set from the broker's Connected response. The check therefore never ran on the first read of a connection, before the peer had authenticated, and the frame size decides how large a buffer `readAtLeast` allocates. The check also compared as `int32`, so any size of 2^31 or more turned negative and passed.

The command size is a second length read off the wire, and nothing checked it fits inside the frame. A frame size of 8 with a command size of 4294967295 defeats the bounds check in `buffer.Read` (the `readerIdx+size` addition wraps uint32) and panics with `slice bounds out of range [8:7]`, taking down the process.

### Modifications

- Bound the frame size by `MaxFrameSize` until the handshake supplies `maxMessageSize`, and compare in uint32 so large sizes cannot pass as negative.
- Reject a command size that does not fit within its frame, written as `cmdSize > frameSize-4` so neither side of the comparison can wrap.
- Rewrite the `buffer.Read` bounds check to compute the readable remainder by subtraction, and refuse reads after `Skip` has moved `readerIdx` past the end of the data.
- Defer a `recoverPanic` guard on each goroutine the package starts (connect/run, reader, ping check). A recovered panic is logged with its stack and closes the connection. 
